### PR TITLE
More support for schema_info generation

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -37,11 +37,11 @@ biocypher:
 
   ## Set to change the log directory
 
-  # log_directory: biocypher-log
+  log_directory: biocypher-log
 
   ## Set to change the output directory
 
-  # output_directory: biocypher-out
+  output_directory: biocypher-out
 
   ## Set to change the cache directory
 

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -37,11 +37,11 @@ biocypher:
 
   ## Set to change the log directory
 
-  log_directory: biocypher-log
+  # log_directory: biocypher-log
 
   ## Set to change the output directory
 
-  output_directory: biocypher-out
+  # output_directory: biocypher-out
 
   ## Set to change the cache directory
 

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -13,6 +13,7 @@ BioCypher core module. Interfaces with the user and distributes tasks to
 submodules.
 """
 from typing import Optional
+from datetime import datetime
 import os
 
 from more_itertools import peekable
@@ -221,6 +222,12 @@ class BioCypher:
         """
 
         if self._offline:
+            timestamp = lambda: datetime.now().strftime("%Y%m%d%H%M%S")
+            outdir = self._output_directory or os.path.join(
+                "biocypher-out", timestamp()
+            )
+            self._output_directory = os.path.abspath(outdir)
+
             self._writer = get_writer(
                 dbms=self._dbms,
                 translator=self._get_translator(),

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -15,6 +15,7 @@ submodules.
 from typing import Optional
 from datetime import datetime
 import os
+import json
 
 from more_itertools import peekable
 import yaml
@@ -252,7 +253,9 @@ class BioCypher:
         else:
             raise NotImplementedError("Cannot get driver in offline mode.")
 
-    def write_nodes(self, nodes, batch_size: int = int(1e6)) -> bool:
+    def write_nodes(
+        self, nodes, batch_size: int = int(1e6), force: bool = False
+    ) -> bool:
         """
         Write nodes to database. Either takes an iterable of tuples (if given,
         translates to ``BioCypherNode`` objects) or an iterable of
@@ -260,6 +263,11 @@ class BioCypher:
 
         Args:
             nodes (iterable): An iterable of nodes to write to the database.
+
+            batch_size (int): The batch size to use when writing to disk.
+
+            force (bool): Whether to force writing to the output directory even
+                if the node type is not present in the schema config file.
 
         Returns:
             bool: True if successful.
@@ -274,7 +282,9 @@ class BioCypher:
         else:
             tnodes = nodes
         # write node files
-        return self._writer.write_nodes(tnodes, batch_size=batch_size)
+        return self._writer.write_nodes(
+            tnodes, batch_size=batch_size, force=force
+        )
 
     def write_edges(self, edges, batch_size: int = int(1e6)) -> bool:
         """
@@ -631,9 +641,9 @@ class BioCypher:
             node = BioCypherNode(
                 node_id="schema_info",
                 node_label="schema_info",
-                properties={"schema_info": yaml.dump(schema)},
+                properties={"schema_info": json.dumps(schema)},
             )
-            self.write_nodes([node])
+            self.write_nodes([node], force=True)
 
         return schema
 

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -578,7 +578,7 @@ class BioCypher:
             )
 
         ontology = self._get_ontology()
-        schema = ontology.mapping.extended_schema
+        schema = ontology.mapping.extended_schema.copy()
         schema["is_schema_info"] = True
 
         deduplicator = self._get_deduplicator()

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -554,7 +554,7 @@ class BioCypher:
 
         self._writer.write_import_call()
 
-    def write_schema_info(self) -> None:
+    def write_schema_info(self, as_node: bool = False) -> None:
         """
         Write an extended schema info YAML file that extends the
         `schema_config.yaml` with run-time information of the built KG. For
@@ -618,6 +618,15 @@ class BioCypher:
         path = os.path.join(self._output_directory, "schema_info.yaml")
         with open(path, "w") as f:
             f.write(yaml.dump(schema))
+
+        if as_node:
+            # write as node
+            node = BioCypherNode(
+                node_id="schema_info",
+                node_label="schema_info",
+                properties={"schema_info": yaml.dump(schema)},
+            )
+            self.write_nodes([node])
 
         return schema
 

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -401,7 +401,7 @@ class _BatchWriter(ABC):
 
         return True
 
-    def _write_node_data(self, nodes, batch_size, force):
+    def _write_node_data(self, nodes, batch_size, force: bool = False):
         """
         Writes biocypher nodes to CSV conforming to the headers created
         with `_write_node_headers()`, and is actually required to be run

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -302,7 +302,9 @@ class _BatchWriter(ABC):
         else:
             return delimiter, delimiter
 
-    def write_nodes(self, nodes, batch_size: int = int(1e6)):
+    def write_nodes(
+        self, nodes, batch_size: int = int(1e6), force: bool = False
+    ):
         """
         Wrapper for writing nodes and their headers.
 
@@ -310,13 +312,19 @@ class _BatchWriter(ABC):
             nodes (BioCypherNode): a list or generator of nodes in
                 :py:class:`BioCypherNode` format
 
+            batch_size (int): The batch size for writing nodes.
+
+            force (bool): Whether to force writing nodes even if their type is
+                not present in the schema.
+
+
         Returns:
             bool: The return value. True for success, False otherwise.
         """
         # TODO check represented_as
 
         # write node data
-        passed = self._write_node_data(nodes, batch_size)
+        passed = self._write_node_data(nodes, batch_size, force)
         if not passed:
             logger.error("Error while writing node data.")
             return False
@@ -393,7 +401,7 @@ class _BatchWriter(ABC):
 
         return True
 
-    def _write_node_data(self, nodes, batch_size):
+    def _write_node_data(self, nodes, batch_size, force):
         """
         Writes biocypher nodes to CSV conforming to the headers created
         with `_write_node_headers()`, and is actually required to be run
@@ -444,13 +452,17 @@ class _BatchWriter(ABC):
                     bin_l[label] = 1
 
                     # get properties from config if present
-                    cprops = (
-                        self.translator.ontology.mapping.extended_schema.get(
+                    if (
+                        label
+                        in self.translator.ontology.mapping.extended_schema
+                    ):
+                        cprops = self.translator.ontology.mapping.extended_schema.get(
                             label
                         ).get(
                             "properties",
                         )
-                    )
+                    else:
+                        cprops = None
                     if cprops:
                         d = dict(cprops)
 
@@ -483,7 +495,12 @@ class _BatchWriter(ABC):
 
                     # get label hierarchy
                     # multiple labels:
-                    all_labels = self.translator.ontology.get_ancestors(label)
+                    if not force:
+                        all_labels = self.translator.ontology.get_ancestors(
+                            label
+                        )
+                    else:
+                        all_labels = None
 
                     if all_labels:
                         # convert to pascal case

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -183,7 +183,7 @@ class _BatchWriter(ABC):
             quote:
                 The quote character to use for the CSV files.
 
-            dirname:
+            output_directory:
                 Path for exporting CSV files.
 
             db_name:
@@ -1887,10 +1887,6 @@ def get_writer(
 
     dbms_config = _config(dbms)
 
-    timestamp = lambda: datetime.now().strftime("%Y%m%d%H%M%S")
-    outdir = output_directory or os.path.join("biocypher-out", timestamp())
-    outdir = os.path.abspath(outdir)
-
     writer = DBMS_TO_CLASS[dbms]
 
     if not writer:
@@ -1903,7 +1899,7 @@ def get_writer(
             delimiter=dbms_config.get("delimiter"),
             array_delimiter=dbms_config.get("array_delimiter"),
             quote=dbms_config.get("quote_character"),
-            output_directory=outdir,
+            output_directory=output_directory,
             db_name=dbms_config.get("database_name"),
             import_call_bin_prefix=dbms_config.get("import_call_bin_prefix"),
             import_call_file_prefix=dbms_config.get("import_call_file_prefix"),

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,5 +1,6 @@
 import os
 
+import yaml
 import pytest
 import networkx as nx
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -54,3 +54,18 @@ def test_ontology_without_schema_config(core_no_schema):
 
     assert isinstance(core_no_schema._ontology, Ontology)
     assert isinstance(core_no_schema._ontology._nx_graph, nx.DiGraph)
+
+
+@pytest.mark.parametrize("l", [4], scope="function")
+def test_write_schema_info_as_node(core, _get_nodes):
+    core.add(_get_nodes)
+
+    schema = core.write_schema_info(as_node=True)
+
+    path = os.path.join(core._output_directory, "schema_info.yaml")
+    assert os.path.exists(path)
+
+    with open(path, "r") as f:
+        schema_loaded = yaml.safe_load(f)
+
+    assert schema_loaded == schema


### PR DESCRIPTION
Allow writing schema_info to a node in the graph for easier access from biochatter

For this, allow writing a node that is not covered by the schema definition using the force parameter (currently only on nodes)

Moved output folder generation (if not configured) to the core module to be able to access it always from the schema info method

Fix bug with schema info (was not copied and thus modified the extended_schema of the ontology class