### PR TITLE
draft pandas-tutorial in jupyter

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -92,6 +92,17 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "cfgv"
 version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
@@ -138,6 +149,22 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
 
 [[package]]
+name = "comm"
+version = "0.1.3"
+description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+traitlets = ">=5.3"
+
+[package.extras]
+lint = ["black (>=22.6.0)", "mdformat (>0.7)", "mdformat-gfm (>=0.3.5)", "ruff (>=0.0.156)"]
+test = ["pytest"]
+typing = ["mypy (>=0.990)"]
+
+[[package]]
 name = "coverage"
 version = "7.2.2"
 description = "Code coverage measurement for Python"
@@ -150,6 +177,14 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 
 [package.extras]
 toml = ["tomli"]
+
+[[package]]
+name = "debugpy"
+version = "1.6.7"
+description = "An implementation of the Debug Adapter Protocol for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "decorator"
@@ -290,6 +325,36 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "ipykernel"
+version = "6.23.1"
+description = "IPython Kernel for Jupyter"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+appnope = {version = "*", markers = "platform_system == \"Darwin\""}
+comm = ">=0.1.1"
+debugpy = ">=1.6.5"
+ipython = ">=7.23.1"
+jupyter-client = ">=6.1.12"
+jupyter-core = ">=4.12,<5.0.0 || >=5.1.0"
+matplotlib-inline = ">=0.1"
+nest-asyncio = "*"
+packaging = "*"
+psutil = "*"
+pyzmq = ">=20"
+tornado = ">=6.1"
+traitlets = ">=5.4.0"
+
+[package.extras]
+cov = ["coverage[toml]", "curio", "matplotlib", "pytest-cov", "trio"]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "trio"]
+pyqt5 = ["pyqt5"]
+pyside6 = ["pyside6"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio", "pytest-cov", "pytest-timeout"]
+
+[[package]]
 name = "ipython"
 version = "8.11.0"
 description = "IPython: Productive Interactive Computing"
@@ -378,6 +443,43 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jupyter-client"
+version = "8.2.0"
+description = "Jupyter protocol implementation and client libraries"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
+jupyter-core = ">=4.12,<5.0.0 || >=5.1.0"
+python-dateutil = ">=2.8.2"
+pyzmq = ">=23.0"
+tornado = ">=6.2"
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["ipykernel", "myst-parser", "pydata-sphinx-theme", "sphinx (>=4)", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
+test = ["coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-commit", "pytest", "pytest-cov", "pytest-jupyter[client] (>=0.4.1)", "pytest-timeout"]
+
+[[package]]
+name = "jupyter-core"
+version = "5.3.0"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+platformdirs = ">=2.5"
+pywin32 = {version = ">=300", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["myst-parser", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "markdown-it-py"
@@ -498,6 +600,14 @@ colorlog = "*"
 neo4j = ">=4.4,<5.0"
 PyYAML = ">=5.0"
 toml = "*"
+
+[[package]]
+name = "nest-asyncio"
+version = "1.5.6"
+description = "Patch asyncio to allow nested event loops"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "networkx"
@@ -664,6 +774,17 @@ python-versions = ">=3.7.0"
 wcwidth = "*"
 
 [[package]]
+name = "psutil"
+version = "5.9.5"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
@@ -681,6 +802,14 @@ python-versions = "*"
 
 [package.extras]
 tests = ["pytest"]
+
+[[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
@@ -775,12 +904,31 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pywin32"
+version = "306"
+description = "Python for Window Extensions"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "pyzmq"
+version = "25.1.0"
+description = "Python bindings for 0MQ"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "rdflib"
@@ -1073,6 +1221,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "tornado"
+version = "6.3.2"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+category = "dev"
+optional = false
+python-versions = ">= 3.8"
+
+[[package]]
 name = "tox"
 version = "4.4.8"
 description = "tox is a generic virtualenv management and test command line tool"
@@ -1196,7 +1352,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0a6573a2442787a31bdc68d3355aa7b43e78bf9dc7b4fbcd50e7425c6f960bb0"
+content-hash = "8663ff72d98dd91a2a51cf105901b23b109ae7301cc87f13d85d89a225fede40"
 
 [metadata.files]
 alabaster = [
@@ -1238,6 +1394,72 @@ cachetools = [
 certifi = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
     {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+]
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -1332,6 +1554,10 @@ colorlog = [
     {file = "colorlog-6.7.0-py2.py3-none-any.whl", hash = "sha256:0d33ca236784a1ba3ff9c532d4964126d8a2c44f1f0cb1d2b0728196f512f662"},
     {file = "colorlog-6.7.0.tar.gz", hash = "sha256:bd94bd21c1e13fac7bd3153f4bc3a7dc0eb0974b8bc2fdf1a989e474f6e582e5"},
 ]
+comm = [
+    {file = "comm-0.1.3-py3-none-any.whl", hash = "sha256:16613c6211e20223f215fc6d3b266a247b6e2641bf4e0a3ad34cb1aff2aa3f37"},
+    {file = "comm-0.1.3.tar.gz", hash = "sha256:a61efa9daffcfbe66fd643ba966f846a624e4e6d6767eda9cf6e993aadaab93e"},
+]
 coverage = [
     {file = "coverage-7.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c90e73bdecb7b0d1cea65a08cb41e9d672ac6d7995603d6465ed4914b98b9ad7"},
     {file = "coverage-7.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e2926b8abedf750c2ecf5035c07515770944acf02e1c46ab08f6348d24c5f94d"},
@@ -1385,6 +1611,26 @@ coverage = [
     {file = "coverage-7.2.2-pp37.pp38.pp39-none-any.whl", hash = "sha256:872d6ce1f5be73f05bea4df498c140b9e7ee5418bfa2cc8204e7f9b817caa968"},
     {file = "coverage-7.2.2.tar.gz", hash = "sha256:36dd42da34fe94ed98c39887b86db9d06777b1c8f860520e21126a75507024f2"},
 ]
+debugpy = [
+    {file = "debugpy-1.6.7-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:b3e7ac809b991006ad7f857f016fa92014445085711ef111fdc3f74f66144096"},
+    {file = "debugpy-1.6.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3876611d114a18aafef6383695dfc3f1217c98a9168c1aaf1a02b01ec7d8d1e"},
+    {file = "debugpy-1.6.7-cp310-cp310-win32.whl", hash = "sha256:33edb4afa85c098c24cc361d72ba7c21bb92f501104514d4ffec1fb36e09c01a"},
+    {file = "debugpy-1.6.7-cp310-cp310-win_amd64.whl", hash = "sha256:ed6d5413474e209ba50b1a75b2d9eecf64d41e6e4501977991cdc755dc83ab0f"},
+    {file = "debugpy-1.6.7-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:38ed626353e7c63f4b11efad659be04c23de2b0d15efff77b60e4740ea685d07"},
+    {file = "debugpy-1.6.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:279d64c408c60431c8ee832dfd9ace7c396984fd7341fa3116aee414e7dcd88d"},
+    {file = "debugpy-1.6.7-cp37-cp37m-win32.whl", hash = "sha256:dbe04e7568aa69361a5b4c47b4493d5680bfa3a911d1e105fbea1b1f23f3eb45"},
+    {file = "debugpy-1.6.7-cp37-cp37m-win_amd64.whl", hash = "sha256:f90a2d4ad9a035cee7331c06a4cf2245e38bd7c89554fe3b616d90ab8aab89cc"},
+    {file = "debugpy-1.6.7-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:5224eabbbeddcf1943d4e2821876f3e5d7d383f27390b82da5d9558fd4eb30a9"},
+    {file = "debugpy-1.6.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae1123dff5bfe548ba1683eb972329ba6d646c3a80e6b4c06cd1b1dd0205e9b"},
+    {file = "debugpy-1.6.7-cp38-cp38-win32.whl", hash = "sha256:9cd10cf338e0907fdcf9eac9087faa30f150ef5445af5a545d307055141dd7a4"},
+    {file = "debugpy-1.6.7-cp38-cp38-win_amd64.whl", hash = "sha256:aaf6da50377ff4056c8ed470da24632b42e4087bc826845daad7af211e00faad"},
+    {file = "debugpy-1.6.7-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:0679b7e1e3523bd7d7869447ec67b59728675aadfc038550a63a362b63029d2c"},
+    {file = "debugpy-1.6.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de86029696e1b3b4d0d49076b9eba606c226e33ae312a57a46dca14ff370894d"},
+    {file = "debugpy-1.6.7-cp39-cp39-win32.whl", hash = "sha256:d71b31117779d9a90b745720c0eab54ae1da76d5b38c8026c654f4a066b0130a"},
+    {file = "debugpy-1.6.7-cp39-cp39-win_amd64.whl", hash = "sha256:c0ff93ae90a03b06d85b2c529eca51ab15457868a377c4cc40a23ab0e4e552a3"},
+    {file = "debugpy-1.6.7-py2.py3-none-any.whl", hash = "sha256:53f7a456bc50706a0eaabecf2d3ce44c4d5010e46dfc65b6b81a518b42866267"},
+    {file = "debugpy-1.6.7.zip", hash = "sha256:c4c2f0810fa25323abfdfa36cbbbb24e5c3b1a42cb762782de64439c575d67f2"},
+]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
@@ -1433,6 +1679,10 @@ iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+ipykernel = [
+    {file = "ipykernel-6.23.1-py3-none-any.whl", hash = "sha256:77aeffab056c21d16f1edccdc9e5ccbf7d96eb401bd6703610a21be8b068aadc"},
+    {file = "ipykernel-6.23.1.tar.gz", hash = "sha256:1aba0ae8453e15e9bc6b24e497ef6840114afcdb832ae597f32137fa19d42a6f"},
+]
 ipython = [
     {file = "ipython-8.11.0-py3-none-any.whl", hash = "sha256:5b54478e459155a326bf5f42ee4f29df76258c0279c36f21d71ddb560f88b156"},
     {file = "ipython-8.11.0.tar.gz", hash = "sha256:735cede4099dbc903ee540307b9171fbfef4aa75cfcacc5a273b2cda2f02be04"},
@@ -1452,6 +1702,14 @@ jedi = [
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+jupyter-client = [
+    {file = "jupyter_client-8.2.0-py3-none-any.whl", hash = "sha256:b18219aa695d39e2ad570533e0d71fb7881d35a873051054a84ee2a17c4b7389"},
+    {file = "jupyter_client-8.2.0.tar.gz", hash = "sha256:9fe233834edd0e6c0aa5f05ca2ab4bdea1842bfd2d8a932878212fc5301ddaf0"},
+]
+jupyter-core = [
+    {file = "jupyter_core-5.3.0-py3-none-any.whl", hash = "sha256:d4201af84559bc8c70cead287e1ab94aeef3c512848dde077b7684b54d67730d"},
+    {file = "jupyter_core-5.3.0.tar.gz", hash = "sha256:6db75be0c83edbf1b7c9f91ec266a9a24ef945da630f3120e1a0046dc13713fc"},
 ]
 markdown-it-py = [
     {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
@@ -1535,6 +1793,10 @@ neo4j = [
 neo4j-utils = [
     {file = "neo4j-utils-0.0.7.tar.gz", hash = "sha256:c50e1e6cc3fd852dceadb93320718271afc6ae4efba662bde0cadd9d591ce031"},
     {file = "neo4j_utils-0.0.7-py3-none-any.whl", hash = "sha256:afb49258e60e9123c93dae99eef86fd5f8572997b5edaccaaae95b8826e02f42"},
+]
+nest-asyncio = [
+    {file = "nest_asyncio-1.5.6-py3-none-any.whl", hash = "sha256:b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8"},
+    {file = "nest_asyncio-1.5.6.tar.gz", hash = "sha256:d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290"},
 ]
 networkx = [
     {file = "networkx-3.0-py3-none-any.whl", hash = "sha256:58058d66b1818043527244fab9d41a51fcd7dcc271748015f3c181b8a90c8e2e"},
@@ -1633,6 +1895,22 @@ prompt-toolkit = [
     {file = "prompt_toolkit-3.0.38-py3-none-any.whl", hash = "sha256:45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f"},
     {file = "prompt_toolkit-3.0.38.tar.gz", hash = "sha256:23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b"},
 ]
+psutil = [
+    {file = "psutil-5.9.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:be8929ce4313f9f8146caad4272f6abb8bf99fc6cf59344a3167ecd74f4f203f"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ab8ed1a1d77c95453db1ae00a3f9c50227ebd955437bcf2a574ba8adbf6a74d5"},
+    {file = "psutil-5.9.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4aef137f3345082a3d3232187aeb4ac4ef959ba3d7c10c33dd73763fbc063da4"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ea8518d152174e1249c4f2a1c89e3e6065941df2fa13a1ab45327716a23c2b48"},
+    {file = "psutil-5.9.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:acf2aef9391710afded549ff602b5887d7a2349831ae4c26be7c807c0a39fac4"},
+    {file = "psutil-5.9.5-cp27-none-win32.whl", hash = "sha256:5b9b8cb93f507e8dbaf22af6a2fd0ccbe8244bf30b1baad6b3954e935157ae3f"},
+    {file = "psutil-5.9.5-cp27-none-win_amd64.whl", hash = "sha256:8c5f7c5a052d1d567db4ddd231a9d27a74e8e4a9c3f44b1032762bd7b9fdcd42"},
+    {file = "psutil-5.9.5-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3c6f686f4225553615612f6d9bc21f1c0e305f75d7d8454f9b46e901778e7217"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a7dd9997128a0d928ed4fb2c2d57e5102bb6089027939f3b722f3a210f9a8da"},
+    {file = "psutil-5.9.5-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89518112647f1276b03ca97b65cc7f64ca587b1eb0278383017c2a0dcc26cbe4"},
+    {file = "psutil-5.9.5-cp36-abi3-win32.whl", hash = "sha256:104a5cc0e31baa2bcf67900be36acde157756b9c44017b86b2c049f11957887d"},
+    {file = "psutil-5.9.5-cp36-abi3-win_amd64.whl", hash = "sha256:b258c0c1c9d145a1d5ceffab1134441c4c5113b2417fafff7315a917a026c3c9"},
+    {file = "psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c607bb3b57dc779d55e1554846352b4e358c10fff3abf3514a7a6601beebdb30"},
+    {file = "psutil-5.9.5.tar.gz", hash = "sha256:5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"},
+]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
@@ -1640,6 +1918,10 @@ ptyprocess = [
 pure-eval = [
     {file = "pure_eval-0.2.2-py3-none-any.whl", hash = "sha256:01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350"},
     {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
+]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pygments = [
     {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
@@ -1668,6 +1950,22 @@ python-dateutil = [
 pytz = [
     {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
     {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+]
+pywin32 = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1710,6 +2008,85 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+pyzmq = [
+    {file = "pyzmq-25.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:1a6169e69034eaa06823da6a93a7739ff38716142b3596c180363dee729d713d"},
+    {file = "pyzmq-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:19d0383b1f18411d137d891cab567de9afa609b214de68b86e20173dc624c101"},
+    {file = "pyzmq-25.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1e931d9a92f628858a50f5bdffdfcf839aebe388b82f9d2ccd5d22a38a789dc"},
+    {file = "pyzmq-25.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d984b1b2f574bc1bb58296d3c0b64b10e95e7026f8716ed6c0b86d4679843f"},
+    {file = "pyzmq-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:154bddda2a351161474b36dba03bf1463377ec226a13458725183e508840df89"},
+    {file = "pyzmq-25.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cb6d161ae94fb35bb518b74bb06b7293299c15ba3bc099dccd6a5b7ae589aee3"},
+    {file = "pyzmq-25.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:90146ab578931e0e2826ee39d0c948d0ea72734378f1898939d18bc9c823fcf9"},
+    {file = "pyzmq-25.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:831ba20b660b39e39e5ac8603e8193f8fce1ee03a42c84ade89c36a251449d80"},
+    {file = "pyzmq-25.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3a522510e3434e12aff80187144c6df556bb06fe6b9d01b2ecfbd2b5bfa5c60c"},
+    {file = "pyzmq-25.1.0-cp310-cp310-win32.whl", hash = "sha256:be24a5867b8e3b9dd5c241de359a9a5217698ff616ac2daa47713ba2ebe30ad1"},
+    {file = "pyzmq-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:5693dcc4f163481cf79e98cf2d7995c60e43809e325b77a7748d8024b1b7bcba"},
+    {file = "pyzmq-25.1.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:13bbe36da3f8aaf2b7ec12696253c0bf6ffe05f4507985a8844a1081db6ec22d"},
+    {file = "pyzmq-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:69511d604368f3dc58d4be1b0bad99b61ee92b44afe1cd9b7bd8c5e34ea8248a"},
+    {file = "pyzmq-25.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a983c8694667fd76d793ada77fd36c8317e76aa66eec75be2653cef2ea72883"},
+    {file = "pyzmq-25.1.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:332616f95eb400492103ab9d542b69d5f0ff628b23129a4bc0a2fd48da6e4e0b"},
+    {file = "pyzmq-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58416db767787aedbfd57116714aad6c9ce57215ffa1c3758a52403f7c68cff5"},
+    {file = "pyzmq-25.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cad9545f5801a125f162d09ec9b724b7ad9b6440151b89645241d0120e119dcc"},
+    {file = "pyzmq-25.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d6128d431b8dfa888bf51c22a04d48bcb3d64431caf02b3cb943269f17fd2994"},
+    {file = "pyzmq-25.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b15247c49d8cbea695b321ae5478d47cffd496a2ec5ef47131a9e79ddd7e46c"},
+    {file = "pyzmq-25.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:442d3efc77ca4d35bee3547a8e08e8d4bb88dadb54a8377014938ba98d2e074a"},
+    {file = "pyzmq-25.1.0-cp311-cp311-win32.whl", hash = "sha256:65346f507a815a731092421d0d7d60ed551a80d9b75e8b684307d435a5597425"},
+    {file = "pyzmq-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b45d722046fea5a5694cba5d86f21f78f0052b40a4bbbbf60128ac55bfcc7b6"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f45808eda8b1d71308c5416ef3abe958f033fdbb356984fabbfc7887bed76b3f"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b697774ea8273e3c0460cf0bba16cd85ca6c46dfe8b303211816d68c492e132"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b324fa769577fc2c8f5efcd429cef5acbc17d63fe15ed16d6dcbac2c5eb00849"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5873d6a60b778848ce23b6c0ac26c39e48969823882f607516b91fb323ce80e5"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:f0d9e7ba6a815a12c8575ba7887da4b72483e4cfc57179af10c9b937f3f9308f"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:414b8beec76521358b49170db7b9967d6974bdfc3297f47f7d23edec37329b00"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:01f06f33e12497dca86353c354461f75275a5ad9eaea181ac0dc1662da8074fa"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-win32.whl", hash = "sha256:b5a07c4f29bf7cb0164664ef87e4aa25435dcc1f818d29842118b0ac1eb8e2b5"},
+    {file = "pyzmq-25.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:968b0c737797c1809ec602e082cb63e9824ff2329275336bb88bd71591e94a90"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:47b915ba666c51391836d7ed9a745926b22c434efa76c119f77bcffa64d2c50c"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5af31493663cf76dd36b00dafbc839e83bbca8a0662931e11816d75f36155897"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5489738a692bc7ee9a0a7765979c8a572520d616d12d949eaffc6e061b82b4d1"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1fc56a0221bdf67cfa94ef2d6ce5513a3d209c3dfd21fed4d4e87eca1822e3a3"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:75217e83faea9edbc29516fc90c817bc40c6b21a5771ecb53e868e45594826b0"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3830be8826639d801de9053cf86350ed6742c4321ba4236e4b5568528d7bfed7"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3575699d7fd7c9b2108bc1c6128641a9a825a58577775ada26c02eb29e09c517"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-win32.whl", hash = "sha256:95bd3a998d8c68b76679f6b18f520904af5204f089beebb7b0301d97704634dd"},
+    {file = "pyzmq-25.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:dbc466744a2db4b7ca05589f21ae1a35066afada2f803f92369f5877c100ef62"},
+    {file = "pyzmq-25.1.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:3bed53f7218490c68f0e82a29c92335daa9606216e51c64f37b48eb78f1281f4"},
+    {file = "pyzmq-25.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:eb52e826d16c09ef87132c6e360e1879c984f19a4f62d8a935345deac43f3c12"},
+    {file = "pyzmq-25.1.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ddbef8b53cd16467fdbfa92a712eae46dd066aa19780681a2ce266e88fbc7165"},
+    {file = "pyzmq-25.1.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9301cf1d7fc1ddf668d0abbe3e227fc9ab15bc036a31c247276012abb921b5ff"},
+    {file = "pyzmq-25.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e23a8c3b6c06de40bdb9e06288180d630b562db8ac199e8cc535af81f90e64b"},
+    {file = "pyzmq-25.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4a82faae00d1eed4809c2f18b37f15ce39a10a1c58fe48b60ad02875d6e13d80"},
+    {file = "pyzmq-25.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:c8398a1b1951aaa330269c35335ae69744be166e67e0ebd9869bdc09426f3871"},
+    {file = "pyzmq-25.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d40682ac60b2a613d36d8d3a0cd14fbdf8e7e0618fbb40aa9fa7b796c9081584"},
+    {file = "pyzmq-25.1.0-cp38-cp38-win32.whl", hash = "sha256:33d5c8391a34d56224bccf74f458d82fc6e24b3213fc68165c98b708c7a69325"},
+    {file = "pyzmq-25.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:c66b7ff2527e18554030319b1376d81560ca0742c6e0b17ff1ee96624a5f1afd"},
+    {file = "pyzmq-25.1.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:af56229ea6527a849ac9fb154a059d7e32e77a8cba27e3e62a1e38d8808cb1a5"},
+    {file = "pyzmq-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bdca18b94c404af6ae5533cd1bc310c4931f7ac97c148bbfd2cd4bdd62b96253"},
+    {file = "pyzmq-25.1.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0b6b42f7055bbc562f63f3df3b63e3dd1ebe9727ff0f124c3aa7bcea7b3a00f9"},
+    {file = "pyzmq-25.1.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4c2fc7aad520a97d64ffc98190fce6b64152bde57a10c704b337082679e74f67"},
+    {file = "pyzmq-25.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be86a26415a8b6af02cd8d782e3a9ae3872140a057f1cadf0133de685185c02b"},
+    {file = "pyzmq-25.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:851fb2fe14036cfc1960d806628b80276af5424db09fe5c91c726890c8e6d943"},
+    {file = "pyzmq-25.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2a21fec5c3cea45421a19ccbe6250c82f97af4175bc09de4d6dd78fb0cb4c200"},
+    {file = "pyzmq-25.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bad172aba822444b32eae54c2d5ab18cd7dee9814fd5c7ed026603b8cae2d05f"},
+    {file = "pyzmq-25.1.0-cp39-cp39-win32.whl", hash = "sha256:4d67609b37204acad3d566bb7391e0ecc25ef8bae22ff72ebe2ad7ffb7847158"},
+    {file = "pyzmq-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:71c7b5896e40720d30cd77a81e62b433b981005bbff0cb2f739e0f8d059b5d99"},
+    {file = "pyzmq-25.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4cb27ef9d3bdc0c195b2dc54fcb8720e18b741624686a81942e14c8b67cc61a6"},
+    {file = "pyzmq-25.1.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0c4fc2741e0513b5d5a12fe200d6785bbcc621f6f2278893a9ca7bed7f2efb7d"},
+    {file = "pyzmq-25.1.0-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fc34fdd458ff77a2a00e3c86f899911f6f269d393ca5675842a6e92eea565bae"},
+    {file = "pyzmq-25.1.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8751f9c1442624da391bbd92bd4b072def6d7702a9390e4479f45c182392ff78"},
+    {file = "pyzmq-25.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:6581e886aec3135964a302a0f5eb68f964869b9efd1dbafdebceaaf2934f8a68"},
+    {file = "pyzmq-25.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5482f08d2c3c42b920e8771ae8932fbaa0a67dff925fc476996ddd8155a170f3"},
+    {file = "pyzmq-25.1.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5e7fbcafa3ea16d1de1f213c226005fea21ee16ed56134b75b2dede5a2129e62"},
+    {file = "pyzmq-25.1.0-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:adecf6d02b1beab8d7c04bc36f22bb0e4c65a35eb0b4750b91693631d4081c70"},
+    {file = "pyzmq-25.1.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6d39e42a0aa888122d1beb8ec0d4ddfb6c6b45aecb5ba4013c27e2f28657765"},
+    {file = "pyzmq-25.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:7018289b402ebf2b2c06992813523de61d4ce17bd514c4339d8f27a6f6809492"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9e68ae9864d260b18f311b68d29134d8776d82e7f5d75ce898b40a88df9db30f"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e21cc00e4debe8f54c3ed7b9fcca540f46eee12762a9fa56feb8512fd9057161"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f666ae327a6899ff560d741681fdcdf4506f990595201ed39b44278c471ad98"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f5efcc29056dfe95e9c9db0dfbb12b62db9c4ad302f812931b6d21dd04a9119"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:48e5e59e77c1a83162ab3c163fc01cd2eebc5b34560341a67421b09be0891287"},
+    {file = "pyzmq-25.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:108c96ebbd573d929740d66e4c3d1bdf31d5cde003b8dc7811a3c8c5b0fc173b"},
+    {file = "pyzmq-25.1.0.tar.gz", hash = "sha256:80c41023465d36280e801564a69cbfce8ae85ff79b080e1913f6e90481fb8957"},
 ]
 rdflib = [
     {file = "rdflib-6.3.2-py3-none-any.whl", hash = "sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63"},
@@ -1797,6 +2174,19 @@ toml = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tornado = [
+    {file = "tornado-6.3.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:c367ab6c0393d71171123ca5515c61ff62fe09024fa6bf299cd1339dc9456829"},
+    {file = "tornado-6.3.2-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b46a6ab20f5c7c1cb949c72c1994a4585d2eaa0be4853f50a03b5031e964fc7c"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2de14066c4a38b4ecbbcd55c5cc4b5340eb04f1c5e81da7451ef555859c833f"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05615096845cf50a895026f749195bf0b10b8909f9be672f50b0fe69cba368e4"},
+    {file = "tornado-6.3.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b17b1cf5f8354efa3d37c6e28fdfd9c1c1e5122f2cb56dac121ac61baa47cbe"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:29e71c847a35f6e10ca3b5c2990a52ce38b233019d8e858b755ea6ce4dcdd19d"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_i686.whl", hash = "sha256:834ae7540ad3a83199a8da8f9f2d383e3c3d5130a328889e4cc991acc81e87a0"},
+    {file = "tornado-6.3.2-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6a0848f1aea0d196a7c4f6772197cbe2abc4266f836b0aac76947872cd29b411"},
+    {file = "tornado-6.3.2-cp38-abi3-win32.whl", hash = "sha256:7efcbcc30b7c654eb6a8c9c9da787a851c18f8ccd4a5a3a95b05c7accfa068d2"},
+    {file = "tornado-6.3.2-cp38-abi3-win_amd64.whl", hash = "sha256:0c325e66c8123c606eea33084976c832aa4e766b7dff8aedd7587ea44a604cdf"},
+    {file = "tornado-6.3.2.tar.gz", hash = "sha256:4b927c4f19b71e627b13f3db2324e4ae660527143f9e1f2e2fb404f3a187e2ba"},
 ]
 tox = [
     {file = "tox-4.4.8-py3-none-any.whl", hash = "sha256:12fe562b8992ea63b1e92556b7e28600cd1b70c9e01ce08984f60ce2d32c243c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pytest-cov = "^3.0.0"
 hypothesis = "^6.50.1"
 isort = "^5.10.1"
 ipython = "^8.7.0"
+ipykernel = "^6.23.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tutorial/08_basics_pandas.ipynb
+++ b/tutorial/08_basics_pandas.ipynb
@@ -13,27 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-danger\">\n",
-    "\n",
-    "While BioCypher was designed as a graph-focused framework, due to the commonality of RDBMS and tabular data, BioCypher also supports pandas DataFrame. This tutorial focuses on how to use BioCypher with tabular data.\n",
-    "\n",
-    "</div>"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<strong> @slobentanzer note that I removed the references to each header (I assume duplicates might cause issues, so I leave those to you) </strong>\n",
-    "I also used html alerts instead of .md alerts (they look ugly in plain Jupyter, shouldn't matter for the website)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The main purpose of BioCypher is to facilitate the pre-processing of biomedical data, and thus save development time in the maintenance of curated knowledge graphs, while allowing simple and efficient creation of task-specific lightweight knowledge graphs in a user-friendly and biology-centric fashion.\n",
     "\n",
     "We are going to use a toy example to familiarise the user with the basic functionality of BioCypher. One central task of BioCypher is the harmonisation of dissimilar datasets describing the same entities. Thus, in this example, the input data - which in the real-world use case could come from any type of interface - are represented by simulated data containing some examples of differently formatted biomedical entities such as proteins and their interactions.\n",
@@ -46,17 +25,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "    \n",
-    "<h5> Neo4j </h5>\n",
-    "\n",
-    "While you can use the files generated to create an actual Neo4j database, it is\n",
-    "not required for this tutorial. For checking the output, you can simply open the\n",
-    "CSV files in a text editor or your IDE; by default, they will be written to the\n",
-    "``biocypher-out`` directory. If you simply want to run the tutorial to see how\n",
-    "it works, you can also run the Pandas version.\n",
-    "\n",
-    "</div>  "
+    "While BioCypher was designed as a graph-focused framework, due to the commonality of RDBMS and tabular data, BioCypher also supports pandas DataFrame(s).\n",
+    "(@slobentanzer  should we add something like this? I also show the ontologies in the end just to make it clear that pandas/2D is not the only focus of BioCypher)\n"
    ]
   },
   {
@@ -128,7 +98,7 @@
    "source": [
     "<div class=\"alert alert-danger\">\n",
     "  <strong> @slobentanzer wouldn't it be easier to just have the data_generator under biocypher.test - to avoid cloning the whole repo for the tutorials?\n",
-    "This file would also then fit in docs () </strong>\n",
+    "This file would also then fit in docs (depending how you want to refer to it for the read the docs) </strong>\n",
     "</div>\n"
    ]
   },
@@ -292,7 +262,7 @@
      "output_type": "stream",
      "text": [
       "INFO -- This is BioCypher v0.5.12.\n",
-      "INFO -- Logging into `biocypher-log/biocypher-20230525-210701.log`.\n"
+      "INFO -- Logging into `biocypher-log/biocypher-20230525-211509.log`.\n"
      ]
     }
    ],
@@ -421,14 +391,14 @@
      "data": {
       "text/plain": [
        "{'protein':   protein                                           sequence  \\\n",
-       " 0  A7K8I3  RDCTLEKWVPWVDPDLDHEICEWYKCGYPEKVLAMKGWITKNWLYL...   \n",
-       " 1  E3N0X6  MYNLPHQTLDMRTEYYQMQTCVTDDTALPVNCDHKGGYIMFDDSNN...   \n",
-       " 2  S6S2Z6  IISTDLQKYKLMFKSPDTRPTTFKRGCKMQVWVRHGACLEWTRETP...   \n",
+       " 0  T5F5P2  MLIINVAYNCWWTGEYAVDMSPQVYKSDVRKGMSNKEWRLGIHSQP...   \n",
+       " 1  H9Y5M8  ECEMKHVGLCQDTKEQNKNGNWVRMREFDVIRVHAWYNKHSPYEML...   \n",
+       " 2  R7S2P8  RYVYTFRFELTPPFEYTRGELGPWWGKIRGNHDHFLANKFNACGHL...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  q o f s w k j a l j  9606  A7K8I3      uniprot  \n",
-       " 1  y u m d w f b o m z  9606  E3N0X6      uniprot  \n",
-       " 2  s k h h k c z g s d  9606  S6S2Z6      uniprot  }"
+       " 0  f o g v u g x m l r  9606  T5F5P2      uniprot  \n",
+       " 1  m t r l m p f s t m  9606  H9Y5M8      uniprot  \n",
+       " 2  b a i t y s e p o s  9606  R7S2P8      uniprot  }"
       ]
      },
      "execution_count": 7,
@@ -532,20 +502,20 @@
      "data": {
       "text/plain": [
        "{'protein':   protein                                           sequence  \\\n",
-       " 0  W3S7W3  PIRCYSWTYKRTHWCHLGPFQPWNQSACQSYDWMMHPDAHWLLGGS...   \n",
-       " 1   77184  TIRGYHPDVANGDVWCKPSCYTGSFDVGPWCQNSPTLEQSRNIDWF...   \n",
-       " 2  M1S7Y8  INLGWNGYWCSFMSYGMMSGFINMMTGLVGTPKWSMAYDVTSHDNK...   \n",
-       " 3  702688  YHMEPQDTACCKFHAYIDGNGFVVMHCDNPTKTASSANQVVTWNYW...   \n",
-       " 4  L5N6Q6  CEGIQIADKIGTPLTRMQQSLRSNEDDEGVKRSRPSGMSFYMDQPY...   \n",
-       " 5  904881  FAYTWDQMMEIAYFMLSTMMYNFVSHWHFLCQTYRVIPCARSAAQQ...   \n",
+       " 0  U2H3B8  MHQRMELYWFDCTYILLHSERQGYQHPLMSRSWLEQQPFHDFPEHW...   \n",
+       " 1  940533  CQPDQHIMDCGKGDNNTYACANTLWEDTCWLPLLTKQSRMLWPEDY...   \n",
+       " 2  G0Q4P4  WFMIWGCDNWELIEPWAGSEDPVIMNGHMGQCYQQILQQITTEKQC...   \n",
+       " 3   53444  STDDVCMFDINHIEKATHADYLVRHYRRYWHSDCLWENFMAHVWPT...   \n",
+       " 4  Y7F5E2  PMEITVRGNHIKPISTGMKDSEDHYQFCLDVERHFRGKMEIDPKVT...   \n",
+       " 5  724996  HEVQEDRWRVTNMQYPVAVCLFSIRMAHQYENVLNDMMNDHKQPHF...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  a h u x y y s m v d  9606  W3S7W3      uniprot  \n",
-       " 1  f w c l k b y l i l  9606   77184      uniprot  \n",
-       " 2  h c c v t f p x s b  9606  M1S7Y8      uniprot  \n",
-       " 3  k n p q i z a y e y  9606  702688      uniprot  \n",
-       " 4  y g q y c b g v c s  9606  L5N6Q6      uniprot  \n",
-       " 5  z y u x g t q b p j  9606  904881      uniprot  }"
+       " 0  n t b j e v b v u z  9606  U2H3B8      uniprot  \n",
+       " 1  e i w y h f g i t b  9606  940533      uniprot  \n",
+       " 2  v q p i a d x n x c  9606  G0Q4P4      uniprot  \n",
+       " 3  j f g i a g i m m x  9606   53444      uniprot  \n",
+       " 4  x e b j g c b n s n  9606  Y7F5E2      uniprot  \n",
+       " 5  m c j h h q u q p u  9606  724996      uniprot  }"
       ]
      },
      "execution_count": 11,
@@ -648,7 +618,7 @@
     "for each subclass (with names in PascalCase).\n",
     "</div>\n",
     "\n",
-    "Let's create a DataFrame with the same data as above, but with a different schema configuration:"
+    "Let's create a DataFrame with the same nodes as above, but with a different schema configuration:"
    ]
   },
   {
@@ -668,23 +638,23 @@
      "data": {
       "text/plain": [
        "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          W3S7W3  PIRCYSWTYKRTHWCHLGPFQPWNQSACQSYDWMMHPDAHWLLGGS...   \n",
-       " 1          M1S7Y8  INLGWNGYWCSFMSYGMMSGFINMMTGLVGTPKWSMAYDVTSHDNK...   \n",
-       " 2          L5N6Q6  CEGIQIADKIGTPLTRMQQSLRSNEDDEGVKRSRPSGMSFYMDQPY...   \n",
+       " 0          U2H3B8  MHQRMELYWFDCTYILLHSERQGYQHPLMSRSWLEQQPFHDFPEHW...   \n",
+       " 1          G0Q4P4  WFMIWGCDNWELIEPWAGSEDPVIMNGHMGQCYQQILQQITTEKQC...   \n",
+       " 2          Y7F5E2  PMEITVRGNHIKPISTGMKDSEDHYQFCLDVERHFRGKMEIDPKVT...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  a h u x y y s m v d  9606  W3S7W3      uniprot  \n",
-       " 1  h c c v t f p x s b  9606  M1S7Y8      uniprot  \n",
-       " 2  y g q y c b g v c s  9606  L5N6Q6      uniprot  ,\n",
+       " 0  n t b j e v b v u z  9606  U2H3B8      uniprot  \n",
+       " 1  v q p i a d x n x c  9606  G0Q4P4      uniprot  \n",
+       " 2  x e b j g c b n s n  9606  Y7F5E2      uniprot  ,\n",
        " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0          77184  TIRGYHPDVANGDVWCKPSCYTGSFDVGPWCQNSPTLEQSRNIDWF...   \n",
-       " 1         702688  YHMEPQDTACCKFHAYIDGNGFVVMHCDNPTKTASSANQVVTWNYW...   \n",
-       " 2         904881  FAYTWDQMMEIAYFMLSTMMYNFVSHWHFLCQTYRVIPCARSAAQQ...   \n",
+       " 0         940533  CQPDQHIMDCGKGDNNTYACANTLWEDTCWLPLLTKQSRMLWPEDY...   \n",
+       " 1          53444  STDDVCMFDINHIEKATHADYLVRHYRRYWHSDCLWENFMAHVWPT...   \n",
+       " 2         724996  HEVQEDRWRVTNMQYPVAVCLFSIRMAHQYENVLNDMMNDHKQPHF...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  f w c l k b y l i l  9606   77184       entrez  \n",
-       " 1  k n p q i z a y e y  9606  702688       entrez  \n",
-       " 2  z y u x g t q b p j  9606  904881       entrez  }"
+       " 0  e i w y h f g i t b  9606  940533       entrez  \n",
+       " 1  j f g i a g i m m x  9606   53444       entrez  \n",
+       " 2  m c j h h q u q p u  9606  724996       entrez  }"
       ]
      },
      "execution_count": 13,
@@ -846,23 +816,23 @@
      "data": {
       "text/plain": [
        "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          A3B0D2  PNQQGCSGCGNADSLFWAYYSKFICDWEHKMTKEIMEGHIEEYKPE...   \n",
-       " 1          R4T7H1  FSKPDNGTILKPFKYWEMRKGPHDIARCGSDVFAKCFMRISVTEHI...   \n",
-       " 2          M6F5M0  FIEECEWVMVKWSFPKMFKDCWNGMRIGQTQSEHCWWFFESALSFV...   \n",
+       " 0          D5G5I7  TNHLWSRNLDHAWMMDWEATMMAENWFQINNCFHDLSYEDGTTTRA...   \n",
+       " 1          X2P1S4  NWWISLGAFASDGSELRTHGGEGGLQKCKCCQNTREPTSSEHRMDA...   \n",
+       " 2          T2U8I9  QWLAQMTQGSHNCDADKHHDTWPATPTIMDWALDATIDNPPKTHQG...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  s w k i j b q u q f  8174  None  A3B0D2      uniprot  \n",
-       " 1  z w c a h f v f b v  8213  None  R4T7H1      uniprot  \n",
-       " 2  w w f d d v s n x i  8077  None  M6F5M0      uniprot  ,\n",
+       " 0  u x a h k w b q i a  5603  None  D5G5I7      uniprot  \n",
+       " 1  j d y t e u d r u i  8980  None  X2P1S4      uniprot  \n",
+       " 2  j j e c c e n g o b  6504  1634  T2U8I9      uniprot  ,\n",
        " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0          32539  TDVFSDVNNKGTRVKVMSFFPNADYYGNTHENMECWWGPRPIYGSI...   \n",
-       " 1          73002  MKLFRGYFRNFYKRIIFERYEDNPLNCQMQLFRQVIMYMRNWLIMW...   \n",
-       " 2         719470  CPRFCMETYHQRCNCLLKQFYWEWVFMWIDEPSKSGGITTFNIRII...   \n",
+       " 0         440496  GCKFMLLLEKREGKSGYCDRYHRPAAEGTGCPMVHLNSPDDHINRG...   \n",
+       " 1         539695  PFMFYNQIIRGFLGVPYPNWMAFFTPNDYNLPPTVYWYMEGWHTME...   \n",
+       " 2         330717  TWEAKELQDYVDMMPMEPYHTAESPVYDTPYAHRCEYELLDHVESC...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  u k i v q y n h e k  9606  None   32539       entrez  \n",
-       " 1  h f u j w k y s t l  9606  None   73002       entrez  \n",
-       " 2  w f m x p h w y l m  9606  None  719470       entrez  }"
+       " 0  r x q v s d h t g a  9606  None  440496       entrez  \n",
+       " 1  o c e f t d q q z k  9606  None  539695       entrez  \n",
+       " 2  y u k a j z h w a l  9606  None  330717       entrez  }"
       ]
      },
      "execution_count": 16,
@@ -993,34 +963,34 @@
      "text": [
       "uniprot.protein\n",
       "  uniprot.protein                                           sequence  \\\n",
-      "0          S4N9S9  LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVA...   \n",
-      "1          D3W1B3  TTHPLTMKNAHPWFKCNFIQRASYTVRGLFFHCNHTRRRHHNFMDF...   \n",
-      "2          V9H4Q3  KQIILTVSYHLFITENPIDYEGNVVMNTPTWFLGQHRCQVKDPHSY...   \n",
+      "0          R5B2H9  HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWIL...   \n",
+      "1          Q2I2W4  KKKVHPDGGYTLVLCKQADYRLIAIEAWAKHMFMIHFNRKPQSMER...   \n",
+      "2          G3R3Z6  ALAKGWMGTTAPGLPWSAKTAYQGRGFIEQMTGKLSWEMERAHDWA...   \n",
       "\n",
       "           description taxon  mass      id preferred_id  \n",
-      "0  v m i r i t g i r m  2834  None  S4N9S9      uniprot  \n",
-      "1  s r i k z z n i a n  9079  6966  D3W1B3      uniprot  \n",
-      "2  x n n b p w e p d h  7976  None  V9H4Q3      uniprot  \n",
+      "0  e e b p c e v r r u  6894  None  R5B2H9      uniprot  \n",
+      "1  a c w g x r z b r b  4760  None  Q2I2W4      uniprot  \n",
+      "2  a z o m f n a g v s   653  None  G3R3Z6      uniprot  \n",
       "protein isoform\n",
       "  protein isoform                                           sequence  \\\n",
-      "0          M9E8U2  PLTKQWENFRAENSWPGLKKQCEIEQWHPSKIRHVWEKNKWLCCNL...   \n",
-      "1          X9A9O5  SLRHCCQSAAWKNKSKMDLLCTAHVPMVWIVGCNQKRFKKTWKQRL...   \n",
-      "2          O8Q8I0  KNFAKSTMMFQQRPKGVNWFDWFNEPQHNTDDSQVQKCIMIGVQHY...   \n",
+      "0          M1U3F5  FKQTSDSTVRPQKGRHWIWANTGVESRWRQGQKFKNQYSTAYFTKW...   \n",
+      "1          F3N8I9  DSNQEKDFIIRHTKLIHDNTQWAGWDTVFFMEGDAGKCDTIEPWVH...   \n",
+      "2          Z0K9H8  RWECELLYYKHMKYQIYIVHVHKHNHRWMLTPHLYKPQYNIRDNES...   \n",
       "\n",
       "           description taxon  mass      id preferred_id  \n",
-      "0  l f v b q n g e v p  2798  None  M9E8U2      uniprot  \n",
-      "1  z w c m m m z c x s  7119  1728  X9A9O5      uniprot  \n",
-      "2  o x c p u w f n b v  6206  None  O8Q8I0      uniprot  \n",
+      "0  f i b j s o g d y v  2859  8185  M1U3F5      uniprot  \n",
+      "1  a f y e d n h f x d  5920  None  F3N8I9      uniprot  \n",
+      "2  s z c j m u w d d p  8833  None  Z0K9H8      uniprot  \n",
       "entrez.protein\n",
       "  entrez.protein                                           sequence  \\\n",
-      "0         254811  KIYSKKLGAGMLIEHYRNELTSFGCQCTGCTRQFLFKFLAHPLTWA...   \n",
-      "1         942300  MFGNWLNWDKGEYVYYRNPEMRKGSHCRLFIDQYQCKLRLANHSLE...   \n",
-      "2         267767  IMVRQQESQHMSVWYNTTTKFVIHMHHHVDESNMPFDLRSNFKDFE...   \n",
+      "0         220796  SFELQYAGHTPLSEWADWKKCVIDMRQMVFKCMAHEVEVWLGCDWM...   \n",
+      "1         250327  LSACDWTNHSKREPDKMRVGVYGDICQKGEKAFATFRNVPDAYGWY...   \n",
+      "2         345723  PEMIDILYVITHQQPDSSHQRGGSVVSMDRGEWQQFLCDGCDVASY...   \n",
       "\n",
       "           description taxon  mass      id preferred_id  \n",
-      "0  g h t i x d d g f j  9606  None  254811       entrez  \n",
-      "1  h q d j q n n j z b  9606  None  942300       entrez  \n",
-      "2  w c g l y d s v y y  9606  None  267767       entrez  \n"
+      "0  w j a p g g r e l c  9606  None  220796       entrez  \n",
+      "1  c h t f p w r d d y  9606  None  250327       entrez  \n",
+      "2  l x x n a b w r f g  9606  None  345723       entrez  \n"
      ]
     }
    ],
@@ -1151,7 +1121,7 @@
     {
      "data": {
       "text/plain": [
-       "'S4N9S9 interacts_with O8Q8I0'"
+       "'Z0K9H8 interacts_with R5B2H9'"
       ]
      },
      "execution_count": 22,
@@ -1160,7 +1130,7 @@
     }
    ],
    "source": [
-    "# naturally interactions contain information about the interacting source and target\n",
+    "# naturally interactions/edges contain information about the interacting source and target nodes\n",
     "# let's look at the first one in the list\n",
     "interaction = ppi[0]\n",
     "f\"{interaction.get_source_id()} {interaction.label} {interaction.get_target_id()}\""
@@ -1174,7 +1144,7 @@
     {
      "data": {
       "text/plain": [
-       "{'source': 'signor'}"
+       "{'method': 'z f j w j p f t e a'}"
       ]
      },
      "execution_count": 23,
@@ -1254,37 +1224,35 @@
      "data": {
       "text/plain": [
        "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          S4N9S9  LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVA...   \n",
-       " 1          D3W1B3  TTHPLTMKNAHPWFKCNFIQRASYTVRGLFFHCNHTRRRHHNFMDF...   \n",
-       " 2          V9H4Q3  KQIILTVSYHLFITENPIDYEGNVVMNTPTWFLGQHRCQVKDPHSY...   \n",
+       " 0          R5B2H9  HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWIL...   \n",
+       " 1          Q2I2W4  KKKVHPDGGYTLVLCKQADYRLIAIEAWAKHMFMIHFNRKPQSMER...   \n",
+       " 2          G3R3Z6  ALAKGWMGTTAPGLPWSAKTAYQGRGFIEQMTGKLSWEMERAHDWA...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  v m i r i t g i r m  2834  None  S4N9S9      uniprot  \n",
-       " 1  s r i k z z n i a n  9079  6966  D3W1B3      uniprot  \n",
-       " 2  x n n b p w e p d h  7976  None  V9H4Q3      uniprot  ,\n",
+       " 0  e e b p c e v r r u  6894  None  R5B2H9      uniprot  \n",
+       " 1  a c w g x r z b r b  4760  None  Q2I2W4      uniprot  \n",
+       " 2  a z o m f n a g v s   653  None  G3R3Z6      uniprot  ,\n",
        " 'protein isoform':   protein isoform                                           sequence  \\\n",
-       " 0          M9E8U2  PLTKQWENFRAENSWPGLKKQCEIEQWHPSKIRHVWEKNKWLCCNL...   \n",
-       " 1          X9A9O5  SLRHCCQSAAWKNKSKMDLLCTAHVPMVWIVGCNQKRFKKTWKQRL...   \n",
-       " 2          O8Q8I0  KNFAKSTMMFQQRPKGVNWFDWFNEPQHNTDDSQVQKCIMIGVQHY...   \n",
+       " 0          M1U3F5  FKQTSDSTVRPQKGRHWIWANTGVESRWRQGQKFKNQYSTAYFTKW...   \n",
+       " 1          F3N8I9  DSNQEKDFIIRHTKLIHDNTQWAGWDTVFFMEGDAGKCDTIEPWVH...   \n",
+       " 2          Z0K9H8  RWECELLYYKHMKYQIYIVHVHKHNHRWMLTPHLYKPQYNIRDNES...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  l f v b q n g e v p  2798  None  M9E8U2      uniprot  \n",
-       " 1  z w c m m m z c x s  7119  1728  X9A9O5      uniprot  \n",
-       " 2  o x c p u w f n b v  6206  None  O8Q8I0      uniprot  ,\n",
+       " 0  f i b j s o g d y v  2859  8185  M1U3F5      uniprot  \n",
+       " 1  a f y e d n h f x d  5920  None  F3N8I9      uniprot  \n",
+       " 2  s z c j m u w d d p  8833  None  Z0K9H8      uniprot  ,\n",
        " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         254811  KIYSKKLGAGMLIEHYRNELTSFGCQCTGCTRQFLFKFLAHPLTWA...   \n",
-       " 1         942300  MFGNWLNWDKGEYVYYRNPEMRKGSHCRLFIDQYQCKLRLANHSLE...   \n",
-       " 2         267767  IMVRQQESQHMSVWYNTTTKFVIHMHHHVDESNMPFDLRSNFKDFE...   \n",
+       " 0         220796  SFELQYAGHTPLSEWADWKKCVIDMRQMVFKCMAHEVEVWLGCDWM...   \n",
+       " 1         250327  LSACDWTNHSKREPDKMRVGVYGDICQKGEKAFATFRNVPDAYGWY...   \n",
+       " 2         345723  PEMIDILYVITHQQPDSSHQRGGSVVSMDRGEWQQFLCDGCDVASY...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  g h t i x d d g f j  9606  None  254811       entrez  \n",
-       " 1  h q d j q n n j z b  9606  None  942300       entrez  \n",
-       " 2  w c g l y d s v y y  9606  None  267767       entrez  ,\n",
-       " 'protein protein interaction':   protein protein interaction   _from     _to  source method\n",
-       " 0                        None  S4N9S9  O8Q8I0  signor   None\n",
-       " 1                intact404645  V9H4Q3  M9E8U2  signor   None\n",
-       " 2                        None  O8Q8I0  254811    None   None\n",
-       " 3                        None  267767  D3W1B3  intact   None}"
+       " 0  w j a p g g r e l c  9606  None  220796       entrez  \n",
+       " 1  c h t f p w r d d y  9606  None  250327       entrez  \n",
+       " 2  l x x n a b w r f g  9606  None  345723       entrez  ,\n",
+       " 'protein protein interaction':   protein protein interaction   _from     _to               method source\n",
+       " 0                        None  Z0K9H8  R5B2H9  z f j w j p f t e a   None\n",
+       " 1                        None  Z0K9H8  345723                 None   None}"
       ]
      },
      "execution_count": 26,
@@ -1333,7 +1301,7 @@
     {
      "data": {
       "text/plain": [
-       "<treelib.tree.Tree at 0x7f63db8db730>"
+       "<treelib.tree.Tree at 0x7f76f03234f0>"
       ]
      },
      "execution_count": 27,
@@ -1389,9 +1357,9 @@
     {
      "data": {
       "text/plain": [
-       "{'sequence': 'LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVAYNVEQIFTVYVTICMVIRYCGFICRQYNIPYSIKLHMDECHHGLKITVEDPGTHHKDHVFRFLTLKSTIEMNLLWLCKLQELIAIAGVEDCEGFITNKVWQILVSPSSYPMGGDPPGVGVSALPMFTHVGAERTCCDQFYCNYCHYPIFAMICNTMNCLANMCM',\n",
-       " 'description': 'v m i r i t g i r m',\n",
-       " 'taxon': '2834'}"
+       "{'sequence': 'HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWILYKQNFHWHFHYNDYKAPIYKSTICQCQNHNCKQILVCEFVGPMYMNETGWNYILANMHIEWQWWNRPQDKINFTQALPNRMRFFSGQFVWINTCSLATNVWMGMRTVVFCFIQDNDPPFSVLSVEDSAHVFNRNEGCQWWMVTCRNCVLKQAIRSVSDRWAREKKFDIDNKGGKAPCYNPENK',\n",
+       " 'description': 'e e b p c e v r r u',\n",
+       " 'taxon': '6894'}"
       ]
      },
      "execution_count": 28,
@@ -1420,23 +1388,23 @@
      "data": {
       "text/plain": [
        "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          A6E1Z1  NNVKFGGTSPMKQLRQQTLQEGMGRGIMMLHSWAEIQFWTCYYNRG...   \n",
-       " 1          N3G9S4  HVWGTAGMKYGHYYIMMSHGMLACCCVAMARVLGLSWRTDGCQFYV...   \n",
-       " 2          O8S7W5  MQYKYPICMLSMAMRDHCKAAVHCGNFFGAASNMHVIFVYLIDHRG...   \n",
-       " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  g b n b f k f a s i  7899  8243  A6E1Z1      uniprot  \n",
-       " 1  f n a t s o x j j q   691  None  N3G9S4      uniprot  \n",
-       " 2  j i a y k q m j e w  7847  None  O8S7W5      uniprot  ,\n",
-       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         629106  VMADTHMFNSMRASLYCQPITFCPDWFNAHCTDGRGETRHPDMELP...   \n",
-       " 1         518879  EENRDACNHNCFEENICPCKCFDFVKMTDKARCQTQPPKYRALRYR...   \n",
-       " 2         123815  MWHKRTYWNCSKMWTDFIDFIWDKEQSSDLAQAGNSDNNCGSGMYM...   \n",
+       " 0          F3O7K0  QPFMMSASMMIGRAHGQIGWLKSPARHFMARQDYCPHHCAEQCFLY...   \n",
+       " 1          A2F0A6  SNCPMWYWRRMQEVEFSVTGLRWELSFQPRLMWNKLFRDFAPDIAI...   \n",
+       " 2          Z8P0Y6  LMWSVIGWALPSMYAYNRRIYGWAGRDVGWVAMENCATCERHFLCK...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  j g o i c g v i e f  9606  629106       entrez  \n",
-       " 1  k x m x a d v g s y  9606  518879       entrez  \n",
-       " 2  f x l j q q h b l o  9606  123815       entrez  }"
+       " 0  c g r q j d w u g v  5503  F3O7K0      uniprot  \n",
+       " 1  f p z r m z l u q u  7683  A2F0A6      uniprot  \n",
+       " 2  e m s b f c l f z y  4912  Z8P0Y6      uniprot  ,\n",
+       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
+       " 0         728388  CNTENHCKPADDSEAVPWINKSDIKPGSSFDASTAGAFIDETADFS...   \n",
+       " 1         654434  FLKQANQEDQWCNLCISSWDEQIVIRSEIVEFMDSFKLCEEDIWES...   \n",
+       " 2         139446  AWVVHILPIHVYPRSLNFIGKPEAAGLKISSGSINECVQLYKKIME...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  r d g w w p v y q t  9606  728388       entrez  \n",
+       " 1  r q s q n v h e n t  9606  654434       entrez  \n",
+       " 2  g k w m k j h u w i  9606  139446       entrez  }"
       ]
      },
      "execution_count": 29,

--- a/tutorial/08_basics_pandas.ipynb
+++ b/tutorial/08_basics_pandas.ipynb
@@ -1,0 +1,1498 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BioCypher Tutorial - Basics with Pandas"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-danger\">\n",
+    "\n",
+    "While BioCypher was designed as a graph-focused framework, due to the commonality of RDBMS and tabular data, BioCypher also supports pandas DataFrame. This tutorial focuses on how to use BioCypher with tabular data.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<strong> @slobentanzer note that I removed the references to each header (I assume duplicates might cause issues, so I leave those to you) </strong>\n",
+    "I also used html alerts instead of .md alerts (they look ugly in plain Jupyter, shouldn't matter for the website)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The main purpose of BioCypher is to facilitate the pre-processing of biomedical data, and thus save development time in the maintenance of curated knowledge graphs, while allowing simple and efficient creation of task-specific lightweight knowledge graphs in a user-friendly and biology-centric fashion.\n",
+    "\n",
+    "We are going to use a toy example to familiarise the user with the basic functionality of BioCypher. One central task of BioCypher is the harmonisation of dissimilar datasets describing the same entities. Thus, in this example, the input data - which in the real-world use case could come from any type of interface - are represented by simulated data containing some examples of differently formatted biomedical entities such as proteins and their interactions.\n",
+    "\n",
+    "There are two other versions of this tutorial, which only differ in the output format. The first uses a CSV output format to write files suitable for Neo4j admin import, and the second creates an in-memory collection of Pandas dataframes. You can find both in the tutorial directory of the BioCypher repository. This tutorial simply takes the in-memory approach to a Jupyter notebook."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "    \n",
+    "<h5> Neo4j </h5>\n",
+    "\n",
+    "While you can use the files generated to create an actual Neo4j database, it is\n",
+    "not required for this tutorial. For checking the output, you can simply open the\n",
+    "CSV files in a text editor or your IDE; by default, they will be written to the\n",
+    "``biocypher-out`` directory. If you simply want to run the tutorial to see how\n",
+    "it works, you can also run the Pandas version.\n",
+    "\n",
+    "</div>  "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run this tutorial, you will need to have cloned and installed the BioCypher repository on your machine. We recommend using [Poetry](https://python-poetry.org/). \n",
+    "\n",
+    "To obtain both, run the following commands in your terminal:"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{bash}\n",
+    "git clone https://github.com/biocypher/biocypher.git\n",
+    "cd biocypher\n",
+    "poetry install\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "<h5> Poetry environment </h5>\n",
+    "\n",
+    "In order to run the tutorial code, you will need to activate the Poetry\n",
+    "environment. This can be done by running `poetry shell` in the `biocypher`\n",
+    "directory. Alternatively, you can run the code from within the Poetry\n",
+    "environment by prepending `poetry run` to the command. For example, to run the\n",
+    "tutorial code, you can run `poetry run python tutorial/01__basic_import.py`.\n",
+    "\n",
+    "\n",
+    "</div>  "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the `biocypher` root directory, you will find a `tutorial` directory with\n",
+    "the files for this tutorial. The `data_generator.py` file contains the\n",
+    "simulated data generation code, and the other files are named according to the\n",
+    "tutorial step they are used in. The `biocypher-out` directory will be created\n",
+    "automatically when you run the tutorial code."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-danger\">\n",
+    "  <strong> @slobentanzer wouldn't it be easier to just have the data_generator under biocypher.test - to avoid cloning the whole repo for the tutorials?\n",
+    "This file would also then fit in docs () </strong>\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# helper function to print yaml files\n",
+    "import yaml\n",
+    "def print_yaml(file_path):\n",
+    "    with open(file_path, 'r') as file:\n",
+    "        yaml_data = yaml.safe_load(file)\n",
+    "\n",
+    "    print(\"--------------\")\n",
+    "    print(yaml.dump(yaml_data, sort_keys=False, indent=4))\n",
+    "    print(\"--------------\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "BioCypher is configured using a YAML file; it comes with a default (which you\n",
+    "can see in the [Configuration](config) section). You can use it, for instance,\n",
+    "to select an output format, the output directory, separators, logging level, and\n",
+    "other options. For this tutorial, we will use a dedicated configuration file for\n",
+    "each of the steps. The configuration files are located in the `tutorial`\n",
+    "directory, and are called using the `biocypher_config_path` argument at\n",
+    "instantiation of the BioCypher interface. For more information, see also the\n",
+    "[Quickstart Configuration](quick_config) section.\n",
+    "\n",
+    "## Section 1: Adding data\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "    \n",
+    "<h5> Tutorial files </h5>\n",
+    "\n",
+    "The code for this tutorial can be found at `tutorial/01__basic_import.py`. The\n",
+    "schema is at `tutorial/01_schema_config.yaml`, configuration in\n",
+    "`tutorial/01_biocypher_config.yaml`. Data generation happens in\n",
+    "`tutorial/data_generator.py`.\n",
+    "\n",
+    "</div>  \n",
+    "\n",
+    "### Input data stream (\"adapter\")\n",
+    "The basic operation of adding data to the knowledge graph requires two\n",
+    "components: an input stream of data (which we call adapter) and a configuration\n",
+    "for the resulting desired output (the schema configuration). The former will be\n",
+    "simulated by calling the `Protein` class of our data generator 10 times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a list of proteins to be imported\n",
+    "from data_generator import Protein\n",
+    "n_proteins = 3\n",
+    "proteins = [Protein() for _ in range(n_proteins)]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each protein in our simulated data has a UniProt ID, a label\n",
+    "(\"uniprot_protein\"), and a dictionary of properties describing it. This is -\n",
+    "purely by coincidence - very close to the input BioCypher expects (for nodes):\n",
+    "- a unique identifier\n",
+    "- an input label (to allow mapping to the ontology, see the second step below)\n",
+    "- a dictionary of further properties (which can be empty)\n",
+    "\n",
+    "These should be presented to BioCypher in the form of a tuple. To achieve this\n",
+    "representation, we can use a generator function that iterates through our\n",
+    "simulated input data and, for each entity, forms the corresponding tuple. The\n",
+    "use of a generator allows for efficient streaming of larger datasets where\n",
+    "required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def node_generator(proteins):\n",
+    "    for protein in proteins:\n",
+    "        yield (\n",
+    "            protein.get_id(),\n",
+    "            protein.get_label(),\n",
+    "            protein.get_properties(),\n",
+    "        )\n",
+    "entities = node_generator(proteins)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The concept of an adapter can become arbitrarily complex and involve\n",
+    "programmatic access to databases, API requests, asynchronous queries, context\n",
+    "managers, and other complicating factors. However, it always boils down to\n",
+    "providing the BioCypher driver with a collection of tuples, one for each entity\n",
+    "in the input data. For more info, see the section on\n",
+    "[Adapters](adapter_functions).\n",
+    "\n",
+    "As descibed above, *nodes* possess:\n",
+    "\n",
+    "- a mandatory ID,\n",
+    "- a mandatory label, and\n",
+    "- a property dictionary,\n",
+    "\n",
+    "while *edges* possess:\n",
+    "\n",
+    "- an (optional) ID,\n",
+    "- two mandatory IDs for source and target,\n",
+    "- a mandatory label, and\n",
+    "- a property dictionary.\n",
+    "\n",
+    "How these entities are mapped to the ontological hierarchy underlying a\n",
+    "BioCypher graph is determined by their mandatory labels, which connect the input\n",
+    "data stream to the schema configuration. This we will see in the following\n",
+    "section."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Schema configuration\n",
+    "How each BioCypher graph is structured is determined by the schema configuration\n",
+    "YAML file that is given to the BioCypher interface. This also serves to ground\n",
+    "the entities of the graph in the biomedical realm by using an ontological\n",
+    "hierarchy. In this tutorial, we refer to the Biolink model as the general\n",
+    "backbone of our ontological hierarchy. The basic premise of the schema\n",
+    "configuration YAML file is that each component of the desired knowledge graph\n",
+    "output should be configured here; if (and only if) an entity is represented in\n",
+    "the schema configuration *and* is present in the input data stream, will it be\n",
+    "part of our knowledge graph.\n",
+    "\n",
+    "In our case, since we only import proteins, we only require few lines of\n",
+    "configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- This is BioCypher v0.5.12.\n",
+      "INFO -- Logging into `biocypher-log/biocypher-20230525-210701.log`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from biocypher import BioCypher\n",
+    "from os.path import join\n",
+    "schema_path = join('..', 'tutorial')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id: uniprot\n",
+      "    input_label: uniprot_protein\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '01_schema_config.yaml'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first line (`protein`) identifies our entity and connects to the\n",
+    "ontological backbone; here we define the first class to be represented in the\n",
+    "graph. In the configuration YAML, we represent entities — similar to the\n",
+    "internal representation of Biolink — in lower sentence case (e.g., \"small\n",
+    "molecule\"). Conversely, for class names, in file names, and property graph\n",
+    "labels, we use PascalCase instead (e.g., \"SmallMolecule\") to avoid issues with\n",
+    "handling spaces. The transformation is done by BioCypher internally. BioCypher\n",
+    "does not strictly enforce the entities allowed in this class definition; in\n",
+    "fact, we provide [several methods of extending the existing ontological\n",
+    "backbone *ad hoc* by providing custom inheritance or hybridising\n",
+    "ontologies](biolink). However, every entity should at some point be connected\n",
+    "to the underlying ontology, otherwise the multiple hierarchical labels will not\n",
+    "be populated. Following this first line are three indented values of the\n",
+    "protein class.\n",
+    "\n",
+    "The second line (`represented_as`) tells BioCypher in which way each entity\n",
+    "should be represented in the graph; the only options are `node` and `edge`.\n",
+    "Representation as an edge is only possible when source and target IDs are\n",
+    "provided in the input data stream. Conversely, relationships can be represented\n",
+    "as both `node` or `edge`, depending on the desired output. When a relationship\n",
+    "should be represented as a node, i.e., \"reified\", BioCypher takes care to create\n",
+    "a set of two edges and a node in place of the relationship. This is useful when\n",
+    "we want to connect the relationship to other entities in the graph, for example\n",
+    "literature references.\n",
+    "\n",
+    "The third line (`preferred_id`) informs the uniqueness of represented entities\n",
+    "by selecting an ontological namespace around which the definition of uniqueness\n",
+    "should revolve. In our example, if a protein has its own uniprot ID, it is\n",
+    "understood to be a unique entity. When there are multiple protein isoforms\n",
+    "carrying the same uniprot ID, they are understood to be aggregated to result in\n",
+    "only one unique entity in the graph. Decisions around uniqueness of graph\n",
+    "constituents sometimes require some consideration in task-specific\n",
+    "applications. Selection of a namespace also has effects in identifier mapping;\n",
+    "in our case, for protein nodes that do not carry a uniprot ID, identifier\n",
+    "mapping will attempt to find a uniprot ID given the other identifiers of that\n",
+    "node. To account for the broadest possible range of identifier systems while\n",
+    "also dealing with parsing of namespace prefixes and validation, we refer to the\n",
+    "[Bioregistry](https://bioregistry.io) project namespaces, which should be\n",
+    "preferred values for this field.\n",
+    "\n",
+    "Finally, the fourth line (`input_label`) connects the input data stream to the\n",
+    "configuration; here we indicate which label to expect in the input tuple for\n",
+    "each class in the graph. In our case, we expect \"uniprot_protein\" as the label\n",
+    "for each protein in the input data stream; all other input entities that do not\n",
+    "carry this label are ignored as long as they are not in the schema\n",
+    "configuration."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating the graph (using the BioCypher interface)\n",
+    "All that remains to be done now is to instantiate the BioCypher interface (as the\n",
+    "main means of communicating with BioCypher) and call the function to create the\n",
+    "graph. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    }
+   ],
+   "source": [
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '01_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '01_schema_config.yaml'),\n",
+    ")\n",
+    "# Add the entities that we generated above to the graph\n",
+    "bc.add(entities)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'protein':   protein                                           sequence  \\\n",
+       " 0  A7K8I3  RDCTLEKWVPWVDPDLDHEICEWYKCGYPEKVLAMKGWITKNWLYL...   \n",
+       " 1  E3N0X6  MYNLPHQTLDMRTEYYQMQTCVTDDTALPVNCDHKGGYIMFDDSNN...   \n",
+       " 2  S6S2Z6  IISTDLQKYKLMFKSPDTRPTTFKRGCKMQVWVRHGACLEWTRETP...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  q o f s w k j a l j  9606  A7K8I3      uniprot  \n",
+       " 1  y u m d w f b o m z  9606  E3N0X6      uniprot  \n",
+       " 2  s k h h k c z g s d  9606  S6S2Z6      uniprot  }"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Print the graph as a dictionary of pandas DataFrame(s) per node label\n",
+    "bc.to_df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 2: Merging data\n",
+    "\n",
+    "### Plain merge\n",
+    "\n",
+    "Using the workflow described above with minor changes, we can merge data from\n",
+    "different input streams. If we do not want to introduce additional ontological\n",
+    "subcategories, we can simply add the new input stream to the existing one and\n",
+    "add the new label to the schema configuration (the new label being\n",
+    "`entrez_protein`). In this case, we would add the following to the schema\n",
+    "configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_generator import Protein, EntrezProtein"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id: uniprot\n",
+      "    input_label:\n",
+      "    - uniprot_protein\n",
+      "    - entrez_protein\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '02_schema_config.yaml'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a list of proteins to be imported\n",
+    "proteins = [\n",
+    "    p for sublist in zip(\n",
+    "        [Protein() for _ in range(n_proteins)],\n",
+    "        [EntrezProtein() for _ in range(n_proteins)],\n",
+    "    ) for p in sublist\n",
+    "]\n",
+    "# Create a new BioCypher instance\n",
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '02_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '02_schema_config.yaml'),\n",
+    ")\n",
+    "# Run the import\n",
+    "bc.add(node_generator(proteins))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'protein':   protein                                           sequence  \\\n",
+       " 0  W3S7W3  PIRCYSWTYKRTHWCHLGPFQPWNQSACQSYDWMMHPDAHWLLGGS...   \n",
+       " 1   77184  TIRGYHPDVANGDVWCKPSCYTGSFDVGPWCQNSPTLEQSRNIDWF...   \n",
+       " 2  M1S7Y8  INLGWNGYWCSFMSYGMMSGFINMMTGLVGTPKWSMAYDVTSHDNK...   \n",
+       " 3  702688  YHMEPQDTACCKFHAYIDGNGFVVMHCDNPTKTASSANQVVTWNYW...   \n",
+       " 4  L5N6Q6  CEGIQIADKIGTPLTRMQQSLRSNEDDEGVKRSRPSGMSFYMDQPY...   \n",
+       " 5  904881  FAYTWDQMMEIAYFMLSTMMYNFVSHWHFLCQTYRVIPCARSAAQQ...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  a h u x y y s m v d  9606  W3S7W3      uniprot  \n",
+       " 1  f w c l k b y l i l  9606   77184      uniprot  \n",
+       " 2  h c c v t f p x s b  9606  M1S7Y8      uniprot  \n",
+       " 3  k n p q i z a y e y  9606  702688      uniprot  \n",
+       " 4  y g q y c b g v c s  9606  L5N6Q6      uniprot  \n",
+       " 5  z y u x g t q b p j  9606  904881      uniprot  }"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bc.to_df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This again creates a single DataFrame, now for both protein types, but now including\n",
+    "both input streams (you should note both uniprot & entrez style IDs in the id column). However, we are generating our `entrez`\n",
+    "proteins as having entrez IDs, which could result in problems in querying.\n",
+    "Additionally, a strict import mode including regex pattern matching of\n",
+    "identifiers will fail at this point due to the difference in pattern of UniProt\n",
+    "vs. Entrez IDs. This issue could be resolved by mapping the Entrez IDs to\n",
+    "UniProt IDs, but we will instead use the opportunity to demonstrate how to\n",
+    "merge data from different sources into the same ontological class using *ad\n",
+    "hoc* subclasses."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### *Ad hoc* subclassing"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the previous section, we saw how to merge data from different sources into\n",
+    "the same ontological class. However, we did not resolve the issue of the\n",
+    "`entrez` proteins living in a different namespace than the `uniprot` proteins,\n",
+    "which could result in problems in querying. In proteins, it would probably be\n",
+    "more appropriate to solve this problem using identifier mapping, but in other\n",
+    "categories, e.g., pathways, this may not be possible because of a lack of\n",
+    "one-to-one mapping between different data sources. Thus, if we so desire, we\n",
+    "can merge datasets into the same ontological class by creating *ad hoc*\n",
+    "subclasses implicitly through BioCypher, by providing multiple preferred\n",
+    "identifiers. In our case, we update our schema configuration as follows:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id:\n",
+      "    - uniprot\n",
+      "    - entrez\n",
+      "    input_label:\n",
+      "    - uniprot_protein\n",
+      "    - entrez_protein\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '03_schema_config.yaml'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will \"implicitly\" create two subclasses of the `protein` class, which will\n",
+    "inherit the entire hierarchy of the `protein` class. The two subclasses will be\n",
+    "named using a combination of their preferred namespace and the name of the\n",
+    "parent class, separated by a dot, i.e., `uniprot.protein` and `entrez.protein`.\n",
+    "In this manner, they can be identified as proteins regardless of their sources\n",
+    "by any queries for the generic `protein` class, while still carrying\n",
+    "information about their namespace and avoiding identifier conflicts.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "The only change affected upon the code from the previous section is the\n",
+    "referral to the updated schema configuration file.\n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-success\">\n",
+    "In the output, we now generate two separate files for the `protein` class, one\n",
+    "for each subclass (with names in PascalCase).\n",
+    "</div>\n",
+    "\n",
+    "Let's create a DataFrame with the same data as above, but with a different schema configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
+       " 0          W3S7W3  PIRCYSWTYKRTHWCHLGPFQPWNQSACQSYDWMMHPDAHWLLGGS...   \n",
+       " 1          M1S7Y8  INLGWNGYWCSFMSYGMMSGFINMMTGLVGTPKWSMAYDVTSHDNK...   \n",
+       " 2          L5N6Q6  CEGIQIADKIGTPLTRMQQSLRSNEDDEGVKRSRPSGMSFYMDQPY...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  a h u x y y s m v d  9606  W3S7W3      uniprot  \n",
+       " 1  h c c v t f p x s b  9606  M1S7Y8      uniprot  \n",
+       " 2  y g q y c b g v c s  9606  L5N6Q6      uniprot  ,\n",
+       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
+       " 0          77184  TIRGYHPDVANGDVWCKPSCYTGSFDVGPWCQNSPTLEQSRNIDWF...   \n",
+       " 1         702688  YHMEPQDTACCKFHAYIDGNGFVVMHCDNPTKTASSANQVVTWNYW...   \n",
+       " 2         904881  FAYTWDQMMEIAYFMLSTMMYNFVSHWHFLCQTYRVIPCARSAAQQ...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  f w c l k b y l i l  9606   77184       entrez  \n",
+       " 1  k n p q i z a y e y  9606  702688       entrez  \n",
+       " 2  z y u x g t q b p j  9606  904881       entrez  }"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '03_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '03_schema_config.yaml'),\n",
+    ")\n",
+    "bc.add(node_generator(proteins))\n",
+    "bc.to_df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we see two separate DaTaFrames, one for each subclass of the `protein` class."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 3: Handling properties\n",
+    "While ID and label are mandatory components of our knowledge graph, properties\n",
+    "are optional and can include different types of information on the entities. In\n",
+    "source data, properties are represented in arbitrary ways, and designations\n",
+    "rarely overlap even for the most trivial of cases (spelling differences,\n",
+    "formatting, etc). Additionally, some data sources contain a large wealth of\n",
+    "information about entities, most of which may not be needed for the given task.\n",
+    "Thus, it is often desirable to filter out properties that are not needed to\n",
+    "save time, disk space, and memory.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Maintaining consistent properties per entity type is particularly important\n",
+    "when using the admin import feature of Neo4j, which requires consistency\n",
+    "between the header and data files. Properties that are introduced into only\n",
+    "some of the rows will lead to column misalignment and import failure. In\n",
+    "\"online mode\", this is not an issue.\n",
+    "\n",
+    "</div>\n",
+    "\n",
+    "We will take a look at how to handle property selection in BioCypher in a\n",
+    "way that is flexible and easy to maintain."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Designated properties\n",
+    "\n",
+    "The simplest and most straightforward way to ensure that properties are\n",
+    "consistent for each entity type is to designate them explicitly in the schema\n",
+    "configuration. This is done by adding a `properties` key to the entity type\n",
+    "configuration. The value of this key is another dictionary, where in the\n",
+    "standard case the keys are the names of the properties that the entity type\n",
+    "should possess, and the values give the type of the property. Possible values\n",
+    "are:\n",
+    "\n",
+    "- `str` (or `string`),\n",
+    "\n",
+    "- `int` (or `integer`, `long`),\n",
+    "\n",
+    "- `float` (or `double`, `dbl`),\n",
+    "\n",
+    "- `bool` (or `boolean`),\n",
+    "\n",
+    "- arrays of any of these types (indicated by square brackets, e.g. `string[]`).\n",
+    "\n",
+    "In the case of properties that are not present in (some of) the source data,\n",
+    "BioCypher will add them to the output with a default value of `None`.\n",
+    "Additional properties in the input that are not represented in these designated\n",
+    "property names will be ignored. Let's imagine that some, but not all, of our\n",
+    "protein nodes have a `mass` value. If we want to include the mass value on all\n",
+    "proteins, we can add the following to our schema configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id:\n",
+      "    - uniprot\n",
+      "    - entrez\n",
+      "    input_label:\n",
+      "    - uniprot_protein\n",
+      "    - entrez_protein\n",
+      "    properties:\n",
+      "        sequence: str\n",
+      "        description: str\n",
+      "        taxon: str\n",
+      "        mass: int\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '04_schema_config.yaml'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will add the `mass` property to all proteins (in addition to the three we\n",
+    "had before); if not encountered, the column will be empty. Implicit subclasses\n",
+    "will automatically inherit the property configuration; in this case, both\n",
+    "`uniprot.protein` and `entrez.protein` will have the `mass` property, even\n",
+    "though the `entrez` proteins do not have a `mass` value in the input data.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "If we wanted to ignore the mass value for all properties, we could simply\n",
+    "remove the `mass` key from the `properties` dictionary.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_generator import EntrezProtein, RandomPropertyProtein"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
+       " 0          A3B0D2  PNQQGCSGCGNADSLFWAYYSKFICDWEHKMTKEIMEGHIEEYKPE...   \n",
+       " 1          R4T7H1  FSKPDNGTILKPFKYWEMRKGPHDIARCGSDVFAKCFMRISVTEHI...   \n",
+       " 2          M6F5M0  FIEECEWVMVKWSFPKMFKDCWNGMRIGQTQSEHCWWFFESALSFV...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  s w k i j b q u q f  8174  None  A3B0D2      uniprot  \n",
+       " 1  z w c a h f v f b v  8213  None  R4T7H1      uniprot  \n",
+       " 2  w w f d d v s n x i  8077  None  M6F5M0      uniprot  ,\n",
+       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
+       " 0          32539  TDVFSDVNNKGTRVKVMSFFPNADYYGNTHENMECWWGPRPIYGSI...   \n",
+       " 1          73002  MKLFRGYFRNFYKRIIFERYEDNPLNCQMQLFRQVIMYMRNWLIMW...   \n",
+       " 2         719470  CPRFCMETYHQRCNCLLKQFYWEWVFMWIDEPSKSGGITTFNIRII...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  u k i v q y n h e k  9606  None   32539       entrez  \n",
+       " 1  h f u j w k y s t l  9606  None   73002       entrez  \n",
+       " 2  w f m x p h w y l m  9606  None  719470       entrez  }"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create a list of proteins to be imported (now with properties)\n",
+    "proteins = [\n",
+    "    p for sublist in zip(\n",
+    "        [RandomPropertyProtein() for _ in range(n_proteins)],\n",
+    "        [EntrezProtein() for _ in range(n_proteins)],\n",
+    "    ) for p in sublist\n",
+    "]\n",
+    "# New instance, populated, and to DataFrame\n",
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '04_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '04_schema_config.yaml'),\n",
+    ")\n",
+    "bc.add(node_generator(proteins))\n",
+    "bc.to_df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inheriting properties\n",
+    "Sometimes, explicit designation of properties requires a lot of maintenance\n",
+    "work, particularly for classes with many properties. In these cases, it may be\n",
+    "more convenient to inherit properties from a parent class. This is done by\n",
+    "adding a `properties` key to a suitable parent class configuration, and then\n",
+    "defining inheritance via the `is_a` key in the child class configuration and\n",
+    "setting the `inherit_properties` key to `true`.\n",
+    "\n",
+    "Let's say we have an additional `protein isoform` class, which can reasonably\n",
+    "inherit from `protein` and should carry the same properties as the parent. We\n",
+    "can add the following to our schema configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_generator import RandomPropertyProteinIsoform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id:\n",
+      "    - uniprot\n",
+      "    - entrez\n",
+      "    input_label:\n",
+      "    - uniprot_protein\n",
+      "    - entrez_protein\n",
+      "    properties:\n",
+      "        sequence: str\n",
+      "        description: str\n",
+      "        taxon: str\n",
+      "        mass: int\n",
+      "protein isoform:\n",
+      "    is_a: protein\n",
+      "    inherit_properties: true\n",
+      "    represented_as: node\n",
+      "    preferred_id: uniprot\n",
+      "    input_label: uniprot_isoform\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '05_schema_config.yaml'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows maintenance of property lists for many classes at once. If the child\n",
+    "class has properties already, they will be kept (if they are not present in the\n",
+    "parent class) or replaced by the parent class properties (if they are present).\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "Again, apart from adding the protein isoforms to the input stream, the code\n",
+    "for this example is identical to the previous one except for the reference to\n",
+    "the updated schema configuration.\n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-success\">\n",
+    "We now create three separate DataFrame, all of which are children of the\n",
+    "`protein` class; two implicit children (`uniprot.protein` and `entrez.protein`)\n",
+    "and one explicit child (`protein isoform`).\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "uniprot.protein\n",
+      "  uniprot.protein                                           sequence  \\\n",
+      "0          S4N9S9  LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVA...   \n",
+      "1          D3W1B3  TTHPLTMKNAHPWFKCNFIQRASYTVRGLFFHCNHTRRRHHNFMDF...   \n",
+      "2          V9H4Q3  KQIILTVSYHLFITENPIDYEGNVVMNTPTWFLGQHRCQVKDPHSY...   \n",
+      "\n",
+      "           description taxon  mass      id preferred_id  \n",
+      "0  v m i r i t g i r m  2834  None  S4N9S9      uniprot  \n",
+      "1  s r i k z z n i a n  9079  6966  D3W1B3      uniprot  \n",
+      "2  x n n b p w e p d h  7976  None  V9H4Q3      uniprot  \n",
+      "protein isoform\n",
+      "  protein isoform                                           sequence  \\\n",
+      "0          M9E8U2  PLTKQWENFRAENSWPGLKKQCEIEQWHPSKIRHVWEKNKWLCCNL...   \n",
+      "1          X9A9O5  SLRHCCQSAAWKNKSKMDLLCTAHVPMVWIVGCNQKRFKKTWKQRL...   \n",
+      "2          O8Q8I0  KNFAKSTMMFQQRPKGVNWFDWFNEPQHNTDDSQVQKCIMIGVQHY...   \n",
+      "\n",
+      "           description taxon  mass      id preferred_id  \n",
+      "0  l f v b q n g e v p  2798  None  M9E8U2      uniprot  \n",
+      "1  z w c m m m z c x s  7119  1728  X9A9O5      uniprot  \n",
+      "2  o x c p u w f n b v  6206  None  O8Q8I0      uniprot  \n",
+      "entrez.protein\n",
+      "  entrez.protein                                           sequence  \\\n",
+      "0         254811  KIYSKKLGAGMLIEHYRNELTSFGCQCTGCTRQFLFKFLAHPLTWA...   \n",
+      "1         942300  MFGNWLNWDKGEYVYYRNPEMRKGSHCRLFIDQYQCKLRLANHSLE...   \n",
+      "2         267767  IMVRQQESQHMSVWYNTTTKFVIHMHHHVDESNMPFDLRSNFKDFE...   \n",
+      "\n",
+      "           description taxon  mass      id preferred_id  \n",
+      "0  g h t i x d d g f j  9606  None  254811       entrez  \n",
+      "1  h q d j q n n j z b  9606  None  942300       entrez  \n",
+      "2  w c g l y d s v y y  9606  None  267767       entrez  \n"
+     ]
+    }
+   ],
+   "source": [
+    "# create a list of proteins to be imported\n",
+    "proteins = [\n",
+    "    p for sublist in zip(\n",
+    "        [RandomPropertyProtein() for _ in range(n_proteins)],\n",
+    "        [RandomPropertyProteinIsoform() for _ in range(n_proteins)],\n",
+    "        [EntrezProtein() for _ in range(n_proteins)],\n",
+    "    ) for p in sublist\n",
+    "]\n",
+    "\n",
+    "# Create BioCypher driver\n",
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '05_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '05_schema_config.yaml'),\n",
+    ")\n",
+    "# Run the import\n",
+    "bc.add(node_generator(proteins))\n",
+    "\n",
+    "for name, df in bc.to_df().items():\n",
+    "    print(name)\n",
+    "    print(df)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Section 4: Handling relationships\n",
+    "\n",
+    "Naturally, we do not only want nodes in our knowledge graph, but also edges. In\n",
+    "BioCypher, the configuration of relationships is very similar to that of nodes,\n",
+    "with some key differences. First the similarities: the top-level class\n",
+    "configuration of edges is the same; class names refer to ontological classes or\n",
+    "are an extension thereof. Similarly, the `is_a` key is used to define\n",
+    "inheritance, and the `inherit_properties` key is used to inherit properties from\n",
+    "a parent class. Relationships also possess a `preferred_id` key, an\n",
+    "`input_label` key, and a `properties` key, which work in the same way as for\n",
+    "nodes.\n",
+    "\n",
+    "Relationships also have a `represented_as` key, which in this case can be\n",
+    "either `node` or `edge`. The `node` option is used to \"reify\" the relationship\n",
+    "in order to be able to connect it to other nodes in the graph. In addition to\n",
+    "the configuration of nodes, relationships also have fields for the `source` and\n",
+    "`target` node types, which refer to the ontological classes of the respective\n",
+    "nodes, and are currently optional.\n",
+    "\n",
+    "To add protein-protein interactions to our graph, we can modify the schema configuration above to the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------------\n",
+      "protein:\n",
+      "    represented_as: node\n",
+      "    preferred_id:\n",
+      "    - uniprot\n",
+      "    - entrez\n",
+      "    input_label:\n",
+      "    - uniprot_protein\n",
+      "    - entrez_protein\n",
+      "    properties:\n",
+      "        sequence: str\n",
+      "        description: str\n",
+      "        taxon: str\n",
+      "        mass: int\n",
+      "protein isoform:\n",
+      "    is_a: protein\n",
+      "    inherit_properties: true\n",
+      "    represented_as: node\n",
+      "    preferred_id: uniprot\n",
+      "    input_label: uniprot_isoform\n",
+      "protein protein interaction:\n",
+      "    is_a: pairwise molecular interaction\n",
+      "    represented_as: edge\n",
+      "    preferred_id: intact\n",
+      "    input_label: interacts_with\n",
+      "    properties:\n",
+      "        method: str\n",
+      "        source: str\n",
+      "\n",
+      "--------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_yaml(join(schema_path, '06_schema_config_pandas.yaml'))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have added `protein protein interaction` as an edge, we have to simulate some interactions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_generator import InteractionGenerator\n",
+    "\n",
+    "# Simulate edges for proteins we defined above\n",
+    "ppi = InteractionGenerator(\n",
+    "    interactors=[p.get_id() for p in proteins],\n",
+    "    interaction_probability=0.05,\n",
+    ").generate_interactions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'S4N9S9 interacts_with O8Q8I0'"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# naturally interactions contain information about the interacting source and target\n",
+    "# let's look at the first one in the list\n",
+    "interaction = ppi[0]\n",
+    "f\"{interaction.get_source_id()} {interaction.label} {interaction.get_target_id()}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'source': 'signor'}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# similarly to notes, it also has a dictionary of properties\n",
+    "interaction.get_properties()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with nodes, we add first createa a new BioCypher instance, and then populate it with nodes as well as edges:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '06_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '06_schema_config_pandas.yaml'),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Extract id, source, target, label, and property dictionary\n",
+    "def edge_generator(ppi):\n",
+    "    for interaction in ppi:\n",
+    "        yield (\n",
+    "            interaction.get_id(),\n",
+    "            interaction.get_source_id(),\n",
+    "            interaction.get_target_id(),\n",
+    "            interaction.get_label(),\n",
+    "            interaction.get_properties(),\n",
+    "        )\n",
+    "\n",
+    "bc.add(node_generator(proteins))\n",
+    "bc.add(edge_generator(ppi))\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at both both:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
+       " 0          S4N9S9  LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVA...   \n",
+       " 1          D3W1B3  TTHPLTMKNAHPWFKCNFIQRASYTVRGLFFHCNHTRRRHHNFMDF...   \n",
+       " 2          V9H4Q3  KQIILTVSYHLFITENPIDYEGNVVMNTPTWFLGQHRCQVKDPHSY...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  v m i r i t g i r m  2834  None  S4N9S9      uniprot  \n",
+       " 1  s r i k z z n i a n  9079  6966  D3W1B3      uniprot  \n",
+       " 2  x n n b p w e p d h  7976  None  V9H4Q3      uniprot  ,\n",
+       " 'protein isoform':   protein isoform                                           sequence  \\\n",
+       " 0          M9E8U2  PLTKQWENFRAENSWPGLKKQCEIEQWHPSKIRHVWEKNKWLCCNL...   \n",
+       " 1          X9A9O5  SLRHCCQSAAWKNKSKMDLLCTAHVPMVWIVGCNQKRFKKTWKQRL...   \n",
+       " 2          O8Q8I0  KNFAKSTMMFQQRPKGVNWFDWFNEPQHNTDDSQVQKCIMIGVQHY...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  l f v b q n g e v p  2798  None  M9E8U2      uniprot  \n",
+       " 1  z w c m m m z c x s  7119  1728  X9A9O5      uniprot  \n",
+       " 2  o x c p u w f n b v  6206  None  O8Q8I0      uniprot  ,\n",
+       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
+       " 0         254811  KIYSKKLGAGMLIEHYRNELTSFGCQCTGCTRQFLFKFLAHPLTWA...   \n",
+       " 1         942300  MFGNWLNWDKGEYVYYRNPEMRKGSHCRLFIDQYQCKLRLANHSLE...   \n",
+       " 2         267767  IMVRQQESQHMSVWYNTTTKFVIHMHHHVDESNMPFDLRSNFKDFE...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  g h t i x d d g f j  9606  None  254811       entrez  \n",
+       " 1  h q d j q n n j z b  9606  None  942300       entrez  \n",
+       " 2  w c g l y d s v y y  9606  None  267767       entrez  ,\n",
+       " 'protein protein interaction':   protein protein interaction   _from     _to  source method\n",
+       " 0                        None  S4N9S9  O8Q8I0  signor   None\n",
+       " 1                intact404645  V9H4Q3  M9E8U2  signor   None\n",
+       " 2                        None  O8Q8I0  254811    None   None\n",
+       " 3                        None  267767  D3W1B3  intact   None}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bc.to_df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, it is worth noting that BioCypher relies on ontologies, which are machine readable representations of domains of knowledge that we use to ground the contents of our knowledge graphs. While details about ontologies are out of scope for this tutorial, and are described in detail in the [BioCypher documentation](https://biocypher.org/tutorial-ontology.html), we can still have a glimpse at the ontology that we used implicitly in this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Showing ontology structure based on https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl\n",
+      "entity\n",
+      "├── association\n",
+      "│   └── gene to gene association\n",
+      "│       └── pairwise gene to gene interaction\n",
+      "│           └── pairwise molecular interaction\n",
+      "│               └── protein protein interaction\n",
+      "└── named thing\n",
+      "    └── biological entity\n",
+      "        └── polypeptide\n",
+      "            └── protein\n",
+      "                ├── entrez.protein\n",
+      "                ├── protein isoform\n",
+      "                └── uniprot.protein\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<treelib.tree.Tree at 0x7f63db8db730>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bc.show_ontology_structure()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### To keep or Remove"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-success\">\n",
+    "BioCypher provides feedback about property conflicts; try running the code\n",
+    "for this example (`04__properties.py`) with the schema configuration of the\n",
+    "previous section (`03_schema_config.yaml`) and see what happens.\n",
+    "</div>\n",
+    "\n",
+    "@slobentanzer - nothing drastic happens haha (I guess it's expected that we don't have mass? :D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'sequence': 'LLGFVDQNKCGRAMNQVPHQCGSLRDMQMVGYGHDRNHPFILAHVAYNVEQIFTVYVTICMVIRYCGFICRQYNIPYSIKLHMDECHHGLKITVEDPGTHHKDHVFRFLTLKSTIEMNLLWLCKLQELIAIAGVEDCEGFITNKVWQILVSPSSYPMGGDPPGVGVSALPMFTHVGAERTCCDQFYCNYCHYPIFAMICNTMNCLANMCM',\n",
+       " 'description': 'v m i r i t g i r m',\n",
+       " 'taxon': '2834'}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proteins[0].get_properties()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO -- Loading ontologies...\n",
+      "INFO -- Instantiating OntologyAdapter class for https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
+       " 0          A6E1Z1  NNVKFGGTSPMKQLRQQTLQEGMGRGIMMLHSWAEIQFWTCYYNRG...   \n",
+       " 1          N3G9S4  HVWGTAGMKYGHYYIMMSHGMLACCCVAMARVLGLSWRTDGCQFYV...   \n",
+       " 2          O8S7W5  MQYKYPICMLSMAMRDHCKAAVHCGNFFGAASNMHVIFVYLIDHRG...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  g b n b f k f a s i  7899  8243  A6E1Z1      uniprot  \n",
+       " 1  f n a t s o x j j q   691  None  N3G9S4      uniprot  \n",
+       " 2  j i a y k q m j e w  7847  None  O8S7W5      uniprot  ,\n",
+       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
+       " 0         629106  VMADTHMFNSMRASLYCQPITFCPDWFNAHCTDGRGETRHPDMELP...   \n",
+       " 1         518879  EENRDACNHNCFEENICPCKCFDFVKMTDKARCQTQPPKYRALRYR...   \n",
+       " 2         123815  MWHKRTYWNCSKMWTDFIDFIWDKEQSSDLAQAGNSDNNCGSGMYM...   \n",
+       " \n",
+       "            description taxon      id preferred_id  \n",
+       " 0  j g o i c g v i e f  9606  629106       entrez  \n",
+       " 1  k x m x a d v g s y  9606  518879       entrez  \n",
+       " 2  f x l j q q h b l o  9606  123815       entrez  }"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "proteins = [\n",
+    "    p for sublist in zip(\n",
+    "        [RandomPropertyProtein() for _ in range(n_proteins)],\n",
+    "        [EntrezProtein() for _ in range(n_proteins)],\n",
+    "    ) for p in sublist\n",
+    "]\n",
+    "\n",
+    "bc = BioCypher(\n",
+    "    biocypher_config_path=join(schema_path, '03_biocypher_config.yaml'),\n",
+    "    schema_config_path=join(schema_path, '03_schema_config.yaml'),\n",
+    ")\n",
+    "bc.add(node_generator(proteins))\n",
+    "bc.to_df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "biocypher-Ca5VQ1YT-py3.9",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "2ff371c403bc11abbc3c8e1391dba3b01886d66becfc523eea8e3dc677d5b98e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorial/08_basics_pandas.ipynb
+++ b/tutorial/08_basics_pandas.ipynb
@@ -1402,7 +1402,9 @@
     "previous section (`03_schema_config.yaml`) and see what happens.\n",
     "</div>\n",
     "\n",
-    "@slobentanzer - nothing drastic happens haha (I guess it's expected that we don't have mass? :D)"
+    "@slobentanzer - nothing drastic happens haha (I guess it's expected that we don't have mass? :D)\n",
+    "\n",
+    "@dbdimitrov - yes; this is important in the batch import setting where we need to adhere to a fixed number of columns, which does not apply to Pandas DataFrames. Not sure ATM whether we should implement a warning for this case or just ignore it."
    ]
   },
   {
@@ -1429,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1444,26 +1446,26 @@
      "data": {
       "text/plain": [
        "{'uniprot.protein':   node_id       node_label                                           sequence   \n",
-       " 0  R5E6J1  uniprot.protein  WTSNHIYTVPYHFLHHYVFFFKFQICIKFMIFLVPGYPHQEWLYCD...  \\\n",
-       " 1  J2N1M0  uniprot.protein  WHDEHQTWEFVSMGAAYPCRFSENVGYFCAIAIIDDLRQHRCCTSW...   \n",
-       " 2  U8K1R6  uniprot.protein  DTASYNTMAGYFWQHRKDPNSRIFSCKLIARSVYQHFALTMYMDPM...   \n",
+       " 0  M2F0O5  uniprot.protein  MQMWILHILSGWLNIIQFLVNNCMMKQLTEMCTIDQQDRARSTLNL...  \\\n",
+       " 1  E8G3H2  uniprot.protein  HDRLATDQDMKLWLGTHQAPENYFLGQMLILCQIYVQHIDRPASTW...   \n",
+       " 2  T5C4X8  uniprot.protein  QYHYNGCKMDDIDTFGWHQRYRSHWHIGVIRKIHITAHRTCSCGWW...   \n",
        " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  p k q i g q r u x t   964  2163  R5E6J1      uniprot  \n",
-       " 1  u b r e v i i c j q  4258  9531  J2N1M0      uniprot  \n",
-       " 2  o f c m z a n y y p   328  7519  U8K1R6      uniprot  ,\n",
+       "            description taxon      id preferred_id    mass  \n",
+       " 0  s g y y i v z c u l  7385  M2F0O5      uniprot     NaN  \n",
+       " 1  n x i f n v g k s e  3477  E8G3H2      uniprot  7440.0  \n",
+       " 2  p s h x s o u q y i   941  T5C4X8      uniprot  6147.0  ,\n",
        " 'entrez.protein':   node_id      node_label                                           sequence   \n",
-       " 0  573426  entrez.protein  NKKADRWISWHQYPRPHIHEIFKFQMHHQLATEYFTWEVLHHMPGL...  \\\n",
-       " 1  865711  entrez.protein  VDMPKRFVFRHDEGWMPANWRPFVPLYMESSYPVRYCTKGPRAEMY...   \n",
-       " 2  639349  entrez.protein  HHPTSLRHFTFYSNQFYTFWHEGFTEEKEDQKGFYLKSGRATKYSW...   \n",
+       " 0  159171  entrez.protein  SSRPYRHQVRLCQLKSSLLLCPCWFLEFIDLNTKTSRSTPQQQHFP...  \\\n",
+       " 1  285933  entrez.protein  DIINFTMVFYMKKIVFPNFWGTPDSPLMRCFYRDWLAIAECLMLCW...   \n",
+       " 2  827912  entrez.protein  PTFHHFQSYSQCISDSNMFHLPLRKKYCCEPMPDGCDNIIPKQINF...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  t s q p e q e w e g  9606  573426       entrez  \n",
-       " 1  x h s y z w r y k x  9606  865711       entrez  \n",
-       " 2  s z c g x b d g k a  9606  639349       entrez  }"
+       " 0  o l j n w x t x a s  9606  159171       entrez  \n",
+       " 1  s n o v y a t n f d  9606  285933       entrez  \n",
+       " 2  v e j y l c y p b d  9606  827912       entrez  }"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/tutorial/08_basics_pandas.ipynb
+++ b/tutorial/08_basics_pandas.ipynb
@@ -25,8 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While BioCypher was designed as a graph-focused framework, due to the commonality of RDBMS and tabular data, BioCypher also supports pandas DataFrame(s).\n",
-    "(@slobentanzer  should we add something like this? I also show the ontologies in the end just to make it clear that pandas/2D is not the only focus of BioCypher)\n"
+    "While BioCypher was designed as a graph-focused framework, due to commonalities in bioinformatics workflows, BioCypher also supports Pandas DataFrames. This allows integration with methods that use tabular data, such as machine learning and statistical analysis, for instance in the [scVerse framework](https://scverse.org)."
    ]
   },
   {
@@ -261,8 +260,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO -- This is BioCypher v0.5.12.\n",
-      "INFO -- Logging into `biocypher-log/biocypher-20230525-211509.log`.\n"
+      "INFO -- This is BioCypher v0.5.15.\n",
+      "INFO -- Logging into `biocypher-log/biocypher-20230531-143205.log`.\n"
      ]
     }
    ],
@@ -390,15 +389,15 @@
     {
      "data": {
       "text/plain": [
-       "{'protein':   protein                                           sequence  \\\n",
-       " 0  T5F5P2  MLIINVAYNCWWTGEYAVDMSPQVYKSDVRKGMSNKEWRLGIHSQP...   \n",
-       " 1  H9Y5M8  ECEMKHVGLCQDTKEQNKNGNWVRMREFDVIRVHAWYNKHSPYEML...   \n",
-       " 2  R7S2P8  RYVYTFRFELTPPFEYTRGELGPWWGKIRGNHDHFLANKFNACGHL...   \n",
+       "{'protein':   node_id node_label                                           sequence   \n",
+       " 0  B9H6B4    protein  WIPLVMQNEATFYLDRRHSYMIVRVNDGFWPTFNFVHADYDMIWVM...  \\\n",
+       " 1  F2T4J1    protein  DFDNHIQDLMLHHSMRRISEPHFELVKSNINLGLLQHPPGWFEYEC...   \n",
+       " 2  G6B5W0    protein  LTIYDIIFFEWPHCMEQVHYQLSTWLKIQIPQVWRCAYQWDPANFR...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  f o g v u g x m l r  9606  T5F5P2      uniprot  \n",
-       " 1  m t r l m p f s t m  9606  H9Y5M8      uniprot  \n",
-       " 2  b a i t y s e p o s  9606  R7S2P8      uniprot  }"
+       " 0  f f o r u x r n l u  9606  B9H6B4      uniprot  \n",
+       " 1  t o z u t s f s p u  9606  F2T4J1      uniprot  \n",
+       " 2  e r s w h w x h i l  9606  G6B5W0      uniprot  }"
       ]
      },
      "execution_count": 7,
@@ -501,21 +500,21 @@
     {
      "data": {
       "text/plain": [
-       "{'protein':   protein                                           sequence  \\\n",
-       " 0  U2H3B8  MHQRMELYWFDCTYILLHSERQGYQHPLMSRSWLEQQPFHDFPEHW...   \n",
-       " 1  940533  CQPDQHIMDCGKGDNNTYACANTLWEDTCWLPLLTKQSRMLWPEDY...   \n",
-       " 2  G0Q4P4  WFMIWGCDNWELIEPWAGSEDPVIMNGHMGQCYQQILQQITTEKQC...   \n",
-       " 3   53444  STDDVCMFDINHIEKATHADYLVRHYRRYWHSDCLWENFMAHVWPT...   \n",
-       " 4  Y7F5E2  PMEITVRGNHIKPISTGMKDSEDHYQFCLDVERHFRGKMEIDPKVT...   \n",
-       " 5  724996  HEVQEDRWRVTNMQYPVAVCLFSIRMAHQYENVLNDMMNDHKQPHF...   \n",
+       "{'protein':   node_id node_label                                           sequence   \n",
+       " 0  I3F2Z9    protein  REHLAWIVSPQCFRERSMCNTYCHHSHLLLRTKPMVDIVEPMACCG...  \\\n",
+       " 1  190794    protein  REPMQAKWMPGYFAYRITILLKSNQMVWSVYMPMHAKWSHEHWLWS...   \n",
+       " 2  G6M3X6    protein  EICYKSPTYFMMRASTAPWAAVDCEEATEGNRWHVPDLGNPGDIGH...   \n",
+       " 3  834464    protein  WCNRTALLTHSGSAYGENCKFQAHKRTRETGKGTHDLIWDRYDYEF...   \n",
+       " 4  E0L5X8    protein  VFFLFGTTMSVCPCDELQMPICDSVIADIFNMCSDEQFQWPWEEQI...   \n",
+       " 5  360805    protein  QRMHIYDLGNIDMPGPCKCMVKDWPSGIDCKNFGTQFHVVKPGEII...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  n t b j e v b v u z  9606  U2H3B8      uniprot  \n",
-       " 1  e i w y h f g i t b  9606  940533      uniprot  \n",
-       " 2  v q p i a d x n x c  9606  G0Q4P4      uniprot  \n",
-       " 3  j f g i a g i m m x  9606   53444      uniprot  \n",
-       " 4  x e b j g c b n s n  9606  Y7F5E2      uniprot  \n",
-       " 5  m c j h h q u q p u  9606  724996      uniprot  }"
+       " 0  v l q z t h w q c x  9606  I3F2Z9      uniprot  \n",
+       " 1  t m f w e z q r m l  9606  190794      uniprot  \n",
+       " 2  h q p i z u a w o t  9606  G6M3X6      uniprot  \n",
+       " 3  h g k u m p p i v b  9606  834464      uniprot  \n",
+       " 4  q l u d k s q p v l  9606  E0L5X8      uniprot  \n",
+       " 5  y i j o l b a c m f  9606  360805      uniprot  }"
       ]
      },
      "execution_count": 11,
@@ -637,24 +636,24 @@
     {
      "data": {
       "text/plain": [
-       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          U2H3B8  MHQRMELYWFDCTYILLHSERQGYQHPLMSRSWLEQQPFHDFPEHW...   \n",
-       " 1          G0Q4P4  WFMIWGCDNWELIEPWAGSEDPVIMNGHMGQCYQQILQQITTEKQC...   \n",
-       " 2          Y7F5E2  PMEITVRGNHIKPISTGMKDSEDHYQFCLDVERHFRGKMEIDPKVT...   \n",
+       "{'uniprot.protein':   node_id       node_label                                           sequence   \n",
+       " 0  I3F2Z9  uniprot.protein  REHLAWIVSPQCFRERSMCNTYCHHSHLLLRTKPMVDIVEPMACCG...  \\\n",
+       " 1  G6M3X6  uniprot.protein  EICYKSPTYFMMRASTAPWAAVDCEEATEGNRWHVPDLGNPGDIGH...   \n",
+       " 2  E0L5X8  uniprot.protein  VFFLFGTTMSVCPCDELQMPICDSVIADIFNMCSDEQFQWPWEEQI...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  n t b j e v b v u z  9606  U2H3B8      uniprot  \n",
-       " 1  v q p i a d x n x c  9606  G0Q4P4      uniprot  \n",
-       " 2  x e b j g c b n s n  9606  Y7F5E2      uniprot  ,\n",
-       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         940533  CQPDQHIMDCGKGDNNTYACANTLWEDTCWLPLLTKQSRMLWPEDY...   \n",
-       " 1          53444  STDDVCMFDINHIEKATHADYLVRHYRRYWHSDCLWENFMAHVWPT...   \n",
-       " 2         724996  HEVQEDRWRVTNMQYPVAVCLFSIRMAHQYENVLNDMMNDHKQPHF...   \n",
+       " 0  v l q z t h w q c x  9606  I3F2Z9      uniprot  \n",
+       " 1  h q p i z u a w o t  9606  G6M3X6      uniprot  \n",
+       " 2  q l u d k s q p v l  9606  E0L5X8      uniprot  ,\n",
+       " 'entrez.protein':   node_id      node_label                                           sequence   \n",
+       " 0  190794  entrez.protein  REPMQAKWMPGYFAYRITILLKSNQMVWSVYMPMHAKWSHEHWLWS...  \\\n",
+       " 1  834464  entrez.protein  WCNRTALLTHSGSAYGENCKFQAHKRTRETGKGTHDLIWDRYDYEF...   \n",
+       " 2  360805  entrez.protein  QRMHIYDLGNIDMPGPCKCMVKDWPSGIDCKNFGTQFHVVKPGEII...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  e i w y h f g i t b  9606  940533       entrez  \n",
-       " 1  j f g i a g i m m x  9606   53444       entrez  \n",
-       " 2  m c j h h q u q p u  9606  724996       entrez  }"
+       " 0  t m f w e z q r m l  9606  190794       entrez  \n",
+       " 1  h g k u m p p i v b  9606  834464       entrez  \n",
+       " 2  y i j o l b a c m f  9606  360805       entrez  }"
       ]
      },
      "execution_count": 13,
@@ -676,7 +675,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we see two separate DaTaFrames, one for each subclass of the `protein` class."
+    "Now we see two separate DataFrames, one for each subclass of the `protein` class."
    ]
   },
   {
@@ -815,24 +814,24 @@
     {
      "data": {
       "text/plain": [
-       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          D5G5I7  TNHLWSRNLDHAWMMDWEATMMAENWFQINNCFHDLSYEDGTTTRA...   \n",
-       " 1          X2P1S4  NWWISLGAFASDGSELRTHGGEGGLQKCKCCQNTREPTSSEHRMDA...   \n",
-       " 2          T2U8I9  QWLAQMTQGSHNCDADKHHDTWPATPTIMDWALDATIDNPPKTHQG...   \n",
+       "{'uniprot.protein':   node_id       node_label                                           sequence   \n",
+       " 0  T4G5C9  uniprot.protein  LQKEYAALFWQPRAFYPYLIKSFLDEAKRDCFWMMIFPVKSWWHHQ...  \\\n",
+       " 1  W5O6Z3  uniprot.protein  SNNQCAIATWAVSFWMSSGAFSLLSMDFCTHENHFGVTRFGDWKEH...   \n",
+       " 2  U5W6F4  uniprot.protein  SYKECEYWEKSGNIFNTMREREWNFCKKLKMQIFKCIWWLNGNKWI...   \n",
+       " \n",
+       "            description taxon    mass      id preferred_id  \n",
+       " 0  f m l t b y w t b i  9138  7018.0  T4G5C9      uniprot  \n",
+       " 1  a p d z o i w u g r  4555  3025.0  W5O6Z3      uniprot  \n",
+       " 2  m g r l w m d d g a  6432     NaN  U5W6F4      uniprot  ,\n",
+       " 'entrez.protein':   node_id      node_label                                           sequence   \n",
+       " 0   75149  entrez.protein  LSCQTWVPFKQPIFNICHIASAPENQQHGCVVGTHPMDKSRTHLEI...  \\\n",
+       " 1  376243  entrez.protein  FSMMCWDLQHWDCRAQRCWKEKKIDSIDSVKRCQFLCDLIREEIPT...   \n",
+       " 2  120953  entrez.protein  TALWMVIRSYFQACYTWHYIRFRNWVFGSWYRMEHIDDDMKFCKEA...   \n",
        " \n",
        "            description taxon  mass      id preferred_id  \n",
-       " 0  u x a h k w b q i a  5603  None  D5G5I7      uniprot  \n",
-       " 1  j d y t e u d r u i  8980  None  X2P1S4      uniprot  \n",
-       " 2  j j e c c e n g o b  6504  1634  T2U8I9      uniprot  ,\n",
-       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         440496  GCKFMLLLEKREGKSGYCDRYHRPAAEGTGCPMVHLNSPDDHINRG...   \n",
-       " 1         539695  PFMFYNQIIRGFLGVPYPNWMAFFTPNDYNLPPTVYWYMEGWHTME...   \n",
-       " 2         330717  TWEAKELQDYVDMMPMEPYHTAESPVYDTPYAHRCEYELLDHVESC...   \n",
-       " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  r x q v s d h t g a  9606  None  440496       entrez  \n",
-       " 1  o c e f t d q q z k  9606  None  539695       entrez  \n",
-       " 2  y u k a j z h w a l  9606  None  330717       entrez  }"
+       " 0  i y y t o u i c o w  9606  None   75149       entrez  \n",
+       " 1  j g g g u s c k f n  9606  None  376243       entrez  \n",
+       " 2  g g s k j f r i f c  9606  None  120953       entrez  }"
       ]
      },
      "execution_count": 16,
@@ -938,7 +937,7 @@
     "</div>\n",
     "\n",
     "<div class=\"alert alert-success\">\n",
-    "We now create three separate DataFrame, all of which are children of the\n",
+    "We now create three separate DataFrames, all of which are children of the\n",
     "`protein` class; two implicit children (`uniprot.protein` and `entrez.protein`)\n",
     "and one explicit child (`protein isoform`).\n",
     "</div>\n"
@@ -962,35 +961,35 @@
      "output_type": "stream",
      "text": [
       "uniprot.protein\n",
-      "  uniprot.protein                                           sequence  \\\n",
-      "0          R5B2H9  HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWIL...   \n",
-      "1          Q2I2W4  KKKVHPDGGYTLVLCKQADYRLIAIEAWAKHMFMIHFNRKPQSMER...   \n",
-      "2          G3R3Z6  ALAKGWMGTTAPGLPWSAKTAYQGRGFIEQMTGKLSWEMERAHDWA...   \n",
+      "  node_id       node_label                                           sequence   \n",
+      "0  U5Z5S0  uniprot.protein  PLWSVAKIHAEELPLLEYFVPDGSYDVPRGKMVNEFSEPEHWNVQC...  \\\n",
+      "1  B1B6J7  uniprot.protein  VMYTFYDDGQHYHMWIGADYLLMVNNQDEPEEGINWWKLPLTNQVN...   \n",
+      "2  R9B8P2  uniprot.protein  WQACQITEDLRKNYQNADRWTSQFALEPTAVQNCYRLLQPQLTQMD...   \n",
       "\n",
-      "           description taxon  mass      id preferred_id  \n",
-      "0  e e b p c e v r r u  6894  None  R5B2H9      uniprot  \n",
-      "1  a c w g x r z b r b  4760  None  Q2I2W4      uniprot  \n",
-      "2  a z o m f n a g v s   653  None  G3R3Z6      uniprot  \n",
+      "           description taxon    mass      id preferred_id  \n",
+      "0  y n d f b v j i d t  8076     NaN  U5Z5S0      uniprot  \n",
+      "1  r j j d c g l b z z  9741     NaN  B1B6J7      uniprot  \n",
+      "2  a h u h p w b x d z  7295  3887.0  R9B8P2      uniprot  \n",
       "protein isoform\n",
-      "  protein isoform                                           sequence  \\\n",
-      "0          M1U3F5  FKQTSDSTVRPQKGRHWIWANTGVESRWRQGQKFKNQYSTAYFTKW...   \n",
-      "1          F3N8I9  DSNQEKDFIIRHTKLIHDNTQWAGWDTVFFMEGDAGKCDTIEPWVH...   \n",
-      "2          Z0K9H8  RWECELLYYKHMKYQIYIVHVHKHNHRWMLTPHLYKPQYNIRDNES...   \n",
+      "  node_id       node_label                                           sequence   \n",
+      "0  H0D1M0  protein isoform  YCETYMKVVMRQYIHREESYRHEPGAKLCDTMWQIPDILPSWYEQF...  \\\n",
+      "1  X8N1C4  protein isoform  MMPIREQSGVQCWCTWKQKSTWSKIANEGRFDHYWGYRRWYVFYMS...   \n",
+      "2  Q3I2X0  protein isoform  MEPYKREGAQPAPASGVASSIWQFSNHMCVDMKGTRIQCKNTRCLA...   \n",
       "\n",
-      "           description taxon  mass      id preferred_id  \n",
-      "0  f i b j s o g d y v  2859  8185  M1U3F5      uniprot  \n",
-      "1  a f y e d n h f x d  5920  None  F3N8I9      uniprot  \n",
-      "2  s z c j m u w d d p  8833  None  Z0K9H8      uniprot  \n",
+      "           description taxon    mass      id preferred_id  \n",
+      "0  f m a c f l u r a d  4278     NaN  H0D1M0      uniprot  \n",
+      "1  c z v l z q r z q i  4830     NaN  X8N1C4      uniprot  \n",
+      "2  s m l i n n k f k x  1925  7594.0  Q3I2X0      uniprot  \n",
       "entrez.protein\n",
-      "  entrez.protein                                           sequence  \\\n",
-      "0         220796  SFELQYAGHTPLSEWADWKKCVIDMRQMVFKCMAHEVEVWLGCDWM...   \n",
-      "1         250327  LSACDWTNHSKREPDKMRVGVYGDICQKGEKAFATFRNVPDAYGWY...   \n",
-      "2         345723  PEMIDILYVITHQQPDSSHQRGGSVVSMDRGEWQQFLCDGCDVASY...   \n",
+      "  node_id      node_label                                           sequence   \n",
+      "0  503804  entrez.protein  NLNTNVYSPEPYAQKYLMDCQLVIHNLPYHLCNSPSSLVYADIFQW...  \\\n",
+      "1  103919  entrez.protein  YPHSFIFYCVSKCWWMKELMMKTLYQTTRCCRTGLQCLSQWDPFMM...   \n",
+      "2  170557  entrez.protein  RTCYFANEPITMCHPNWQWHHTCKADNAIGKNDMWTCIGYLAPDTW...   \n",
       "\n",
       "           description taxon  mass      id preferred_id  \n",
-      "0  w j a p g g r e l c  9606  None  220796       entrez  \n",
-      "1  c h t f p w r d d y  9606  None  250327       entrez  \n",
-      "2  l x x n a b w r f g  9606  None  345723       entrez  \n"
+      "0  p w z n p o x u v l  9606  None  503804       entrez  \n",
+      "1  a p o j l y j w n n  9606  None  103919       entrez  \n",
+      "2  g m s x m q q z i j  9606  None  170557       entrez  \n"
      ]
     }
    ],
@@ -1121,7 +1120,7 @@
     {
      "data": {
       "text/plain": [
-       "'Z0K9H8 interacts_with R5B2H9'"
+       "'U5Z5S0 interacts_with R9B8P2'"
       ]
      },
      "execution_count": 22,
@@ -1138,22 +1137,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'method': 'z f j w j p f t e a'}"
+       "{'source': 'signor'}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# similarly to notes, it also has a dictionary of properties\n",
+    "# similarly to nodes, it also has a dictionary of properties\n",
     "interaction.get_properties()"
    ]
   },
@@ -1167,7 +1166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,7 +1178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1212,56 +1211,127 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's look at both both:"
+    "Let's look at the interaction DataFrame:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>relationship_id</th>\n",
+       "      <th>source_id</th>\n",
+       "      <th>target_id</th>\n",
+       "      <th>relationship_label</th>\n",
+       "      <th>source</th>\n",
+       "      <th>method</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>intact867611</td>\n",
+       "      <td>U5Z5S0</td>\n",
+       "      <td>R9B8P2</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>signor</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>None</td>\n",
+       "      <td>H0D1M0</td>\n",
+       "      <td>U5Z5S0</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>None</td>\n",
+       "      <td>H0D1M0</td>\n",
+       "      <td>X8N1C4</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>intact</td>\n",
+       "      <td>x f i d j l n r u n</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>None</td>\n",
+       "      <td>H0D1M0</td>\n",
+       "      <td>R9B8P2</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>None</td>\n",
+       "      <td>y j m c u r l c x p</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>None</td>\n",
+       "      <td>X8N1C4</td>\n",
+       "      <td>103919</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>intact</td>\n",
+       "      <td>v w c m l a t q v g</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>None</td>\n",
+       "      <td>X8N1C4</td>\n",
+       "      <td>R9B8P2</td>\n",
+       "      <td>protein protein interaction</td>\n",
+       "      <td>intact</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
       "text/plain": [
-       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          R5B2H9  HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWIL...   \n",
-       " 1          Q2I2W4  KKKVHPDGGYTLVLCKQADYRLIAIEAWAKHMFMIHFNRKPQSMER...   \n",
-       " 2          G3R3Z6  ALAKGWMGTTAPGLPWSAKTAYQGRGFIEQMTGKLSWEMERAHDWA...   \n",
-       " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  e e b p c e v r r u  6894  None  R5B2H9      uniprot  \n",
-       " 1  a c w g x r z b r b  4760  None  Q2I2W4      uniprot  \n",
-       " 2  a z o m f n a g v s   653  None  G3R3Z6      uniprot  ,\n",
-       " 'protein isoform':   protein isoform                                           sequence  \\\n",
-       " 0          M1U3F5  FKQTSDSTVRPQKGRHWIWANTGVESRWRQGQKFKNQYSTAYFTKW...   \n",
-       " 1          F3N8I9  DSNQEKDFIIRHTKLIHDNTQWAGWDTVFFMEGDAGKCDTIEPWVH...   \n",
-       " 2          Z0K9H8  RWECELLYYKHMKYQIYIVHVHKHNHRWMLTPHLYKPQYNIRDNES...   \n",
-       " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  f i b j s o g d y v  2859  8185  M1U3F5      uniprot  \n",
-       " 1  a f y e d n h f x d  5920  None  F3N8I9      uniprot  \n",
-       " 2  s z c j m u w d d p  8833  None  Z0K9H8      uniprot  ,\n",
-       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         220796  SFELQYAGHTPLSEWADWKKCVIDMRQMVFKCMAHEVEVWLGCDWM...   \n",
-       " 1         250327  LSACDWTNHSKREPDKMRVGVYGDICQKGEKAFATFRNVPDAYGWY...   \n",
-       " 2         345723  PEMIDILYVITHQQPDSSHQRGGSVVSMDRGEWQQFLCDGCDVASY...   \n",
-       " \n",
-       "            description taxon  mass      id preferred_id  \n",
-       " 0  w j a p g g r e l c  9606  None  220796       entrez  \n",
-       " 1  c h t f p w r d d y  9606  None  250327       entrez  \n",
-       " 2  l x x n a b w r f g  9606  None  345723       entrez  ,\n",
-       " 'protein protein interaction':   protein protein interaction   _from     _to               method source\n",
-       " 0                        None  Z0K9H8  R5B2H9  z f j w j p f t e a   None\n",
-       " 1                        None  Z0K9H8  345723                 None   None}"
+       "  relationship_id source_id target_id           relationship_label  source   \n",
+       "0    intact867611    U5Z5S0    R9B8P2  protein protein interaction  signor  \\\n",
+       "1            None    H0D1M0    U5Z5S0  protein protein interaction    None   \n",
+       "2            None    H0D1M0    X8N1C4  protein protein interaction  intact   \n",
+       "3            None    H0D1M0    R9B8P2  protein protein interaction    None   \n",
+       "4            None    X8N1C4    103919  protein protein interaction  intact   \n",
+       "5            None    X8N1C4    R9B8P2  protein protein interaction  intact   \n",
+       "\n",
+       "                method  \n",
+       "0                 None  \n",
+       "1                 None  \n",
+       "2  x f i d j l n r u n  \n",
+       "3  y j m c u r l c x p  \n",
+       "4  v w c m l a t q v g  \n",
+       "5                 None  "
       ]
      },
-     "execution_count": 26,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "bc.to_df()"
+    "bc.to_df()[\"protein protein interaction\"]"
    ]
   },
   {
@@ -1274,7 +1344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1301,10 +1371,10 @@
     {
      "data": {
       "text/plain": [
-       "<treelib.tree.Tree at 0x7f76f03234f0>"
+       "<treelib.tree.Tree at 0x11f7fe2c0>"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1312,20 +1382,6 @@
    "source": [
     "bc.show_ontology_structure()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "attachments": {},
@@ -1351,18 +1407,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'sequence': 'HKLIPKEALMEFNPRQKFMEMCIEYRTGMIPWCFVTRNQTWGWWILYKQNFHWHFHYNDYKAPIYKSTICQCQNHNCKQILVCEFVGPMYMNETGWNYILANMHIEWQWWNRPQDKINFTQALPNRMRFFSGQFVWINTCSLATNVWMGMRTVVFCFIQDNDPPFSVLSVEDSAHVFNRNEGCQWWMVTCRNCVLKQAIRSVSDRWAREKKFDIDNKGGKAPCYNPENK',\n",
-       " 'description': 'e e b p c e v r r u',\n",
-       " 'taxon': '6894'}"
+       "{'sequence': 'PLWSVAKIHAEELPLLEYFVPDGSYDVPRGKMVNEFSEPEHWNVQCRADMYPEESIGKKYDILQMNDCMQTAFPAPIHQRCIEQHSEKKPMGLRGECFSHYMYEGTYKDIIPWQCGYDKHTLVIDIVGPGCRYTFFPWTSNFRRMGKLRKVLLPVNIKPYQRSWYNMVYDTAWGDVHGYDFIYPIWYNAMCAIDSNVYIGTHLFIMFEHMMAMKYIKRFCFLKEWFPHSLCKTKPKKDNDRNIQASVV',\n",
+       " 'description': 'y n d f b v j i d t',\n",
+       " 'taxon': '8076'}"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1373,7 +1429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -1387,41 +1443,42 @@
     {
      "data": {
       "text/plain": [
-       "{'uniprot.protein':   uniprot.protein                                           sequence  \\\n",
-       " 0          F3O7K0  QPFMMSASMMIGRAHGQIGWLKSPARHFMARQDYCPHHCAEQCFLY...   \n",
-       " 1          A2F0A6  SNCPMWYWRRMQEVEFSVTGLRWELSFQPRLMWNKLFRDFAPDIAI...   \n",
-       " 2          Z8P0Y6  LMWSVIGWALPSMYAYNRRIYGWAGRDVGWVAMENCATCERHFLCK...   \n",
+       "{'uniprot.protein':   node_id       node_label                                           sequence   \n",
+       " 0  R5E6J1  uniprot.protein  WTSNHIYTVPYHFLHHYVFFFKFQICIKFMIFLVPGYPHQEWLYCD...  \\\n",
+       " 1  J2N1M0  uniprot.protein  WHDEHQTWEFVSMGAAYPCRFSENVGYFCAIAIIDDLRQHRCCTSW...   \n",
+       " 2  U8K1R6  uniprot.protein  DTASYNTMAGYFWQHRKDPNSRIFSCKLIARSVYQHFALTMYMDPM...   \n",
+       " \n",
+       "            description taxon  mass      id preferred_id  \n",
+       " 0  p k q i g q r u x t   964  2163  R5E6J1      uniprot  \n",
+       " 1  u b r e v i i c j q  4258  9531  J2N1M0      uniprot  \n",
+       " 2  o f c m z a n y y p   328  7519  U8K1R6      uniprot  ,\n",
+       " 'entrez.protein':   node_id      node_label                                           sequence   \n",
+       " 0  573426  entrez.protein  NKKADRWISWHQYPRPHIHEIFKFQMHHQLATEYFTWEVLHHMPGL...  \\\n",
+       " 1  865711  entrez.protein  VDMPKRFVFRHDEGWMPANWRPFVPLYMESSYPVRYCTKGPRAEMY...   \n",
+       " 2  639349  entrez.protein  HHPTSLRHFTFYSNQFYTFWHEGFTEEKEDQKGFYLKSGRATKYSW...   \n",
        " \n",
        "            description taxon      id preferred_id  \n",
-       " 0  c g r q j d w u g v  5503  F3O7K0      uniprot  \n",
-       " 1  f p z r m z l u q u  7683  A2F0A6      uniprot  \n",
-       " 2  e m s b f c l f z y  4912  Z8P0Y6      uniprot  ,\n",
-       " 'entrez.protein':   entrez.protein                                           sequence  \\\n",
-       " 0         728388  CNTENHCKPADDSEAVPWINKSDIKPGSSFDASTAGAFIDETADFS...   \n",
-       " 1         654434  FLKQANQEDQWCNLCISSWDEQIVIRSEIVEFMDSFKLCEEDIWES...   \n",
-       " 2         139446  AWVVHILPIHVYPRSLNFIGKPEAAGLKISSGSINECVQLYKKIME...   \n",
-       " \n",
-       "            description taxon      id preferred_id  \n",
-       " 0  r d g w w p v y q t  9606  728388       entrez  \n",
-       " 1  r q s q n v h e n t  9606  654434       entrez  \n",
-       " 2  g k w m k j h u w i  9606  139446       entrez  }"
+       " 0  t s q p e q e w e g  9606  573426       entrez  \n",
+       " 1  x h s y z w r y k x  9606  865711       entrez  \n",
+       " 2  s z c g x b d g k a  9606  639349       entrez  }"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# Create a list of proteins to be imported (now with properties)\n",
     "proteins = [\n",
     "    p for sublist in zip(\n",
     "        [RandomPropertyProtein() for _ in range(n_proteins)],\n",
     "        [EntrezProtein() for _ in range(n_proteins)],\n",
     "    ) for p in sublist\n",
     "]\n",
-    "\n",
+    "# New instance, populated, and to DataFrame\n",
     "bc = BioCypher(\n",
-    "    biocypher_config_path=join(schema_path, '03_biocypher_config.yaml'),\n",
+    "    biocypher_config_path=join(schema_path, '04_biocypher_config.yaml'),\n",
     "    schema_config_path=join(schema_path, '03_schema_config.yaml'),\n",
     ")\n",
     "bc.add(node_generator(proteins))\n",
@@ -1452,7 +1509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Hi @slobentanzer,

I added a simple pandas tutorial in ipynb (it's very much based on the basic tutorial with some minor changes and re-formatting). 

- schemas are printed inline
- Minor text modifications
- Removed the references to each header (I assume duplicates might cause issues, so I leave those to you)
- Used html alerts instead of .md alerts (they look ugly in plain Jupyter, shouldn't matter for the docs page)

It might be best to have this notebook as part of the docs (and maybe remove 01-06 pandas.py scripts, they seem repetitive to me and if this notebook is there, they are not needed imo).

Note that I tagged you in a couple of places with some minor comments. 