### PR TITLE
Fix neo4j CSV output not escaping quote character and cause import error

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -19,6 +19,16 @@ class _BatchWriter(_Writer, ABC):
     """Abstract batch writer class"""
 
     @abstractmethod
+    def _quote_string(self, value: str) -> str:
+        """
+        Abstract method to quote a string. Escaping is handled by the database-specific writer.
+        """
+
+        raise NotImplementedError(
+            "Database writer must override '_quote_string'"
+        )
+
+    @abstractmethod
     def _get_default_import_call_bin_prefix(self):
         """
         Abstract method to provide the default string for the import call bin prefix.
@@ -626,7 +636,7 @@ class _BatchWriter(_Writer, ABC):
                         if isinstance(p, list):
                             plist.append(self._write_array_string(p))
                         else:
-                            plist.append(f"{self.quote}{str(p)}{self.quote}")
+                            plist.append(self._quote_string(str(p)))
 
                 line.append(self.delim.join(plist))
             line.append(labels)
@@ -861,7 +871,7 @@ class _BatchWriter(_Writer, ABC):
                     if isinstance(p, list):
                         plist.append(self._write_array_string(p))
                     else:
-                        plist.append(self.quote + str(p) + self.quote)
+                        plist.append(self._quote_string(str(p)))
 
             entries = [e.get_source_id()]
 

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -64,7 +64,7 @@ class _Neo4jBatchWriter(_BatchWriter):
             str: The string representation of an array for the neo4j admin import
         """
         string = self.adelim.join(string_list)
-        return f"{self.quote}{string}{self.quote}"
+        return self._quote_string(string)
 
     def _write_node_headers(self):
         """

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -44,12 +44,12 @@ class _Neo4jBatchWriter(_BatchWriter):
         """
 
         return "bin/"
-    
+
     def _quote_string(self, value: str) -> str:
         """
         Quote a string. Quote character is escaped by doubling it.
         """
-        
+
         return f"{self.quote}{value.replace(self.quote, self.quote * 2)}{self.quote}"
 
     def _write_array_string(self, string_list):

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -44,6 +44,13 @@ class _Neo4jBatchWriter(_BatchWriter):
         """
 
         return "bin/"
+    
+    def _quote_string(self, value: str) -> str:
+        """
+        Quote a string. Quote character is escaped by doubling it.
+        """
+        
+        return f"{self.quote}{value.replace(self.quote, self.quote * 2)}{self.quote}"
 
     def _write_array_string(self, string_list):
         """

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -395,7 +395,7 @@ class _RDFWriter(_BatchWriter):
         """
         Quote a string.
         """
-        
+
         return f"{self.quote}{value}{self.quote}"
 
     def _write_array_string(self, string_list):

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -391,6 +391,13 @@ class _RDFWriter(_BatchWriter):
         """
         return ""
 
+    def _quote_string(self, value: str) -> str:
+        """
+        Quote a string.
+        """
+        
+        return f"{self.quote}{value}{self.quote}"
+
     def _write_array_string(self, string_list):
         """
         Abstract method to write the string representation of an array into a .csv file

--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -57,6 +57,13 @@ class _PostgreSQLBatchWriter(_BatchWriter):
             )
             return "VARCHAR"
 
+    def _quote_string(self, value: str) -> str:
+        """
+        Quote a string.
+        """
+
+        return f"{self.quote}{value}{self.quote}"
+
     def _write_array_string(self, string_list) -> str:
         """
         Abstract method to output.write the string representation of an array into a .csv file


### PR DESCRIPTION
My recent customer support brought me back to this issue. While this is not the only reason for his trouble but this certainly complicated his problem so I decided to fix it now. This PR detects and escapes quote character appears in a field to prevent import error due to quote character conflict and the subsequent incorrect splitting of a CSV row.

Before fix:
`5'-ABC-3'`, `5'-DEF-3'` results into `'` `5'-ABC-3'|5'-DEF-3'` `'` which cannot be parsed correctly, following neo4j documentation, quote character could be escaped by doubling it so now it becomes `'` `5''-ABC-3''|5''-DEF-3''` `'`

Tested single field and array field to confirm the output could be imported correctly.

Only neo4j is fixed, RDF and Protgres remain unfixed, their behaviour is unchanged as I don't want to invest time on them for now. I still tested the ability to output these two formats to confirm there is no regression.