### PR TITLE
refactor(write): return the path of the import call file

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -558,10 +558,13 @@ class BioCypher:
 
         return self._ontology.show_ontology_structure(**kwargs)
 
-    def write_import_call(self) -> None:
+    def write_import_call(self) -> str:
         """
         Write a shell script to import the database depending on the chosen
         DBMS.
+
+        Returns:
+            str: path toward the file holding the import call.
         """
 
         if not self._offline:
@@ -569,7 +572,7 @@ class BioCypher:
                 "Cannot write import call in online mode."
             )
 
-        self._writer.write_import_call()
+        return self._writer.write_import_call()
 
     def write_schema_info(self, as_node: bool = False) -> None:
         """

--- a/biocypher/_write.py
+++ b/biocypher/_write.py
@@ -1007,14 +1007,14 @@ class _BatchWriter(ABC):
 
         return self._construct_import_call()
 
-    def write_import_call(self) -> bool:
+    def write_import_call(self) -> str:
         """
         Function to write the import call detailing folder and
         individual node and edge headers and data files, as well as
         delimiters and database name, to the export folder as txt.
 
         Returns:
-            bool: The return value. True for success, False otherwise.
+            str: The path of the file holding the import call.
         """
 
         file_path = os.path.join(self.outdir, self._get_import_script_name())
@@ -1023,7 +1023,7 @@ class _BatchWriter(ABC):
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(self._construct_import_call())
 
-        return True
+        return file_path
 
 
 class _Neo4jBatchWriter(_BatchWriter):


### PR DESCRIPTION
This allows the user to manipulate the actual path, since no accessors exist otherwise. For instance, this can be printed on stdout and piped in a shell automatically. The returned string can still be used in a test, hence not changing the interface much.