### PR TITLE
feat(neo4j): allow several labels sorting methods

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -85,6 +85,13 @@ neo4j:
   array_delimiter: "|"
   quote_character: "'"
 
+  # How to write the labels in the export files.
+  labels_order: "Alphabetical" # The default.
+  # Or:
+  # labels_order: "Ascending" # From more specific to more generic.
+  # labels_order: "Descending" # From more generic to more specific.
+  # labels_order: "Leaves" # Only the more specific label.
+
   ## MultiDB functionality
   ## Set to false for using community edition or older versions of Neo4j
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -124,6 +124,7 @@ class _BatchWriter(_Writer, ABC):
         db_port: str = None,
         rdf_format: str = None,
         rdf_namespaces: dict = {},
+        labels_order: str = "Alphabetical"
     ):
         """Abtract parent class for writing node and edge representations to disk
         using the format specified by each database type. The database-specific
@@ -250,6 +251,11 @@ class _BatchWriter(_Writer, ABC):
         self._import_call_file_prefix = import_call_file_prefix
 
         self.parts = {}  # dict to store the paths of part files for each label
+
+        self._labels_orders = ["Alphabetical", "Ascending", "Descending", "Leaves"]
+        if labels_order not in self._labels_orders:
+            raise ValueError(f"neo4j's 'labels_order' parameter cannot be '{labels_order}', must be one of: {' ,'.join(self._labels_orders)}")
+        self.labels_order = labels_order
 
         # TODO not memory efficient, but should be fine for most cases; is
         # there a more elegant solution?
@@ -472,8 +478,19 @@ class _BatchWriter(_Writer, ABC):
                         all_labels = [self.translator.name_sentence_to_pascal(label) for label in all_labels]
                         # remove duplicates
                         all_labels = list(OrderedDict.fromkeys(all_labels))
-                        # order alphabetically
-                        all_labels.sort()
+                        match self.labels_order:
+                            case "Alphabetical": # Default in config.
+                                all_labels.sort()
+                            case "Ascending":
+                                pass # Default from get_ancestors.
+                            case "Descending":
+                                all_labels.reverse()
+                            case "Leaves":
+                                assert len(all_labels) >= 1
+                                all_labels = [all_labels[0]]
+                            case _:
+                                # In case someone touched _label_orders after constructor.
+                                assert(self.labels_order in self._labels_orders)
                         # concatenate with array delimiter
                         all_labels = self._write_array_string(all_labels)
                     else:

--- a/docs/output/neo4j.md
+++ b/docs/output/neo4j.md
@@ -54,6 +54,14 @@ neo4j:  ### Neo4j configuration ###
   array_delimiter: '|'
   quote_character: "'"
 
+  # How to write the labels in the export files.
+  labels_order: "Alphabetical" # The default.
+  # Or:
+  # labels_order: "Ascending" # From more specific to more generic.
+  # labels_order: "Descending" # From more generic to more specific.
+  # labels_order: "Leaves" # Only the more specific label.
+
+
   # MultiDB functionality
   # Set to false for using community edition or older versions of Neo4j
   multi_db: true
@@ -185,3 +193,24 @@ If there exists no BioCypher graph in the currently active database, or
 if the user explicitly specifies so using the ``wipe`` attribute of the
 driver, a new BioCypher database is created using the schema
 configuration specified in the [schema-config.yaml](tut_01_schema).
+
+## Note on labels order
+
+Neo4j do not support managing the hierarchy of types of the vocabulary given by
+the input ontology. What it does is to attach to nodes and edges each type label
+of all the ancestors in the types hierarchy.
+
+By default, the Neo4j driver exports those type labels as an
+alphabetically-sorted list, which may be useful for comparing output files.
+But this may be less easy to understand within a graph browser that would show
+the labels in the same order.
+
+To get a more readable labels list, you can set `labels_order` as either
+`Ascending` or `Descending`; both of which will display labels in the order
+given by the type hierarchy of the ontology's vocabulary.
+
+To get even simpler label, you can set `labels_order: Leaves`, which
+will write down only the more specific type label (the "leaf" of the types
+tree). Be warn that the resulting export will completely lose the ontological
+information, hence making it impossible to query the graph on high-level types.
+


### PR DESCRIPTION
Keep the same default as the previous implementation (as "Alphabetical"), for retro-compatibility but I would have found it cleaner to use "Ascending".