### PR TITLE
fix issue #228: fix doctest and run docs build on PRs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -31,6 +32,7 @@ jobs:
       uses: ./.github/actions/build_docs
 
   build_and_deploy_docs:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions: write-all
     steps:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -272,11 +272,6 @@ bc.log_duplicates()           # show duplicates in the input data
 bc.show_ontology_structure()  # show ontological hierarchy
 ```
 
-```{testoutput} python
-:hide:
-...
-```
-
 ## Section 2: Merging data
 
 (merging)=


### PR DESCRIPTION
The doctest is fixed and to avoid failures like this in the future, the CICD pipeline is adapted to also run the docs build on PRs.