### PR TITLE
Allow multiple edge type creation

### DIFF
--- a/biocypher/_config/test_schema_config.yaml
+++ b/biocypher/_config/test_schema_config.yaml
@@ -146,7 +146,7 @@ dsDNA sequence:
 post translational interaction:
   represented_as: node
   label_as_edge: INTERACTS_POST_TRANSLATIONAL
-  label_in_input: post_translational
+  label_in_input: protein_interacts_with_protein
 
 # auto label as edge
 phosphorylation:
@@ -156,8 +156,8 @@ phosphorylation:
 # merge edges
 gene to disease association:
   represented_as: edge
-  label_as_edge: PERTURBED_IN_DISEASE
-  label_in_input: [protein_disease, gene_disease]
+  label_as_edge: [PERTURBED_IN_DISEASE, PERTURBED_IN_DISEASE]
+  label_in_input: [protein_PERTURBED_IN_DISEASE_disease, gene_PERTURBED_IN_DISEASE_disease]
   exclude_properties: accession
 
 # multiple inheritance

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -566,6 +566,7 @@ class BiolinkAdapter:
                     values.get('label_as_edge')
                     if values.get('label_as_edge') else entity
                 )
+
                 self.translator._add_translation_mappings(input_label, bc_name)
 
                 # create dict of biolink class definition and biolink
@@ -1232,14 +1233,11 @@ class Translator:
                     elif isinstance(self.leaves[bl_type].get('label_as_edge'), list):
                         input_labels = self.leaves[bl_type].get('label_in_input')
                         
-                        # This error check can be moved to more proper place
                         if not isinstance(input_labels, list):
                             logger.error(" Type of 'label_in_input' field should be list in config file.")
-                            return False
-                        
+                            
                         if len(input_labels) != len(self.leaves[bl_type].get('label_as_edge')):
-                            logger.error("'label_in_input' list and 'label_as_edge' list are not of equal length.")                            
-                            return False
+                            logger.error("'label_in_input' list and 'label_as_edge' list are not of equal length.")
                         
                         for l in input_labels:
                             if l == _type:
@@ -1389,7 +1387,12 @@ class Translator:
         PascalCase version of the BioCypher name, since sentence case is
         not useful for Cypher queries.
         """
-        if isinstance(original_name, list):
+        if isinstance(original_name, list) and isinstance(biocypher_name, list):
+            for on, bn in zip(original_name, biocypher_name):
+                self.mappings[on] = self.name_sentence_to_pascal(
+                    bn,
+                )
+        elif isinstance(original_name, list):
             for on in original_name:
                 self.mappings[on] = self.name_sentence_to_pascal(
                     biocypher_name,
@@ -1399,7 +1402,11 @@ class Translator:
                 biocypher_name,
             )
 
-        if isinstance(biocypher_name, list):
+        if isinstance(original_name, list) and isinstance(biocypher_name, list):
+            for on, bn in zip(original_name, biocypher_name):
+                self.reverse_mappings[self.name_sentence_to_pascal(bn, )
+                ] = on
+        elif isinstance(biocypher_name, list):
             for bn in biocypher_name:
                 self.reverse_mappings[self.name_sentence_to_pascal(bn, )
                                      ] = original_name

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -1232,11 +1232,14 @@ class Translator:
                     elif isinstance(self.leaves[bl_type].get('label_as_edge'), list):
                         input_labels = self.leaves[bl_type].get('label_in_input')
                         
+                        # This error check can be moved to more proper place
                         if not isinstance(input_labels, list):
                             logger.error(" Type of 'label_in_input' field should be list in config file.")
-                            
+                            return False
+                        
                         if len(input_labels) != len(self.leaves[bl_type].get('label_as_edge')):
-                            logger.error("'label_in_input' list and 'label_as_edge' list are not of equal length.")
+                            logger.error("'label_in_input' list and 'label_as_edge' list are not of equal length.")                            
+                            return False
                         
                         for l in input_labels:
                             if l == _type:

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -469,6 +469,9 @@ class BatchWriter:
         Returns:
             bool: The return value. True for success, False otherwise.
         """
+        # define allowed data types
+        allowed_data_types = ['int', 'long', 'integer', 'float', 'double', 'dbl', 'bool', 'boolean', 'str', 'string']
+
         # load headers from data parse
         if not self.node_property_dict:
             logger.error(
@@ -501,13 +504,23 @@ class BatchWriter:
                 # concatenate key:value in props
                 props_list = []
                 for k, v in props.items():
-                    if v in ['int', 'long']:
+                    if v.replace('[]', '') not in allowed_data_types:
+                        logger.error(f'Invalid property data type in configuration file. Property -> {k}: {v}')
+                        return False           
+
+                    if v in ['int', 'long', 'integer']:
                         props_list.append(f'{k}:long')
+                    elif v in ['int[]', 'long[]', 'integer[]']:
+                        props_list.append(f'{k}:long[]')
                     elif v in ['float', 'double', 'dbl']:
                         props_list.append(f'{k}:double')
+                    elif v in ['float[]', 'double[]', 'dbl[]']:
+                        props_list.append(f'{k}:double[]')
                     elif v in ['bool', 'boolean']:
                         # TODO Neo4j boolean support / spelling?
                         props_list.append(f'{k}:boolean')
+                    elif v in ['bool[]', 'boolean[]']:
+                        props_list.append(f'{k}:boolean[]')
                     elif v in ['str[]', 'string[]']:
                         props_list.append(f'{k}:string[]')
                     else:
@@ -811,6 +824,9 @@ class BatchWriter:
         Returns:
             bool: The return value. True for success, False otherwise.
         """
+        # define allowed data types
+        allowed_data_types = ['int', 'long', 'integer', 'float', 'double', 'dbl', 'bool', 'boolean', 'str', 'string']
+
         # load headers from data parse
         if not self.edge_property_dict:
             logger.error(
@@ -837,15 +853,25 @@ class BatchWriter:
                 # concatenate key:value in props
                 props_list = []
                 for k, v in props.items():
-                    if v in ['int', 'long']:
+                    if v.replace('[]', '') not in allowed_data_types:
+                        logger.error(f'Invalid property data type in configuration file. Property -> {k}: {v}')
+                        return False            
+
+                    if v in ['int', 'long', 'integer']:
                         props_list.append(f'{k}:long')
-                    elif v in ['float', 'double']:
+                    elif v in ['int[]', 'long[]', 'integer[]']:
+                        props_list.append(f'{k}:long[]')
+                    elif v in ['float', 'double', 'dbl']:
                         props_list.append(f'{k}:double')
-                    elif v in [
-                        'bool',
-                        'boolean',
-                    ]:  # TODO does Neo4j support bool?
+                    elif v in ['float[]', 'double[]', 'dbl[]']:
+                        props_list.append(f'{k}:double[]')
+                    elif v in ['bool', 'boolean']:
+                        # TODO Neo4j boolean support / spelling?
                         props_list.append(f'{k}:boolean')
+                    elif v in ['bool[]', 'boolean[]']:
+                        props_list.append(f'{k}:boolean[]')
+                    elif v in ['str[]', 'string[]']:
+                        props_list.append(f'{k}:string[]')
                     else:
                         props_list.append(f'{k}')
 

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -322,6 +322,7 @@ class BatchWriter:
             # for now, relevant for `int`
             labels = {}  # dict to store the additional labels for each
             # primary graph constituent from biolink hierarchy
+
             for node in nodes:
                 _id = node.get_id()
                 label = node.get_label()
@@ -403,7 +404,7 @@ class BatchWriter:
                         )
 
                     labels[label] = all_labels
-
+                
                 else:
                     # add to list
                     bins[label].append(node)
@@ -443,6 +444,7 @@ class BatchWriter:
             # properties in the generator pass
 
             # save config or first-node properties to instance attribute
+            
             for label in reference_props.keys():
                 self.node_property_dict[label] = reference_props[label]
 
@@ -653,8 +655,8 @@ class BatchWriter:
             )  # dict to store a dict of properties
             # for each label to check for consistency and their type
             # for now, relevant for `int`
+
             for e in edges:
-            
                 if isinstance(e, BioCypherRelAsNode):
                     # shouldn't happen any more
                     logger.error(
@@ -673,12 +675,12 @@ class BatchWriter:
                 label = e.get_label()
                 input_label = e.get_input_label()
                 label_class = self.translator._ontology_mapping.get(input_label)
-                
+
                 if not input_label in self.seen_edges.keys():
                     self.seen_edges[input_label] = set()
 
                 src_tar_id = '_'.join([e.get_source_id(), e.get_target_id()])
-
+                
                 # check duplicates for input_label
                 if src_tar_id in self.seen_edges.get(input_label, set()):
                     self.duplicate_edge_ids.add(src_tar_id)
@@ -739,11 +741,12 @@ class BatchWriter:
                     # TODO
                     
                     # create reference_props
-                    if isinstance(self.ontology_adapter.leaves.get(label_class).get('label_in_input'), str):
+                    if isinstance(self.ontology_adapter.leaves.get(label_class, {}).get('label_in_input'), str):
                         reference_props[self.ontology_adapter.leaves.get(label_class).get('label_in_input')] = d
                         
-                    else: # for association classes that have multiple 'label_in_input' fields create key-value pair for each 
-                        for l in self.ontology_adapter.leaves.get(label_class).get('label_in_input'):
+                    elif isinstance(self.ontology_adapter.leaves.get(label_class, {}).get('label_in_input'), list): 
+                        # for association classes that have multiple 'label_in_input' fields create key-value pair for each 
+                        for l in self.ontology_adapter.leaves.get(label_class, {}).get('label_in_input'):
                             reference_props[l] = d
                             
                 else:
@@ -945,7 +948,7 @@ class BatchWriter:
                                     plist.append(
                                         self.quote + self.adelim.join(p) + self.quote
                                     )
-                                elif '**' in p:
+                                elif isinstance(p, str) and '**' in p:
                                     plist.append(
                                         self.quote + p.replace('**', self.adelim) +
                                         self.quote

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -105,8 +105,8 @@ def test_specific_and_generic_ids(translator):
 def test_translate_edges(translator):
     # edge type association (defined in `schema_config.yaml`)
     src_tar_type_edge = [
-        ('G15258', 'MONDO1', 'gene_disease', {}),
-        ('G15258', 'MONDO2', 'protein_disease', {}),
+        ('G15258', 'MONDO1', 'gene_PERTURBED_IN_DISEASE_disease', {}),
+        ('G15258', 'MONDO2', 'protein_PERTURBED_IN_DISEASE_disease', {}),
         ('G15258', 'G15242', 'phosphorylation', {}),
     ]
 
@@ -117,14 +117,14 @@ def test_translate_edges(translator):
 
     assert type(next(t)) == BioCypherEdge
     assert next(t).get_label() == 'PERTURBED_IN_DISEASE'
-    assert next(t).get_label() == 'phosphorylation'
+    assert next(t).get_input_label() == 'phosphorylation'
 
     # node type association (defined in `schema_config.yaml`)
     src_tar_type_node = [
         (
             'G21058',
             'G50127',
-            'post_translational',
+            'protein_interacts_with_protein',
             {
                 'prop1': 'test',
             },
@@ -132,7 +132,7 @@ def test_translate_edges(translator):
         (
             'G22418',
             'G50123',
-            'post_translational',
+            'protein_interacts_with_protein',
             {
                 'directed': 'arbitrary_string',
             },
@@ -140,7 +140,7 @@ def test_translate_edges(translator):
         (
             'G15258',
             'G16347',
-            'post_translational',
+            'protein_interacts_with_protein',
             {
                 'directed': True,
                 'effect': -1,
@@ -481,7 +481,7 @@ def test_exclude_properties(translator):
         (
             'G49205',
             'AD',
-            'gene_disease',
+            'gene_PERTURBED_IN_DISEASE_disease',
             {
                 'directional': True,
                 'score': 0.5,
@@ -490,7 +490,7 @@ def test_exclude_properties(translator):
         (
             'G92035',
             'AD',
-            'gene_disease',
+            'gene_PERTURBED_IN_DISEASE_disease',
             {
                 'directional': False,
                 'score': 0.5,
@@ -516,13 +516,13 @@ def test_exclude_properties(translator):
 def test_translate_term(translator, biolink_adapter):
     assert translator.translate_term('hgnc') == 'Gene'
     assert (
-        translator.translate_term('protein_disease') == 'PERTURBED_IN_DISEASE'
+        translator.translate_term('protein_PERTURBED_IN_DISEASE_disease') == 'PERTURBED_IN_DISEASE'
     )
 
 
 def test_reverse_translate_term(translator, biolink_adapter):
     assert 'hgnc' in translator.reverse_translate_term('Gene')
-    assert 'protein_disease' in translator.reverse_translate_term(
+    assert 'gene_PERTURBED_IN_DISEASE_disease' in translator.reverse_translate_term(
         'PERTURBED_IN_DISEASE',
     )
 
@@ -530,7 +530,7 @@ def test_reverse_translate_term(translator, biolink_adapter):
 def test_translate_query(translator, biolink_adapter):
     # we translate to PascalCase for cypher queries, not to internal
     # sentence case
-    query = 'MATCH (n:hgnc)-[r:gene_disease]->(d:Disease) RETURN n'
+    query = 'MATCH (n:hgnc)-[r:gene_PERTURBED_IN_DISEASE_disease]->(d:Disease) RETURN n'
     assert (
         translator.translate(query) ==
         'MATCH (n:Gene)-[r:PERTURBED_IN_DISEASE]->(d:Disease) RETURN n'

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1105,3 +1105,4 @@ def test_write_strict(bw_strict):
         prot = f.read()
 
     assert prot == "p1;'StringProperty1';4.32;9606;'gene1|gene2';'p1';'id';'source1';'version1';'licence1';BiologicalEntity|ChemicalEntityOrGeneOrGeneProduct|ChemicalEntityOrProteinOrPolypeptide|Entity|GeneOrGeneProduct|GeneProductMixin|MacromolecularMachineMixin|Mixin|NamedThing|Polypeptide|Protein|ThingWithTaxon\n"
+    

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -560,8 +560,8 @@ def test_write_edge_data_from_gen(bw):
 
     passed = bw._write_edge_data(edge_gen(edges), batch_size=int(1e4))
 
-    pid_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part000.csv')
-    imi_csv = os.path.join(path, 'Is_Mutated_In-part000.csv')
+    pid_csv = os.path.join(path, 'GeneToDiseaseAssociation-part000.csv')
+    imi_csv = os.path.join(path, 'MutationToTissueAssociation-part000.csv')
 
     with open(pid_csv) as f:
         l = f.read()
@@ -570,9 +570,9 @@ def test_write_edge_data_from_gen(bw):
 
     assert (
         passed and l ==
-        "p0;'T253';4;p1;PERTURBED_IN_DISEASE\np1;'T253';4;p2;PERTURBED_IN_DISEASE\np2;'T253';4;p3;PERTURBED_IN_DISEASE\np3;'T253';4;p4;PERTURBED_IN_DISEASE\n"
+        "p0;'T253';'4';p1;PERTURBED_IN_DISEASE\np1;'T253';'4';p2;PERTURBED_IN_DISEASE\np2;'T253';'4';p3;PERTURBED_IN_DISEASE\np3;'T253';'4';p4;PERTURBED_IN_DISEASE\n"
         and c ==
-        "m0;'3-UTR';1;p1;Is_Mutated_In\nm1;'3-UTR';1;p2;Is_Mutated_In\nm2;'3-UTR';1;p3;Is_Mutated_In\nm3;'3-UTR';1;p4;Is_Mutated_In\n"
+        "m0;'3-UTR';'1';p1;Is_Mutated_In\nm1;'3-UTR';'1';p2;Is_Mutated_In\nm2;'3-UTR';'1';p3;Is_Mutated_In\nm3;'3-UTR';'1';p4;Is_Mutated_In\n"
     )
 
 
@@ -582,7 +582,8 @@ def _get_edges(l):
         e1 = BioCypherEdge(
             source_id=f'p{i}',
             target_id=f'p{i + 1}',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label = "_".join(['gene', 'PERTURBED_IN_DISEASE', 'disease']),
             properties={
                 'residue': 'T253',
                 'level': 4,
@@ -594,7 +595,8 @@ def _get_edges(l):
         e2 = BioCypherEdge(
             source_id=f'm{i}',
             target_id=f'p{i + 1}',
-            relationship_label='Is_Mutated_In',
+            graph_db_relationship_label='Is_Mutated_In',
+            input_relationship_label = 'Gene_Is_Mutated_In_Cell_Tissue',
             properties={
                 'site': '3-UTR',
                 'confidence': 1,
@@ -615,10 +617,10 @@ def test_write_edge_data_from_large_gen(bw):
 
     passed = bw._write_edge_data(edge_gen(edges), batch_size=int(1e4))
 
-    apl0_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part000.csv')
-    ips0_csv = os.path.join(path, 'Is_Mutated_In-part000.csv')
-    apl1_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part001.csv')
-    ips1_csv = os.path.join(path, 'Is_Mutated_In-part001.csv')
+    apl0_csv = os.path.join(path, 'GeneToDiseaseAssociation-part000.csv')
+    ips0_csv = os.path.join(path, 'MutationToTissueAssociation-part000.csv')
+    apl1_csv = os.path.join(path, 'GeneToDiseaseAssociation-part001.csv')
+    ips1_csv = os.path.join(path, 'MutationToTissueAssociation-part001.csv')
 
     l_lines0 = sum(1 for _ in open(apl0_csv))
     c_lines0 = sum(1 for _ in open(ips0_csv))
@@ -636,8 +638,8 @@ def test_write_edge_data_from_list(bw):
 
     passed = bw._write_edge_data(edges, batch_size=int(1e4))
 
-    apl_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part000.csv')
-    ips_csv = os.path.join(path, 'Is_Mutated_In-part000.csv')
+    apl_csv = os.path.join(path, 'GeneToDiseaseAssociation-part000.csv')
+    ips_csv = os.path.join(path, 'MutationToTissueAssociation-part000.csv')
 
     with open(apl_csv) as f:
         l = f.read()
@@ -646,9 +648,9 @@ def test_write_edge_data_from_list(bw):
 
     assert (
         passed and l ==
-        "p0;'T253';4;p1;PERTURBED_IN_DISEASE\np1;'T253';4;p2;PERTURBED_IN_DISEASE\np2;'T253';4;p3;PERTURBED_IN_DISEASE\np3;'T253';4;p4;PERTURBED_IN_DISEASE\n"
+        "p0;'T253';'4';p1;PERTURBED_IN_DISEASE\np1;'T253';'4';p2;PERTURBED_IN_DISEASE\np2;'T253';'4';p3;PERTURBED_IN_DISEASE\np3;'T253';'4';p4;PERTURBED_IN_DISEASE\n"
         and c ==
-        "m0;'3-UTR';1;p1;Is_Mutated_In\nm1;'3-UTR';1;p2;Is_Mutated_In\nm2;'3-UTR';1;p3;Is_Mutated_In\nm3;'3-UTR';1;p4;Is_Mutated_In\n"
+        "m0;'3-UTR';'1';p1;Is_Mutated_In\nm1;'3-UTR';'1';p2;Is_Mutated_In\nm2;'3-UTR';'1';p3;Is_Mutated_In\nm3;'3-UTR';'1';p4;Is_Mutated_In\n"
     )
 
 
@@ -659,20 +661,22 @@ def test_write_edge_data_from_list_no_props(bw):
         e1 = BioCypherEdge(
             source_id=f'p{i}',
             target_id=f'p{i + 1}',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label = "_".join(['gene', 'PERTURBED_IN_DISEASE', 'disease'])
         )
         edges.append(e1)
         e2 = BioCypherEdge(
             source_id=f'm{i}',
             target_id=f'p{i + 1}',
-            relationship_label='Is_Mutated_In',
+            graph_db_relationship_label='Is_Mutated_In',
+            input_relationship_label = 'Gene_Is_Mutated_In_Cell_Tissue'
         )
         edges.append(e2)
 
     passed = bw._write_edge_data(edges, batch_size=int(1e4))
 
-    ptl_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part000.csv')
-    pts_csv = os.path.join(path, 'Is_Mutated_In-part000.csv')
+    ptl_csv = os.path.join(path, 'GeneToDiseaseAssociation-part000.csv')
+    pts_csv = os.path.join(path, 'MutationToTissueAssociation-part000.csv')
 
     with open(ptl_csv) as f:
         l = f.read()
@@ -704,8 +708,8 @@ def test_write_edge_data_headers_import_call(bw):
 
     bw.write_import_call()
 
-    ptl_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-header.csv')
-    pts_csv = os.path.join(path, 'Is_Mutated_In-header.csv')
+    ptl_csv = os.path.join(path, 'GeneToDiseaseAssociation-header.csv')
+    pts_csv = os.path.join(path, 'MutationToTissueAssociation-header.csv')
     call_csv = os.path.join(path, 'neo4j-admin-import-call.sh')
 
     with open(ptl_csv) as f:
@@ -718,7 +722,7 @@ def test_write_edge_data_headers_import_call(bw):
     assert (
         passed and l == ':START_ID;residue;level:long;:END_ID;:TYPE' and
         c == ':START_ID;site;confidence:long;:END_ID;:TYPE' and call ==
-        f'bin/neo4j-admin import --database=neo4j --delimiter=";" --array-delimiter="|" --quote="\'" --force=true --nodes="{path}/Protein-header.csv,{path}/Protein-part.*" --nodes="{path}/MicroRNA-header.csv,{path}/MicroRNA-part.*" --relationships="{path}/PERTURBED_IN_DISEASE-header.csv,{path}/PERTURBED_IN_DISEASE-part.*" --relationships="{path}/Is_Mutated_In-header.csv,{path}/Is_Mutated_In-part.*" '
+        f'bin/neo4j-admin import --database=neo4j --delimiter=";" --array-delimiter="|" --quote="\'" --force=true --nodes="{path}/Protein-header.csv,{path}/Protein-part.*" --nodes="{path}/MicroRNA-header.csv,{path}/MicroRNA-part.*" --relationships="{path}/GeneToDiseaseAssociation-header.csv,{path}/GeneToDiseaseAssociation-part.*" --relationships="{path}/MutationToTissueAssociation-header.csv,{path}/MutationToTissueAssociation-part.*" '
     )
 
 
@@ -728,8 +732,8 @@ def test_write_duplicate_edges(bw):
 
     passed = bw.write_edges(edges)
 
-    ptl_csv = os.path.join(path, 'PERTURBED_IN_DISEASE-part000.csv')
-    pts_csv = os.path.join(path, 'Is_Mutated_In-part000.csv')
+    ptl_csv = os.path.join(path, 'GeneToDiseaseAssociation-part000.csv')
+    pts_csv = os.path.join(path, 'MutationToTissueAssociation-part000.csv')
 
     l = sum(1 for _ in open(ptl_csv))
     c = sum(1 for _ in open(pts_csv))
@@ -780,12 +784,14 @@ def _get_rel_as_nodes(l):
         e1 = BioCypherEdge(
             source_id=f'i{i+1}',
             target_id=f'p{i+1}',
-            relationship_label='IS_SOURCE_OF',
+            graph_db_relationship_label='IS_SOURCE_OF',
+            input_relationship_label = "_".join([f'i{i+1}', 'IS_SOURCE_OF', f'p{i+1}'])
         )
         e2 = BioCypherEdge(
             source_id=f'i{i}',
             target_id=f'p{i + 2}',
-            relationship_label='IS_TARGET_OF',
+            graph_db_relationship_label='IS_TARGET_OF',
+            input_relationship_label = "_".join([f'i{i}', 'IS_TARGET_OF', f'p{i + 2}'])
         )
         rels.append(BioCypherRelAsNode(n, e1, e2))
     return rels
@@ -817,7 +823,8 @@ def test_write_mixed_edges(bw):
         e3 = BioCypherEdge(
             source_id=f'p{i+1}',
             target_id=f'p{i+1}',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label="_".join(['gene', 'PERTURBED_IN_DISEASE', 'disease'])
         )
         mixed.append(e3)
 
@@ -828,12 +835,14 @@ def test_write_mixed_edges(bw):
         e1 = BioCypherEdge(
             source_id=f'i{i+1}',
             target_id=f'p{i+1}',
-            relationship_label='IS_SOURCE_OF',
+            graph_db_relationship_label='IS_SOURCE_OF',
+            input_relationship_label="_".join(['gene', 'PERTURBED_IN_DISEASE', 'disease'])
         )
         e2 = BioCypherEdge(
             source_id=f'i{i}',
             target_id=f'p{i+2}',
-            relationship_label='IS_TARGET_OF',
+            graph_db_relationship_label='IS_TARGET_OF',
+            input_relationship_label="_".join(['gene', 'PERTURBED_IN_DISEASE', 'disease'])
         )
         mixed.append(BioCypherRelAsNode(n, e1, e2))
 
@@ -864,19 +873,22 @@ def test_create_import_call(bw):
         e1 = BioCypherEdge(
             source_id=f'i{i+1}',
             target_id=f'p{i+1}',
-            relationship_label='IS_SOURCE_OF',
+            graph_db_relationship_label='IS_SOURCE_OF',
+            input_relationship_label = "_".join([f'i{i+1}', 'IS_SOURCE_OF', f'p{i+1}'])
         )
         e2 = BioCypherEdge(
             source_id=f'i{i}',
             target_id=f'p{i+2}',
-            relationship_label='IS_TARGET_OF',
+            graph_db_relationship_label='IS_TARGET_OF',
+            input_relationship_label = "_".join([f'i{i}', 'IS_TARGET_OF', f'p{i+2}'])
         )
         mixed.append(BioCypherRelAsNode(n, e1, e2))
 
         e3 = BioCypherEdge(
             source_id=f'p{i+1}',
             target_id=f'p{i+1}',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label = "_".join([f'p{i+1}', 'IS_TARGET_OF', f'p{i+1}'])
         )
         mixed.append(e3)
 
@@ -1035,13 +1047,14 @@ def test_duplicate_edges(bw):
         BioCypherEdge(
             source_id='p1',
             target_id='p2',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label = 'gene_PERTURBED_IN_DISEASE_disease'
         )
     )
 
     passed = bw.write_edges(edges)
 
-    assert 'PERTURBED_IN_DISEASE' in bw.duplicate_edge_types
+    assert 'gene_PERTURBED_IN_DISEASE_disease' in bw.duplicate_edge_types
     assert 'p1_p2' in bw.duplicate_edge_ids
 
 
@@ -1051,7 +1064,8 @@ def test_get_duplicate_edges(bw):
         BioCypherEdge(
             source_id='p1',
             target_id='p2',
-            relationship_label='PERTURBED_IN_DISEASE',
+            graph_db_relationship_label='PERTURBED_IN_DISEASE',
+            input_relationship_label = 'gene_PERTURBED_IN_DISEASE_disease'
         )
     )
 
@@ -1061,7 +1075,7 @@ def test_get_duplicate_edges(bw):
     types = d[0]
     ids = d[1]
 
-    assert 'PERTURBED_IN_DISEASE' in types
+    assert 'gene_PERTURBED_IN_DISEASE_disease' in types
     assert 'p1_p2' in ids
 
 


### PR DESCRIPTION
Hi Sebastian,

To allow multiple edge type creation in association classes of config file, I did some changes in BioCypher script.

Right now one can create multiple edge types using this type of structure in config file:
```
protein to cellular component association:
  represented_as: edge
  label_as_edge: [located_in, part_of, is_active_in]
  preferred_id: id
  source: protein
  target: cellular component
  label_in_input: [protein_located_in_cellular_component, protein_part_of_cellular_component, protein_is_active_in_cellular_component] 
  properties:
    reference: str
    evidence_code: str
```
Instead of this:
```
protein to cellular component association loc:
  represented_as: edge
  label_as_edge: protein_located_in_cellular_component
  preferred_id: id
  source: protein
  target: cellular component
  label_in_input: protein_located_in_cellular_component
  properties:
    reference: str
    evidence_code: str
    
protein to cellular component association part:
  represented_as: edge
  label_as_edge: protein_part_of_cellular_component
  preferred_id: id
  source: protein
  target: cellular component
  label_in_input: protein_part_of_cellular_component
  properties:
    reference: str
    evidence_code: str
    
protein to cellular component association active:
  represented_as: edge
  label_as_edge: protein_is_active_in_cellular_component
  preferred_id: id
  source: protein
  target: cellular component
  label_in_input: protein_is_active_in_cellular_component
  properties:
    reference: str
    evidence_code: str
```
In my opinion, this option was crowding config file and was error prone. 

In my changes, I used `label_in_input` field to map BioCypher's ontological backbone. So, it should be unique among all `label_in_input` edge types. And I used `label_as_edge` field to display edge label of corresponding `label_in_input` field in graph db. In addition to that, PR's script create csv files for each association class for edges (e.g., `ProteinToCellularComponentAssociation-header.csv, ProteinToCellularComponentAssociation-part000.csv`). If I continue with previous csv file creation approach, it would have caused issues. For example, Protein-Go and Protein Domain-Go edges may have same edge labels (`label_as_edge`) but not the same properties. This may create inconsistency in csv creation. Also, this may create csv file abundance if someone wants create multiple edge types for many association classes.

I tested these functionalities in fairly complex data that is composed of Protein-Go, Go-Go, Domain-Go edges. It looks like it works fine. Still, there is a possibility that I may have made mistakes and there is also room for improvement. So, I would appreciate it if you could review and check my PR.
