### PR TITLE
feat(write): OWL

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -130,6 +130,12 @@ rdf:
   ### RDF configuration ###
   rdf_format: turtle
 
+owl:
+  ### OWL configuration ###
+  rdf_format: turtle
+  edge_model: Association # or: ObjectProperty
+  file_stem: biocypher # without the extension
+
 sqlite:
   ### SQLite configuration ###
   # SQLite connection credentials

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -128,11 +128,11 @@ postgresql:
 
 rdf:
   ### RDF configuration ###
-  file_format: turtle # turtle, xml, json-ld, ntriples, n3, trig, trix or nquads
+  file_format: turtle # turtle or ttl, xml, json-ld, ntriples, n3, trig, trix or nquads
 
 owl:
   ### OWL configuration ###
-  file_format: turtle # turtle, xml, json-ld, ntriples, n3, trig, trix or nquads
+  file_format: turtle # turtle or ttl, xml, json-ld, ntriples, n3, trig, trix or nquads
   edge_model: Association # or: ObjectProperty
   file_stem: biocypher # without the extension
 

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -128,11 +128,11 @@ postgresql:
 
 rdf:
   ### RDF configuration ###
-  rdf_format: turtle
+  file_format: turtle # turtle, xml, json-ld, ntriples, n3, trig, trix or nquads
 
 owl:
   ### OWL configuration ###
-  rdf_format: turtle
+  file_format: turtle # turtle, xml, json-ld, ntriples, n3, trig, trix or nquads
   edge_model: Association # or: ObjectProperty
   file_stem: biocypher # without the extension
 

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -131,7 +131,6 @@ class OntologyAdapter:
             g.triples((None, rdflib.RDF.type, rdflib.RDFS.Class)),  # Root classes
             g.triples((None, rdflib.RDFS.subPropertyOf, None)),  # OWL "edges" classes
             g.triples((None, rdflib.RDF.type, rdflib.OWL.ObjectProperty)),  # OWL "edges" root classes
-            # HERE
         ):
             if self.has_label(s, g):
                 one_to_one_inheritance_graph.add((s, p, o))
@@ -161,8 +160,6 @@ class OntologyAdapter:
             for s_, _, _ in chain(
                 g.triples((None, rdflib.RDFS.subClassOf, node)),
                 g.triples((None, rdflib.RDFS.subPropertyOf, node)),
-                # FIXME check RDF.type as well to avoid missing the root class(es)
-                # HERE
             ):
                 child_name = s_
 
@@ -189,7 +186,6 @@ class OntologyAdapter:
             bool: True if the node has a label, False otherwise
 
         """
-        # FIXME check IRI and RDF.label
         return (node, rdflib.RDFS.label, None) in g
 
     def _retrieve_rdf_linked_list(self, subject: rdflib.URIRef) -> list:
@@ -275,8 +271,6 @@ class OntologyAdapter:
             - switching the id and label if requested
             - adapting the labels (replace _ with space and convert to lower
                 sentence case)
-            FIXME why is a BioCypher format even needed?
-
         Args:
         ----
             nx_graph (nx.DiGraph): The networkx graph

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -1,6 +1,6 @@
-"""BioCypher 'ontology' module. Contains classes and functions to handle parsing
-and representation of single ontologies as well as their hybridisation and
-other advanced operations.
+"""BioCypher 'ontology' module to parse and represent ontologies.
+
+Also performs ontology hybridisation and other advanced operations.
 """
 
 import os
@@ -28,14 +28,15 @@ logger.debug(f"Loading module {__name__}.")
 
 
 class OntologyAdapter:
-    """Class that represents an ontology to be used in the Biocypher framework. Can
-    read from a variety of formats, including OWL, OBO, and RDF/XML. The
+    """Class that represents an ontology to be used in the Biocypher framework.
+
+    Can read from a variety of formats, including OWL, OBO, and RDF/XML. The
     ontology is represented by a networkx.DiGraph object; an RDFlib graph is
     also kept. By default, the DiGraph reverses the label and identifier of the
     nodes, such that the node name in the graph is the human-readable label. The
-    edges are oriented from child to parent.
-    Labels are formatted in lower sentence case and underscores are replaced by spaces.
-    Identifiers are taken as defined and the prefixes are removed by default.
+    edges are oriented from child to parent. Labels are formatted in lower
+    sentence case and underscores are replaced by spaces. Identifiers are taken
+    as defined and the prefixes are removed by default.
     """
 
     def __init__(
@@ -178,7 +179,7 @@ class OntologyAdapter:
         return intersection
 
     def has_label(self, node: rdflib.URIRef, g: rdflib.Graph) -> bool:
-        """Does the node have a label in g?
+        """Check if the node has a label in the graph.
 
         Args:
         ----
@@ -192,16 +193,22 @@ class OntologyAdapter:
         return (node, rdflib.RDFS.label, None) in g
 
     def _retrieve_rdf_linked_list(self, subject: rdflib.URIRef) -> list:
-        """Recursively retrieves a linked list from RDF.
+        """Recursively retrieve a linked list from RDF.
+
         Example RDF list with the items [item1, item2]:
         list_node - first -> item1
         list_node - rest -> list_node2
         list_node2 - first -> item2
         list_node2 - rest -> nil
+
         Args:
+        ----
             subject (rdflib.URIRef): One list_node of the RDF list
+
         Returns:
+        -------
             list: The items of the RDF list
+
         """
         g = self._rdf_graph
         rdf_list = []
@@ -261,11 +268,15 @@ class OntologyAdapter:
         switch_label_and_id: bool,
         rename_nodes: bool = True,
     ) -> nx.DiGraph:
-        """Change the nodes in the networkx graph to BioCypher format:
-            - remove the prefix of the identifier
-            - switch id and label
-            - adapt the labels (replace _ with space and convert to lower sentence case)
+        """Change the nodes in the networkx graph to BioCypher format.
+
+        This involves:
+            - removing the prefix of the identifier
+            - switching the id and label if requested
+            - adapting the labels (replace _ with space and convert to lower
+                sentence case)
             FIXME why is a BioCypher format even needed?
+
         Args:
         ----
             nx_graph (nx.DiGraph): The networkx graph
@@ -347,16 +358,28 @@ class OntologyAdapter:
             labels_in_ontology = []
             for label_subject, _, label_in_ontology in g.triples((None, rdflib.RDFS.label, None)):
                 labels_in_ontology.append(str(label_in_ontology))
-            raise ValueError(
+            msg = (
                 f"Could not find root node with label '{root_label}'. "
-                f"The ontology contains the following labels: {labels_in_ontology}",
+                f"The ontology contains the following labels: {labels_in_ontology}"
             )
+            logger.error(msg)
+            raise ValueError(msg)
         return root
 
     def _remove_prefix(self, uri: str) -> str:
-        """Remove the prefix of a URI. URIs can contain either "#" or "/" as a
-        separator between the prefix and the local name. The prefix is
-        everything before the last separator.
+        """Remove the prefix of a URI.
+
+        URIs can contain either "#" or "/" as a separator between the prefix
+        and the local name. The prefix is everything before the last separator.
+
+        Args:
+        ----
+            uri (str): The URI to remove the prefix from
+
+        Returns:
+        -------
+            str: The URI without the prefix
+
         """
         if self._remove_prefixes:
             return uri.rsplit("#", 1)[-1].rsplit("/", 1)[-1]
@@ -364,8 +387,18 @@ class OntologyAdapter:
             return uri
 
     def _load_rdf_graph(self, ontology_file):
-        """Load the ontology into an RDFlib graph. The ontology file can be in
-        OWL, OBO, or RDF/XML format.
+        """Load the ontology into an RDFlib graph.
+
+        The ontology file can be in OWL, OBO, or RDF/XML format.
+
+        Args:
+        ----
+            ontology_file (str): The path to the ontology file
+
+        Returns:
+        -------
+            rdflib.Graph: The RDFlib graph
+
         """
         g = rdflib.Graph()
         g.parse(ontology_file, format=self._get_format(ontology_file))
@@ -383,18 +416,24 @@ class OntologyAdapter:
             elif self._format == "ttl":
                 return self._format
             else:
-                raise ValueError(f"Could not determine format of ontology file {ontology_file}")
+                msg = f"Could not determine format of ontology file {ontology_file}"
+                logger.error(msg)
+                raise ValueError(msg)
 
         if ontology_file.endswith(".owl"):
             return "application/rdf+xml"
         elif ontology_file.endswith(".obo"):
-            raise NotImplementedError("OBO format not yet supported")
+            msg = "OBO format not yet supported"
+            logger.error(msg)
+            raise NotImplementedError(msg)
         elif ontology_file.endswith(".rdf"):
             return "application/rdf+xml"
         elif ontology_file.endswith(".ttl"):
             return "ttl"
         else:
-            raise ValueError(f"Could not determine format of ontology file {ontology_file}")
+            msg = f"Could not determine format of ontology file {ontology_file}"
+            logger.error(msg)
+            raise ValueError(msg)
 
     def get_nx_graph(self):
         """Get the networkx graph representing the ontology."""
@@ -409,8 +448,8 @@ class OntologyAdapter:
 
         Returns
         -------
-            root_node: If _switch_label_and_id is True, the root node label is returned,
-                otherwise the root node id is returned.
+            root_node: If _switch_label_and_id is True, the root node label is
+                returned, otherwise the root node id is returned.
 
         """
         root_node = None
@@ -436,10 +475,11 @@ class OntologyAdapter:
 
 
 class Ontology:
-    """A class that represents the ontological "backbone" of a BioCypher knowledge
-    graph. The ontology can be built from a single resource, or hybridised from
-    a combination of resources, with one resource being the "head" ontology,
-    while an arbitrary number of other resources can become "tail" ontologies at
+    """A class that represents the ontological "backbone" of a KG.
+
+    The ontology can be built from a single resource, or hybridised from a
+    combination of resources, with one resource being the "head" ontology, while
+    an arbitrary number of other resources can become "tail" ontologies at
     arbitrary fusion points inside the "head" ontology.
     """
 
@@ -472,10 +512,11 @@ class Ontology:
         self._main()
 
     def _main(self) -> None:
-        """Main method to be run on instantiation. Loads the ontologies, joins
-        them, and returns the hybrid ontology. Loads only the head ontology
-        if nothing else is given. Adds user extensions and properties from
-        the mapping.
+        """Instantiate the ontology.
+
+        Loads the ontologies, joins them, and returns the hybrid ontology.
+        Loads only the head ontology if nothing else is given. Adds user
+        extensions and properties from the mapping.
         """
         self._load_ontologies()
 
@@ -495,8 +536,10 @@ class Ontology:
             self._add_properties()
 
     def _load_ontologies(self) -> None:
-        """For each ontology, load the OntologyAdapter object and store it as an
-        instance variable (head) or a dictionary (tail).
+        """For each ontology, load the OntologyAdapter object.
+
+        Store it as an instance variable (head) or in an instance dictionary
+        (tail).
         """
         logger.info("Loading ontologies...")
 
@@ -520,14 +563,23 @@ class Ontology:
                 )
 
     def _get_head_join_node(self, adapter: OntologyAdapter) -> str:
-        """Tries to find the head join node of the given ontology adapter in the
-        head ontology. If the join node is not found, the method will raise an
-        error.
+        """Try to find the head join node of the given ontology adapter.
+
+        Find the node in the head ontology that is the head join node. If the
+        join node is not found, the method will raise an error.
 
         Args:
         ----
             adapter (OntologyAdapter): The ontology adapter of which to find the
                 join node in the head ontology.
+
+        Returns:
+        -------
+            str: The head join node in the head ontology.
+
+        Raises:
+        ------
+            ValueError: If the head join node is not found in the head ontology.
 
         """
         head_join_node = None
@@ -549,14 +601,18 @@ class Ontology:
                 self._head_ontology._switch_label_and_id,
                 rename_nodes=False,
             )
-            raise ValueError(
+            msg = (
                 f"Head join node '{head_join_node}' not found in head ontology. "
-                f"The head ontology contains the following nodes: {head_ontology.nodes}.",
+                f"The head ontology contains the following nodes: {head_ontology.nodes}."
             )
+            logger.error(msg)
+            raise ValueError(msg)
         return head_join_node
 
     def _join_ontologies(self, adapter: OntologyAdapter, head_join_node) -> None:
-        """Joins the ontologies by adding the tail ontology as a subgraph to the
+        """Join the present ontologies.
+
+        Join two ontologies by adding the tail ontology as a subgraph to the
         head ontology at the specified join nodes.
 
         Args:
@@ -680,7 +736,9 @@ class Ontology:
             self._nx_graph.add_edge(node, "entity")
 
     def _add_properties(self) -> None:
-        """For each entity in the mapping, update the ontology with the properties
+        """Add properties to the ontology.
+
+        For each entity in the mapping, update the ontology with the properties
         specified in the mapping. Updates synonym information in the graph,
         setting the synonym as the primary node label.
         """
@@ -691,7 +749,9 @@ class Ontology:
             if value.get("synonym_for"):
                 # change node label to synonym
                 if value["synonym_for"] not in self._nx_graph.nodes:
-                    raise ValueError(f"Node {value['synonym_for']} not found in ontology.")
+                    msg = f"Node {value['synonym_for']} not found in ontology."
+                    logger.error(msg)
+                    raise ValueError(msg)
 
                 self._nx_graph = nx.relabel_nodes(self._nx_graph, {value["synonym_for"]: key})
 
@@ -725,16 +785,20 @@ class Ontology:
 
         """
         if not full and not self.mapping.extended_schema:
-            raise ValueError(
+            msg = (
                 "You are attempting to visualise a subset of the loaded"
                 "ontology, but have not provided a schema configuration. "
                 "To display a partial ontology graph, please provide a schema "
                 "configuration file; to visualise the full graph, please use "
                 "the parameter `full = True`.",
             )
+            logger.error(msg)
+            raise ValueError(msg)
 
         if not self._nx_graph:
-            raise ValueError("Ontology not loaded.")
+            msg = "Ontology not loaded."
+            logger.error(msg)
+            raise ValueError(msg)
 
         if not self._tail_ontologies:
             msg = f"Showing ontology structure based on {self._head_ontology._ontology_file}"
@@ -797,7 +861,9 @@ class Ontology:
             return True
 
     def get_dict(self) -> dict:
-        """Returns a dictionary compatible with a BioCypher node for compatibility
+        """Return a dictionary representation of the ontology.
+
+        The dictionary is compatible with a BioCypher node for compatibility
         with the Neo4j driver.
         """
         d = {
@@ -811,8 +877,9 @@ class Ontology:
         return d
 
     def _get_current_id(self):
-        """Instantiate a version ID for the current session. For now does simple
-        versioning using datetime.
+        """Instantiate a version ID for the current session.
+
+        For now does simple versioning using datetime.
 
         Can later implement incremental versioning, versioning from
         config file, or manual specification via argument.
@@ -821,8 +888,9 @@ class Ontology:
         return now.strftime("v%Y%m%d-%H%M%S")
 
     def get_rdf_graph(self):
-        """
-        Returns the merged RDF graphs of all loaded ontologies (head and tails).
+        """Return the merged RDF graph.
+
+        Return the merged graph of all loaded ontologies (head and tails).
         """
         graph = self._head_ontology.get_rdf_graph()
         if self._tail_ontologies:

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -1,10 +1,11 @@
-"""
-BioCypher 'translation' module. Responsible for translating between the raw
-input data and the BioCypherNode and BioCypherEdge objects.
+"""BioCypher 'translation' module.
+
+Responsible for translating between the raw input data and the
+BioCypherNode and BioCypherEdge objects.
 """
 
 from collections.abc import Generator, Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 from more_itertools import peekable
 
@@ -19,21 +20,23 @@ __all__ = ["Translator"]
 
 
 class Translator:
-    """
-    Class responsible for exacting the translation process that is configured in
-    the schema_config.yaml file. Creates a mapping dictionary from that file,
-    and, given nodes and edges, translates them into BioCypherNodes and
-    BioCypherEdges. During this process, can also filter the properties of the
-    entities if the schema_config.yaml file specifies a property whitelist or
-    blacklist.
+    """Class responsible for exacting the translation process.
+
+    Translation is configured in the schema_config.yaml file. Creates a mapping
+    dictionary from that file, and, given nodes and edges, translates them into
+    BioCypherNodes and BioCypherEdges. During this process, can also filter the
+    properties of the entities if the schema_config.yaml file specifies a property
+    whitelist or blacklist.
 
     Provides utility functions for translating between input and output labels
     and cypher queries.
     """
 
     def __init__(self, ontology: "Ontology", strict_mode: bool = False):
-        """
+        """Initialise the translator.
+
         Args:
+        ----
             leaves:
                 Dictionary detailing the leaves of the hierarchy
                 tree representing the structure of the graph; the leaves are
@@ -43,8 +46,8 @@ class Translator:
             strict_mode:
                 If True, the translator will raise an error if input data do not
                 carry source, licence, and version information.
-        """
 
+        """
         self.ontology = ontology
         self.strict_mode = strict_mode
 
@@ -59,11 +62,7 @@ class Translator:
 
     def translate_entities(self, entities):
         entities = peekable(entities)
-        if (
-            isinstance(entities.peek(), BioCypherNode)
-            or isinstance(entities.peek(), BioCypherEdge)
-            or isinstance(entities.peek(), BioCypherRelAsNode)
-        ):
+        if isinstance(entities.peek(), BioCypherEdge | BioCypherNode | BioCypherRelAsNode):
             translated_entities = entities
         elif len(entities.peek()) < 4:
             translated_entities = self.translate_nodes(entities)
@@ -75,19 +74,20 @@ class Translator:
         self,
         node_tuples: Iterable,
     ) -> Generator[BioCypherNode, None, None]:
-        """
-        Translates input node representation to a representation that
-        conforms to the schema of the given BioCypher graph. For now
-        requires explicit statement of node type on pass.
+        """Translate input node representation.
+
+        Translate the node tuples to a representation that conforms to the
+        schema of the given BioCypher graph. For now requires explicit
+        statement of node type on pass.
 
         Args:
+        ----
             node_tuples (list of tuples): collection of tuples
                 representing individual nodes by their unique id and a type
                 that is translated from the original database notation to
                 the corresponding BioCypher notation.
 
         """
-
         self._log_begin_translate(node_tuples, "nodes")
 
         for _id, _type, _props in node_tuples:
@@ -101,10 +101,12 @@ class Translator:
 
                 for prop in required_props:
                     if prop not in _props:
-                        raise ValueError(
+                        msg = (
                             f"Property `{prop}` missing from node {_id}. "
-                            "Strict mode is enabled, so this is not allowed."
+                            "Strict mode is enabled, so this is not allowed.",
                         )
+                        logger.error(msg)
+                        raise ValueError(msg)
 
             # find the node in leaves that represents ontology node type
             _ontology_class = self._get_ontology_mapping(_type)
@@ -129,10 +131,11 @@ class Translator:
         self._log_finish_translate("nodes")
 
     def _get_preferred_id(self, _bl_type: str) -> str:
-        """
-        Returns the preferred id for the given Biolink type.
-        """
+        """Return the preferred id for the given Biolink type.
 
+        If the preferred id is not specified in the schema_config.yaml file,
+        return "id".
+        """
         return (
             self.ontology.mapping.extended_schema[_bl_type]["preferred_id"]
             if "preferred_id" in self.ontology.mapping.extended_schema.get(_bl_type, {})
@@ -140,10 +143,11 @@ class Translator:
         )
 
     def _filter_props(self, bl_type: str, props: dict) -> dict:
-        """
-        Filters properties for those specified in schema_config if any.
-        """
+        """Filter properties for those specified in schema_config if any.
 
+        If the properties are not specified in the schema_config.yaml file,
+        return the original properties.
+        """
         filter_props = self.ontology.mapping.extended_schema[bl_type].get("properties", {})
 
         # strict mode: add required properties (only if there is a whitelist)
@@ -179,14 +183,15 @@ class Translator:
     def translate_edges(
         self,
         edge_tuples: Iterable,
-    ) -> Generator[Union[BioCypherEdge, BioCypherRelAsNode], None, None]:
-        """
-        Translates input edge representation to a representation that
-        conforms to the schema of the given BioCypher graph. For now
-        requires explicit statement of edge type on pass.
+    ) -> Generator[BioCypherEdge | BioCypherRelAsNode, None, None]:
+        """Translate input edge representation.
+
+        Translate the edge tuples to a representation that conforms to the
+        schema of the given BioCypher graph. For now requires explicit
+        statement of edge type on pass.
 
         Args:
-
+        ----
             edge_tuples (list of tuples):
 
                 collection of tuples representing source and target of
@@ -194,8 +199,8 @@ class Translator:
                 of interaction in the original database notation, which
                 is translated to BioCypher notation using the `leaves`.
                 Can optionally possess its own ID.
-        """
 
+        """
         self._log_begin_translate(edge_tuples, "edges")
 
         # legacy: deal with 4-tuples (no edge id)
@@ -208,15 +213,19 @@ class Translator:
             # check for strict mode requirements
             if self.strict_mode:
                 if "source" not in _props:
-                    raise ValueError(
-                        f"Edge {_id if _id else (_src, _tar)} does not have a `source` property.",
+                    msg = (
+                        f"Edge {_id if _id else (_src, _tar)} does not have a `source` property."
                         " This is required in strict mode.",
                     )
+                    logger.error(msg)
+                    raise ValueError(msg)
                 if "licence" not in _props:
-                    raise ValueError(
-                        f"Edge {_id if _id else (_src, _tar)} does not have a `licence` property.",
+                    msg = (
+                        f"Edge {_id if _id else (_src, _tar)} does not have a `licence` property."
                         " This is required in strict mode.",
                     )
+                    logger.error(msg)
+                    raise ValueError(msg)
 
             # match the input label (_type) to
             # a Biolink label from schema_config # FIXME this may be any ontology, remove comment?
@@ -295,11 +304,11 @@ class Translator:
         self._log_finish_translate("edges")
 
     def _record_no_type(self, _type: Any, what: Any) -> None:
-        """
-        Records the type of a node or edge that is not represented in the
-        schema_config.
-        """
+        """Record the type of a non-represented node or edge.
 
+        In case of an entity that is not represented in the schema_config,
+        record the type and the entity.
+        """
         logger.error(f"No ontology type defined for `{_type}`: {what}")
 
         if self.notype.get(_type, None):
@@ -309,11 +318,11 @@ class Translator:
             self.notype[_type] = 1
 
     def get_missing_biolink_types(self) -> dict:
-        """
-        Returns a dictionary of types that were not represented in the
-        schema_config.
-        """
+        """Return a dictionary of non-represented types.
 
+        The dictionary contains the type as the key and the number of
+        occurrences as the value.
+        """
         return self.notype
 
     @staticmethod
@@ -327,12 +336,10 @@ class Translator:
         logger.debug(f"Finished translating {what} to BioCypher.")
 
     def _update_ontology_types(self):
-        """
-        Creates a dictionary to translate from input labels to ontology labels.
+        """Create a dictionary to translate from input to ontology labels.
 
         If multiple input labels, creates mapping for each.
         """
-
         self._ontology_mapping = {}
 
         for key, value in self.ontology.mapping.extended_schema.items():
@@ -351,47 +358,45 @@ class Translator:
             else:
                 self._add_translation_mappings(labels, key)
 
-    def _get_ontology_mapping(self, label: str) -> Optional[str]:
-        """
+    def _get_ontology_mapping(self, label: str) -> str | None:
+        """Find the ontology class for the given input type.
+
         For each given input type ("input_label" or "label_in_input"), find the
         corresponding ontology class in the leaves dictionary (from the
         `schema_config.yam`).
 
         Args:
+        ----
             label:
                 The input type to find (`input_label` or `label_in_input` in
                 `schema_config.yaml`).
+
         """
         # FIXME does not seem like a necessary function.
         # commented out until behaviour of _update_bl_types is fixed
         return self._ontology_mapping.get(label, None)
 
     def translate_term(self, term):
-        """
-        Translate a single term.
-        """
-
+        """Translate a single term."""
         return self.mappings.get(term, None)
 
     def reverse_translate_term(self, term):
-        """
-        Reverse translate a single term.
-        """
-
+        """Reverse translate a single term."""
         return self.reverse_mappings.get(term, None)
 
     def translate(self, query):
-        """
-        Translate a cypher query. Only translates labels as of now.
+        """Translate a cypher query.
+
+        Only translates labels as of now.
         """
         for key in self.mappings:
             query = query.replace(":" + key, ":" + self.mappings[key])
         return query
 
     def reverse_translate(self, query):
-        """
-        Reverse translate a cypher query. Only translates labels as of
-        now.
+        """Reverse translate a cypher query.
+
+        Only translates labels as of now.
         """
         for key in self.reverse_mappings:
             a = ":" + key + ")"
@@ -399,12 +404,14 @@ class Translator:
             # TODO this conditional probably does not cover all cases
             if a in query or b in query:
                 if isinstance(self.reverse_mappings[key], list):
-                    raise NotImplementedError(
+                    msg = (
                         "Reverse translation of multiple inputs not "
                         "implemented yet. Many-to-one mappings are "
                         "not reversible. "
                         f"({key} -> {self.reverse_mappings[key]})",
                     )
+                    logger.error(msg)
+                    raise NotImplementedError(msg)
                 else:
                     query = query.replace(
                         a,
@@ -413,10 +420,10 @@ class Translator:
         return query
 
     def _add_translation_mappings(self, original_name, biocypher_name):
-        """
-        Add translation mappings for a label and name. We use here the
-        PascalCase version of the BioCypher name, since sentence case is
-        not useful for Cypher queries.
+        """Add translation mappings for a label and name.
+
+        We use here the PascalCase version of the BioCypher name, since
+        sentence case is not useful for Cypher queries.
         """
         if isinstance(original_name, list):
             for on in original_name:
@@ -444,9 +451,7 @@ class Translator:
 
     @staticmethod
     def name_sentence_to_pascal(name: str) -> str:
-        """
-        Converts a name in sentence case to pascal case.
-        """
+        """Convert a name in sentence case to pascal case."""
         # split on dots if dot is present
         if "." in name:
             return ".".join(

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -228,7 +228,7 @@ class Translator:
                     raise ValueError(msg)
 
             # match the input label (_type) to
-            # a Biolink label from schema_config # FIXME this may be any ontology, remove comment?
+            # an ontology label from schema_config
             bl_type = self._get_ontology_mapping(_type)
 
             if bl_type:

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -219,7 +219,7 @@ class Translator:
                     )
 
             # match the input label (_type) to
-            # a Biolink label from schema_config
+            # a Biolink label from schema_config # FIXME this may be any ontology, remove comment?
             bl_type = self._get_ontology_mapping(_type)
 
             if bl_type:
@@ -300,7 +300,7 @@ class Translator:
         schema_config.
         """
 
-        logger.debug(f"No ontology type defined for `{_type}`: {what}")
+        logger.error(f"No ontology type defined for `{_type}`: {what}")
 
         if self.notype.get(_type, None):
             self.notype[_type] += 1
@@ -362,7 +362,7 @@ class Translator:
                 The input type to find (`input_label` or `label_in_input` in
                 `schema_config.yaml`).
         """
-
+        # FIXME does not seem like a necessary function.
         # commented out until behaviour of _update_bl_types is fixed
         return self._ontology_mapping.get(label, None)
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -1,3 +1,5 @@
+"""Abstract base class for all batch writers."""
+
 import glob
 import os
 import re

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -125,6 +125,7 @@ class _BatchWriter(_Writer, ABC):
         rdf_format: str = None,
         rdf_namespaces: dict = {},
         labels_order: str = "Ascending",
+        **kwargs,
     ):
         """Abtract parent class for writing node and edge representations to disk
         using the format specified by each database type. The database-specific

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -148,7 +148,7 @@ class _BatchWriter(_Writer, ABC):
         db_password: str = None,
         db_host: str = None,
         db_port: str = None,
-        rdf_format: str = None,
+        file_format: str = None,
         rdf_namespaces: dict = {},
         labels_order: str = "Ascending",
         **kwargs,
@@ -234,7 +234,7 @@ class _BatchWriter(_Writer, ABC):
             db_port:
                 The database port.
 
-            rdf_format:
+            file_format:
                 The format of RDF.
 
             rdf_namespaces:
@@ -256,7 +256,7 @@ class _BatchWriter(_Writer, ABC):
         self.db_password = db_password
         self.db_host = db_host or "localhost"
         self.db_port = db_port
-        self.rdf_format = rdf_format
+        self.file_format = file_format
         self.rdf_namespaces = rdf_namespaces
 
         self.delim, self.escaped_delim = self._process_delimiter(delimiter)

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -18,30 +18,37 @@ from biocypher.output.write._writer import _Writer
 
 
 class _BatchWriter(_Writer, ABC):
-    """Abstract batch writer class"""
+    """Abstract batch writer class."""
 
     @abstractmethod
     def _quote_string(self, value: str) -> str:
-        """Abstract method to quote a string. Escaping is handled by the database-specific writer."""
-        raise NotImplementedError(
-            "Database writer must override '_quote_string'",
-        )
+        """Quote a string.
+
+        Escaping is handled by the database-specific writer.
+        """
+        msg = "Database writer must override '_quote_string'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _get_default_import_call_bin_prefix(self):
-        """Abstract method to provide the default string for the import call bin prefix.
+        """Provide the default string for the import call bin prefix.
 
         Returns
         -------
             str: The database-specific string for the path to the import call bin prefix
 
         """
-        raise NotImplementedError("Database writer must override '_get_default_import_call_bin_prefix'")
+        msg = "Database writer must override '_get_default_import_call_bin_prefix'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _write_array_string(self, string_list):
-        """Abstract method to write the string representation of an array into a .csv file.
-        Different databases require different formats of array to optimize import speed.
+        """Write the string representation of an array into a .csv file.
+
+        Different databases require different formats of array to optimize
+        import speed.
 
         Args:
         ----
@@ -52,50 +59,65 @@ class _BatchWriter(_Writer, ABC):
             str: The database-specific string representation of an array
 
         """
-        raise NotImplementedError("Database writer must override '_write_array_string'")
+        msg = "Database writer must override '_write_array_string'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _write_node_headers(self):
-        """Abstract method that takes care of importing properties of a graph entity that is represented
-        as a node as per the definition in the `schema_config.yaml`
+        """Write header files for nodes.
+
+        Write header files (node properties) for nodes as per the
+        definition in the `schema_config.yaml`.
 
         Returns
         -------
             bool: The return value. True for success, False otherwise.
 
         """
-        raise NotImplementedError("Database writer must override '_write_node_headers'")
+        msg = "Database writer must override '_write_node_headers'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _write_edge_headers(self):
-        """Abstract method to write a database import-file for a graph entity that is represented
-        as an edge as per the definition in the `schema_config.yaml`,
-        containing only the header for this type of edge.
+        """Write a database import-file for an edge.
+
+        Write a database import-file for an edge as per the definition in
+        the `schema_config.yaml`, containing only the header for this type
+        of edge.
 
         Returns
         -------
             bool: The return value. True for success, False otherwise.
 
         """
-        raise NotImplementedError("Database writer must override '_write_edge_headers'")
+        msg = "Database writer must override '_write_edge_headers'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _construct_import_call(self) -> str:
-        """Function to construct the import call detailing folder and
-        individual node and edge headers and data files, as well as
-        delimiters and database name. Built after all data has been
-        processed to ensure that nodes are called before any edges.
+        """Construct the import call.
+
+        Construct the import call detailing folder and individual node and
+        edge headers and data files, as well as delimiters and database name.
+        Built after all data has been processed to ensure that nodes are
+        called before any edges.
 
         Returns
         -------
             str: A bash command for csv import.
 
         """
-        raise NotImplementedError("Database writer must override '_construct_import_call'")
+        msg = "Database writer must override '_construct_import_call'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def _get_import_script_name(self) -> str:
-        """Returns the name of the import script.
+        """Return the name of the import script.
+
         The name will be chosen based on the used database.
 
         Returns
@@ -103,7 +125,9 @@ class _BatchWriter(_Writer, ABC):
             str: The name of the import script (ending in .sh)
 
         """
-        raise NotImplementedError("Database writer must override '_get_import_script_name'")
+        msg = "Database writer must override '_get_import_script_name'"
+        logger.error(msg)
+        raise NotImplementedError(msg)
 
     def __init__(
         self,
@@ -129,7 +153,9 @@ class _BatchWriter(_Writer, ABC):
         labels_order: str = "Ascending",
         **kwargs,
     ):
-        """Abtract parent class for writing node and edge representations to disk
+        """Write node and edge representations to disk.
+
+        Abstract parent class for writing node and edge representations to disk
         using the format specified by each database type. The database-specific
         functions are implemented by the respective child-classes. This abstract
         class contains all methods expected by a bach writer instance, some of
@@ -183,7 +209,8 @@ class _BatchWriter(_Writer, ABC):
                 call.
 
             wipe:
-                Whether to force import (removing existing DB content). (Specific to Neo4j.)
+                Whether to force import (removing existing DB content).
+                    (Specific to Neo4j.)
 
             strict_mode:
                 Whether to enforce source, version, and license properties.
@@ -280,8 +307,16 @@ class _BatchWriter(_Writer, ABC):
             return self._import_call_file_prefix
 
     def _process_delimiter(self, delimiter: str) -> str:
-        """Return escaped characters in case of receiving their string
-        representation (e.g. tab for '\t').
+        """Process a delimited to escape correctly.
+
+        Args:
+        ----
+            delimiter (str): The delimiter to process.
+
+        Returns:
+        -------
+            tuple: The delimiter and its escaped representation.
+
         """
         if delimiter == "\\t":
             return "\t", "\\t"
@@ -290,7 +325,7 @@ class _BatchWriter(_Writer, ABC):
             return delimiter, delimiter
 
     def write_nodes(self, nodes, batch_size: int = int(1e6), force: bool = False):
-        """Wrapper for writing nodes and their headers.
+        """Write nodes and their headers.
 
         Args:
         ----
@@ -328,7 +363,7 @@ class _BatchWriter(_Writer, ABC):
         edges: list | GeneratorType,
         batch_size: int = int(1e6),
     ) -> bool:
-        """Wrapper for writing edges and their headers.
+        """Write edges and their headers.
 
         Args:
         ----
@@ -390,12 +425,13 @@ class _BatchWriter(_Writer, ABC):
         return True
 
     def _write_node_data(self, nodes, batch_size, force: bool = False):
-        """Writes biocypher nodes to CSV conforming to the headers created
-        with `_write_node_headers()`, and is actually required to be run
-        before calling `_write_node_headers()` to set the
-        :py:attr:`self.node_property_dict` for passing the node properties
-        to the instance. Expects list or generator of nodes from the
-        :py:class:`BioCypherNode` class.
+        """Write biocypher nodes to CSV.
+
+        Conforms to the headers created with `_write_node_headers()`, and
+        is actually required to be run before calling `_write_node_headers()`
+        to set the :py:attr:`self.node_property_dict` for passing the node
+        properties to the instance. Expects list or generator of nodes from
+        the :py:class:`BioCypherNode` class.
 
         Args:
         ----
@@ -574,7 +610,9 @@ class _BatchWriter(_Writer, ABC):
         prop_dict: dict,
         labels: str,
     ):
-        """This function takes one list of biocypher nodes and writes them
+        """Write a list of biocypher nodes to a CSV file.
+
+        This function takes one list of biocypher nodes and writes them
         to a Neo4j admin import compatible CSV file.
 
         Args:
@@ -658,7 +696,9 @@ class _BatchWriter(_Writer, ABC):
         return True
 
     def _write_edge_data(self, edges, batch_size):
-        """Writes biocypher edges to CSV conforming to the headers created
+        """Write biocypher edges to CSV.
+
+        Writes biocypher edges to CSV conforming to the headers created
         with `_write_edge_headers()`, and is actually required to be run
         before calling `_write_node_headers()` to set the
         :py:attr:`self.edge_property_dict` for passing the edge
@@ -807,7 +847,9 @@ class _BatchWriter(_Writer, ABC):
         label: str,
         prop_dict: dict,
     ):
-        """This function takes one list of biocypher edges and writes them
+        """Write a list of biocypher edges to a CSV file.
+
+        This function takes one list of biocypher edges and writes them
         to a Neo4j admin import compatible CSV file.
 
         Args:
@@ -926,7 +968,7 @@ class _BatchWriter(_Writer, ABC):
         return True
 
     def _write_next_part(self, label: str, lines: list):
-        """This function writes a list of strings to a new part file.
+        """Write a list of strings to a new part file.
 
         Args:
         ----
@@ -978,9 +1020,10 @@ class _BatchWriter(_Writer, ABC):
             self.parts[label].append(part)
 
     def get_import_call(self) -> str:
-        """Function to return the import call detailing folder and
-        individual node and edge headers and data files, as well as
-        delimiters and database name.
+        """Eeturn the import call.
+
+        Return the import call detailing folder and individual node and
+        edge headers and data files, as well as delimiters and database name.
 
         Returns
         -------
@@ -990,7 +1033,9 @@ class _BatchWriter(_Writer, ABC):
         return self._construct_import_call()
 
     def write_import_call(self) -> str:
-        """Function to write the import call detailing folder and
+        """Write the import call.
+
+        Function to write the import call detailing folder and
         individual node and edge headers and data files, as well as
         delimiters and database name, to the export folder as txt.
 
@@ -1009,9 +1054,10 @@ class _BatchWriter(_Writer, ABC):
 
 
 def parse_label(label: str) -> str:
-    """Check if the label is compliant with Neo4j naming conventions,
-    https://neo4j.com/docs/cypher-manual/current/syntax/naming/, and if not,
-    remove non-compliant characters.
+    """Check if the label is compliant with Neo4j naming conventions.
+
+    Check against https://neo4j.com/docs/cypher-manual/current/syntax/naming/,
+    and if not compliant, remove non-compliant characters.
 
     Args:
     ----

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -1,19 +1,6 @@
-"""
-BioCypher 'offline' module. Handles the writing of node and edge representations
+"""BioCypher 'offline' module. Handles the writing of node and edge representations
 suitable for import into a DBMS.
 """
-
-from biocypher._logger import logger
-from biocypher.output.write.graph._rdf import _RDFWriter
-from biocypher.output.write.graph._owl import _OWLWriter
-from biocypher.output.write.graph._neo4j import _Neo4jBatchWriter
-from biocypher.output.write.graph._arangodb import _ArangoDBBatchWriter
-from biocypher.output.write.graph._networkx import _NetworkXWriter
-from biocypher.output.write.relational._csv import _PandasCSVWriter
-from biocypher.output.write.relational._sqlite import _SQLiteBatchWriter
-from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
-
-logger.debug(f"Loading module {__name__}.")
 
 from typing import TYPE_CHECKING
 
@@ -22,6 +9,7 @@ from biocypher._logger import logger
 from biocypher.output.write.graph._arangodb import _ArangoDBBatchWriter
 from biocypher.output.write.graph._neo4j import _Neo4jBatchWriter
 from biocypher.output.write.graph._networkx import _NetworkXWriter
+from biocypher.output.write.graph._owl import _OWLWriter
 from biocypher.output.write.graph._rdf import _RDFWriter
 from biocypher.output.write.relational._csv import _PandasCSVWriter
 from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
@@ -69,11 +57,11 @@ def get_writer(
     output_directory: str,
     strict_mode: bool,
 ):
-    """
-    Function to return the writer class based on the selection in the config
+    """Function to return the writer class based on the selection in the config
     file.
 
     Args:
+    ----
         dbms: the database management system; for options, see DBMS_TO_CLASS.
         translator: the Translator object.
         deduplicator: the Deduplicator object.
@@ -81,9 +69,10 @@ def get_writer(
         strict_mode: whether to use strict mode.
 
     Returns:
+    -------
         instance: an instance of the selected writer class.
-    """
 
+    """
     dbms_config = _config(dbms)
 
     writer = DBMS_TO_CLASS[dbms]

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -3,6 +3,18 @@ BioCypher 'offline' module. Handles the writing of node and edge representations
 suitable for import into a DBMS.
 """
 
+from biocypher._logger import logger
+from biocypher.output.write.graph._rdf import _RDFWriter
+from biocypher.output.write.graph._owl import _OWLWriter
+from biocypher.output.write.graph._neo4j import _Neo4jBatchWriter
+from biocypher.output.write.graph._arangodb import _ArangoDBBatchWriter
+from biocypher.output.write.graph._networkx import _NetworkXWriter
+from biocypher.output.write.relational._csv import _PandasCSVWriter
+from biocypher.output.write.relational._sqlite import _SQLiteBatchWriter
+from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
+
+logger.debug(f"Loading module {__name__}.")
+
 from typing import TYPE_CHECKING
 
 from biocypher._config import config as _config
@@ -37,6 +49,8 @@ DBMS_TO_CLASS = {
     "sqlite3": _SQLiteBatchWriter,
     "rdf": _RDFWriter,
     "RDF": _RDFWriter,
+    "owl": _OWLWriter,
+    "OWL": _OWLWriter,
     "csv": _PandasCSVWriter,
     "CSV": _PandasCSVWriter,
     "pandas": _PandasCSVWriter,
@@ -97,4 +111,5 @@ def get_writer(
             db_port=dbms_config.get("port"),  # psql
             rdf_format=dbms_config.get("rdf_format"),  # rdf
             rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf
+            edge_model=dbms_config.get("edge_model"),  # owl
         )

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -79,6 +79,15 @@ def get_writer(
 
     writer = DBMS_TO_CLASS[dbms]
 
+    if "rdf_format" in dbms_config:
+        logger.warning("The 'rdf_format' config option is deprecated, use 'file_format' instead.")
+        if "file_format" not in dbms_config:
+            format = dbms_config["rdf_format"]
+            logger.warning(f"I will set 'file_format: {format}' for you.")
+            dbms_config["file_format"] = format
+            dbms_config.pop("rdf_format")
+        logger.warning("NOTE: this warning will become an error in next versions.")
+
     if not writer:
         msg = f"Unknown dbms: {dbms}"
         raise ValueError(msg)
@@ -101,8 +110,8 @@ def get_writer(
             db_user=dbms_config.get("user"),  # psql
             db_password=dbms_config.get("password"),  # psql
             db_port=dbms_config.get("port"),  # psql
-            rdf_format=dbms_config.get("rdf_format"),  # rdf
-            rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf
+            file_format=dbms_config.get("file_format"),  # rdf, owl
+            rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf, owl
             edge_model=dbms_config.get("edge_model"),  # owl
         )
     return None

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -1,11 +1,14 @@
-"""BioCypher 'offline' module. Handles the writing of node and edge representations
-suitable for import into a DBMS.
+"""BioCypher 'offline' module.
+
+Handles the writing of node and edge representations suitable for import into a
+DBMS.
 """
 
 from typing import TYPE_CHECKING
 
 from biocypher._config import config as _config
 from biocypher._logger import logger
+from biocypher.output.write._batch_writer import _BatchWriter
 from biocypher.output.write.graph._arangodb import _ArangoDBBatchWriter
 from biocypher.output.write.graph._neo4j import _Neo4jBatchWriter
 from biocypher.output.write.graph._networkx import _NetworkXWriter
@@ -56,9 +59,8 @@ def get_writer(
     deduplicator: "Deduplicator",
     output_directory: str,
     strict_mode: bool,
-):
-    """Function to return the writer class based on the selection in the config
-    file.
+) -> _BatchWriter | None:
+    """Return the writer class based on the selection in the config file.
 
     Args:
     ----
@@ -78,7 +80,8 @@ def get_writer(
     writer = DBMS_TO_CLASS[dbms]
 
     if not writer:
-        raise ValueError(f"Unknown dbms: {dbms}")
+        msg = f"Unknown dbms: {dbms}"
+        raise ValueError(msg)
 
     if writer is not None:
         return writer(
@@ -102,3 +105,4 @@ def get_writer(
             rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf
             edge_model=dbms_config.get("edge_model"),  # owl
         )
+    return None

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -1,7 +1,7 @@
-"""BioCypher 'offline' module.
+"""Module to provide one of the available writer classes.
 
-Handles the writing of node and edge representations suitable for import into a
-DBMS.
+The writer classes are responsible for writing the node and edge representations
+to disk in a format suitable for import into a DBMS.
 """
 
 from typing import TYPE_CHECKING

--- a/biocypher/output/write/graph/_arangodb.py
+++ b/biocypher/output/write/graph/_arangodb.py
@@ -1,3 +1,5 @@
+"""Module to provide the ArangoDB writer class."""
+
 import os
 
 from biocypher._logger import logger
@@ -5,38 +7,43 @@ from biocypher.output.write.graph._neo4j import _Neo4jBatchWriter
 
 
 class _ArangoDBBatchWriter(_Neo4jBatchWriter):
-    """
-    Class for writing node and edge representations to disk using the format
-    specified by ArangoDB for the use of "arangoimport". Output files are
-    similar to Neo4j, but with a different header format.
+    """Class for writing node and edge representations to disk.
+
+    Uses the format specified by ArangoDB for the use of "arangoimport".
+    Output files are similar to Neo4j, but with a different header format.
     """
 
     def _get_default_import_call_bin_prefix(self):
-        """
-        Method to provide the default string for the import call bin prefix.
+        """Provide the default string for the import call bin prefix.
 
-        Returns:
+        Returns
+        -------
             str: The default location for the neo4j admin import location
+
         """
         return ""
 
     def _get_import_script_name(self) -> str:
-        """
-        Returns the name of the neo4j admin import script
+        """Return the name of the neo4j admin import script.
 
-        Returns:
+        Returns
+        -------
             str: The name of the import script (ending in .sh)
+
         """
         return "arangodb-import-call.sh"
 
     def _write_node_headers(self):
-        """
-        Writes single CSV file for a graph entity that is represented
-        as a node as per the definition in the `schema_config.yaml`,
-        containing only the header for this type of node.
+        """Write single CSV file for a graph entity.
 
-        Returns:
+        The graph entity is represented as a node as per the definition
+        in the `schema_config.yaml`, containing only the header for this type
+        of node.
+
+        Returns
+        -------
             bool: The return value. True for success, False otherwise.
+
         """
         # load headers from data parse
         if not self.node_property_dict:
@@ -86,9 +93,9 @@ class _ArangoDBBatchWriter(_Neo4jBatchWriter):
             parts = self.parts.get(label, [])
 
             if not parts:
-                raise ValueError(
-                    f"No parts found for node label {label}. " f"Check that the data was parsed first.",
-                )
+                msg = f"No parts found for node label {label}. Check that the data was parsed first."
+                logger.error(msg)
+                raise ValueError(msg)
 
             for part in parts:
                 import_call_header_path = os.path.join(
@@ -105,19 +112,22 @@ class _ArangoDBBatchWriter(_Neo4jBatchWriter):
                         import_call_header_path,
                         import_call_parts_path,
                         collection,
-                    )
+                    ),
                 )
 
         return True
 
     def _write_edge_headers(self):
-        """
-        Writes single CSV file for a graph entity that is represented
-        as an edge as per the definition in the `schema_config.yaml`,
-        containing only the header for this type of edge.
+        """Write single CSV file for a graph entity.
 
-        Returns:
+        The graph entity is represented as an edge as per the definition
+        in the `schema_config.yaml`, containing only the header for this type
+        of edge.
+
+        Returns
+        -------
             bool: The return value. True for success, False otherwise.
+
         """
         # load headers from data parse
         if not self.edge_property_dict:
@@ -182,22 +192,24 @@ class _ArangoDBBatchWriter(_Neo4jBatchWriter):
                     header_import_call_path,
                     parts_import_call_path,
                     collection,
-                )
+                ),
             )
 
         return True
 
     def _construct_import_call(self) -> str:
-        """
-        Function to construct the import call detailing folder and
-        individual node and edge headers and data files, as well as
-        delimiters and database name. Built after all data has been
+        """Construct the import call.
+
+        Details folder and individual node and edge headers and data files,
+        as well as delimiters and database name. Built after all data has been
         processed to ensure that nodes are called before any edges.
 
-        Returns:
-            str: a bash command for neo4j-admin import
+        Returns
+        -------
+            str: a bash command for arangoimport
+
         """
-        import_call = f"{self.import_call_bin_prefix}arangoimp " f"--type csv " f'--separator="{self.escaped_delim}" '
+        import_call = f"{self.import_call_bin_prefix}arangoimp --type csv " f'--separator="{self.escaped_delim}" '
 
         if self.quote == "'":
             import_call += f'--quote="{self.quote}" '

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -1,3 +1,5 @@
+"""Module to provide the Neo4j writer class."""
+
 import os
 
 from biocypher._logger import logger
@@ -45,10 +47,7 @@ class _Neo4jBatchWriter(_BatchWriter):
         return "bin/"
 
     def _quote_string(self, value: str) -> str:
-        """
-        Quote a string. Quote character is escaped by doubling it.
-        """
-
+        """Quote a string. Quote character is escaped by doubling it."""
         return f"{self.quote}{value.replace(self.quote, self.quote * 2)}{self.quote}"
 
     def _write_array_string(self, string_list):

--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# Copyright 2021, Heidelberg University Clinic
-# Copyright 2025, Institut Pasteur
-#
-# File author(s):  Loes van den Biggelaar
-#                  Sebastian Lobentanzer
-#                  Johann Dreo
-#
-# Distributed under MIT licence, see the file `LICENSE`.
-#
 """Module to provide the OWL writer class."""
 import os
 
@@ -251,8 +240,8 @@ class _OWLWriter(_RDFWriter):
         Returns:
         -------
             bool: True for success, False otherwise.
-        """
 
+        """
         # NOTE: despite its name, this function does not write to file,
         #       but to self.graph.
         # NOTE: labels and prop_dict are not used.
@@ -397,7 +386,6 @@ class _OWLWriter(_RDFWriter):
             bool: True for success, False otherwise.
 
         """
-
         # NOTE: despite its name, this function does not write to file,
         #       but to self.graph.
         # NOTE: prop_dict is not used.

--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -250,9 +250,11 @@ class _OWLWriter(_RDFWriter):
         Returns:
         -------
             bool: True for success, False otherwise.
-
         """
-        # FIXME labels and prop_dict are not used.
+
+        # NOTE: despite its name, this function does not write to file,
+        #       but to self.graph.
+        # NOTE: labels and prop_dict are not used.
 
         if not all(isinstance(n, BioCypherNode) for n in node_list):
             logger.error("Nodes must be passed as type BioCypherNode.")
@@ -394,7 +396,10 @@ class _OWLWriter(_RDFWriter):
             bool: True for success, False otherwise.
 
         """
-        # FIXME prop_dict is not used.
+
+        # NOTE: despite its name, this function does not write to file,
+        #       but to self.graph.
+        # NOTE: prop_dict is not used.
 
         if not all(isinstance(n, BioCypherEdge) for n in edge_list):
             logger.error("Edges must be passed as type BioCypherEdge.")

--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -94,7 +94,7 @@ class _OWLWriter(_RDFWriter):
         db_password: str = None,
         db_host: str = None,
         db_port: str = None,
-        rdf_format: str = None,
+        file_format: str = None,
         rdf_namespaces: dict = {},
         labels_order: str = "Ascending",
         edge_model: str = "Association",
@@ -162,7 +162,7 @@ class _OWLWriter(_RDFWriter):
             db_port:
                 The database port.
 
-            rdf_format:
+            file_format:
                 The format of RDF.
 
             rdf_namespaces:
@@ -175,7 +175,7 @@ class _OWLWriter(_RDFWriter):
 
             file_stem:
                 The stem (name without the path and extension) of the output
-                OWL file. The extension is determined from `rdf_format`.
+                OWL file. The extension is determined from `file_format`.
 
         """
         super().__init__(
@@ -196,9 +196,10 @@ class _OWLWriter(_RDFWriter):
             db_password=db_password,
             db_host=db_host,
             db_port=db_port,
-            rdf_format=rdf_format,
+            file_format=file_format,
             rdf_namespaces=rdf_namespaces,
             labels_order=labels_order,
+            **kwargs,
         )
 
         # Starts with the loaded ontologies RDF graph,
@@ -577,4 +578,4 @@ class _OWLWriter(_RDFWriter):
         if self._has_nodes and self._has_edges:
             file_name = os.path.join(self.outdir, f"{self.file_stem}.{self.extension}")
             logger.info(f"Writing {len(self.graph)} terms to {file_name}")
-            self.graph.serialize(destination=file_name, format=self.rdf_format)
+            self.graph.serialize(destination=file_name, format=self.file_format)

--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python
+#
+# Copyright 2021, Heidelberg University Clinic
+# Copyright 2025, Institut Pasteur
+#
+# File author(s):  Loes van den Biggelaar
+#                  Sebastian Lobentanzer
+#                  Johann Dreo
+#
+# Distributed under MIT licence, see the file `LICENSE`.
+#
+"""
+BioCypher 'offline' module. Handles the writing of node and edge representations
+suitable for import into a DBMS.
+"""
+import os
+
+from types import GeneratorType
+from typing import Optional, Union
+from urllib.parse import quote_plus as url_quote
+
+from rdflib import (
+    OWL,
+    RDF,
+    RDFS,
+    Literal,
+)
+
+from biocypher._create import BioCypherEdge, BioCypherNode
+from biocypher._deduplicate import Deduplicator
+from biocypher._logger import logger
+from biocypher._translate import Translator
+from biocypher.output.write.graph._rdf import _RDFWriter
+
+
+class _OWLWriter(_RDFWriter):
+    """
+    Class to write BioCypher's graph into a self-contained OWL file.
+    The resulting OWL file contains both the input vocabulary and
+    the output instances.
+
+    The behavior rely mainly on the `edge_model` parameter,
+    which can takes two values:
+
+    - "ObjectProperty", which translates BioCypher's edges into
+      OWL's object properties (if they are available under the
+      selected root term). Object properties are the natural way
+      to model edges in OWL, but they do not support annotation,
+      thus being incompatible with having BioCypher's properties
+      on edges.
+      As most of OWL files do not model a common term on top of both
+      owl:topObjectProperty and owl:Thing, you may need to ensure
+      that the input OWL contains a common ancestor honoring both:
+
+      - owl:Thing rdfs:subClassOf <root_node>
+      - owl:topObjectProperty rdfs:subPropertyOf <root_node>
+
+      and that you select it in your BioCypher configuration.
+    - "Association" (the default), which translates BioCypher's
+      edges into OWL's class instances. Those edges instances are
+      inserted inbetween the instances coming from BioCypher's nodes.
+      This allows to keep edges properties, but adds OWL instances
+      to model relationships, which does not follow the classical
+      OWL model. In this approach, all OWL instances are linked
+      with a generic "edge_source" (linking source instance to
+      the association instance) and "edge_target" (linking the association
+      instance to the target instance). Both of which inherits from "edge",
+      and are in the biocypher namespace.
+
+    This class takes care of keeping the vocabulary underneath the
+    selected root node and exports it along the instances in the
+    resulting OWL file. It discards whatever terms are not in the
+    tree below the selected root node.
+
+    To output a valid self-contained OWL file, it is required that
+    you call *both* `write_nodes` *and* `write_edges`.
+
+    This class heavily rely on the _RDFWriter class interface and code.
+    """
+
+    def __init__(
+        self,
+        translator: Translator,
+        deduplicator: Deduplicator,
+        delimiter: str,
+        array_delimiter: str = ",",
+        quote: str = '"',
+        output_directory: Optional[str] = None,
+        db_name: str = "neo4j",
+        import_call_bin_prefix: Optional[str] = None,
+        import_call_file_prefix: Optional[str] = None,
+        wipe: bool = True,
+        strict_mode: bool = False,
+        skip_bad_relationships: bool = False,
+        skip_duplicate_nodes: bool = False,
+        db_user: str = None,
+        db_password: str = None,
+        db_host: str = None,
+        db_port: str = None,
+        rdf_format: str = None,
+        rdf_namespaces: dict = {},
+        labels_order: str = "Ascending",
+        edge_model: str = "Association",
+        file_stem: str = "biocypher",
+        **kwargs,
+    ):
+        """Constructor.
+
+        Args:
+        ----
+            translator:
+                Instance of :py:class:`Translator` to enable translation of
+                nodes and manipulation of properties.
+
+            deduplicator:
+                Instance of :py:class:`Deduplicator` to enable deduplication
+                of nodes and edges.
+
+            delimiter:
+                The delimiter to use for the CSV files.
+
+            array_delimiter:
+                The delimiter to use for array properties.
+
+            quote:
+                The quote character to use for the CSV files.
+
+            output_directory:
+                Path for exporting CSV files.
+
+            db_name:
+                Name of the database that will be used in the generated
+                commands.
+
+            import_call_bin_prefix:
+                Path prefix for the admin import call binary.
+
+            import_call_file_prefix:
+                Path prefix for the data files (headers and parts) in the import
+                call.
+
+            wipe:
+                Whether to force import (removing existing DB content). (Specific to Neo4j.)
+
+            strict_mode:
+                Whether to enforce source, version, and license properties.
+
+            skip_bad_relationships:
+                Whether to skip relationships that do not have a valid
+                start and end node. (Specific to Neo4j.)
+
+            skip_duplicate_nodes:
+                Whether to skip duplicate nodes. (Specific to Neo4j.)
+
+            db_user:
+                The database user.
+
+            db_password:
+                The database password.
+
+            db_host:
+                The database host. Defaults to localhost.
+
+            db_port:
+                The database port.
+
+            rdf_format:
+                The format of RDF.
+
+            rdf_namespaces:
+                The namespaces for RDF.
+
+            edge_model:
+                Whether to model an edge as OWL's "ObjectProperty" (discards edges properties)
+                or "Association" (adds an intermediate node that holds the edge properties).
+
+            file_stem:
+                The stem (name without the path and extension) of the output
+                OWL file. The extension is determined from `rdf_format`.
+        """
+
+        super().__init__(
+            translator=translator,
+            deduplicator=deduplicator,
+            delimiter=delimiter,
+            array_delimiter=array_delimiter,
+            quote=quote,
+            output_directory=output_directory,
+            db_name=db_name,
+            import_call_bin_prefix=import_call_bin_prefix,
+            import_call_file_prefix=import_call_file_prefix,
+            wipe=wipe,
+            strict_mode=strict_mode,
+            skip_bad_relationships=skip_bad_relationships,
+            skip_duplicate_nodes=skip_duplicate_nodes,
+            db_user=db_user,
+            db_password=db_password,
+            db_host=db_host,
+            db_port=db_port,
+            rdf_format=rdf_format,
+            rdf_namespaces=rdf_namespaces,
+            labels_order=labels_order,
+        )
+
+        # Starts with the loaded ontologies RDF graph,
+        # so as to keep the declared vocabulary.
+        self.graph = self.translator.ontology.get_rdf_graph()
+        self._init_namespaces(self.graph)
+
+        # Write guards because Biocypher has `write_nodes` and `write_edges`,
+        # but not `write`, so we need to ensure to call both.
+        self._has_nodes = False
+        self._has_edges = False
+
+        self.edge_models = ["Association", "ObjectProperty"]
+        if edge_model not in self.edge_models:
+            raise ValueError(
+                f"`edge_model` cannot be '{edge_model}', but should be either: {' or '.join(self.edge_models)}"
+            )
+        self.edge_model = edge_model
+
+        self.file_stem = file_stem
+
+    def _write_single_node_list_to_file(
+        self,
+        node_list: list,
+        label: str,
+        prop_dict: dict,
+        labels: str,
+    ):
+        """
+        This function takes a list of BioCypherNodes
+        and save them in self.graph.
+        It re-uses RDFWriter's machinery, hence the
+        misleading name.
+
+        Nodes are modelled as class instances, being
+        also owl:NamedIndividual.
+
+        Args:
+            node_list (list): A list of BioCypherNodes to be written.
+
+            label (str): The label (type) of the nodes.
+
+            prop_dict (dict): A dictionary of properties and their types for the node class.
+
+            labels (str): string of one or several concatenated labels
+
+        Returns:
+            bool: True for success, False otherwise.
+        """
+
+        # FIXME labels and prop_dict are not used.
+
+        if not all(isinstance(n, BioCypherNode) for n in node_list):
+            logger.error("Nodes must be passed as type BioCypherNode.")
+            return False
+
+        # Cache for terms with specific namespaces.
+        already_found = {}
+
+        for n in node_list:
+            rdf_subject = url_quote(n.get_id())
+            properties = n.get_properties()
+            logger.debug(f"Node Class: [{rdf_subject}]")
+
+            all_labels = list(reversed(list(self.translator.ontology.get_ancestors(n.get_label()).nodes)))
+            logger.debug(f"\tVocabulary ancestors: {all_labels}")
+
+            # Create types in ancestors that would not exist in the vocabulary.
+            # For those that exists, get the URI (and thus the correct namespace).
+            for ancestor, current_class in zip(all_labels, all_labels[1:]):
+                logger.debug(f"\t\t'{current_class}' is_a '{ancestor}'")
+                ancestor_label = self.translator.name_sentence_to_pascal(ancestor)
+                current_label = self.translator.name_sentence_to_pascal(current_class)
+
+                # Fast search using default (or biocypher, if no default) namespace.
+                rdf_currents = list(
+                    self.graph.triples(
+                        (
+                            self.to_uri(current_label),
+                            RDFS.subClassOf,
+                            self.to_uri(ancestor_label),
+                        )
+                    )
+                )
+
+                if not rdf_currents:
+                    # Slow search with SPARQL queries.
+
+                    # Use cache if term has been found already.
+                    if ancestor_label in already_found:
+                        uri_ancestor = already_found[ancestor_label]
+                    else:
+                        # Use SPARQL queries to get a term with an existing namespace.
+                        # Because the missing term may be just in another namespace.
+                        # But we don't want to SPARQL before, because it is so slow.
+                        # FIXME this is VERY slow, maybe we can recover the namespaces
+                        # from some BioCypher data structure?
+
+                        # Note: using \\b in the regexp does not seems to work.
+                        uri_ancestor = self.find_uri(f"#{ancestor_label}$")
+                        if not uri_ancestor:
+                            msg = f"I found no term with subject URI matching `#{ancestor_label}$`, but it should exist"
+                            logger.error(msg)
+                            raise RuntimeError(msg)
+
+                        already_found[ancestor_label] = uri_ancestor
+
+                    if current_label not in already_found:
+                        uri_current = self.find_uri(f"#{current_label}$")
+                        if not uri_current:
+                            uri_current = self.as_uri(current_label, "biocypher")
+                            # Create the term in biocypher namespace.
+                            self.graph.add(
+                                (
+                                    uri_current,
+                                    RDF.type,
+                                    uri_ancestor,
+                                )
+                            )
+                            logger.debug(f"\t\t\t[{uri_current}]--(type)->[{uri_ancestor}]")
+
+                        already_found[current_label] = uri_current
+
+                else:  # Found by fast search.
+                    assert len(rdf_currents) > 0
+                    uri_current = rdf_currents[0][0]
+
+            # Add the instance.
+            self.graph.add(
+                (
+                    self.to_uri(rdf_subject),
+                    RDF.type,
+                    uri_current,
+                )
+            )
+            logger.debug(f"\t[{rdf_subject}]--(type)->[{uri_current}]")
+
+            # The instance is also a NamedIndividual, in OWL.
+            self.graph.add(
+                (
+                    self.to_uri(rdf_subject),
+                    RDF.type,
+                    OWL.NamedIndividual,
+                )
+            )
+            logger.debug(f"\t[{rdf_subject}]--(type)->[NamedIndividual]")
+
+            # Add a readable label.
+            self.graph.add(
+                (
+                    self.to_uri(rdf_subject),
+                    RDFS.label,
+                    Literal(n.get_id()),
+                )
+            )
+            logger.debug(f"\t[{rdf_subject}]--(label)->[{n.get_id()}]")
+
+            # Add properties.
+            for key, value in properties.items():
+                # only write value if it exists.
+                if value:
+                    self.add_property_to_graph(self.graph, rdf_subject, value, key)
+
+        self._has_nodes = True
+        return True
+
+    def _write_single_edge_list_to_file(
+        self,
+        edge_list: list,
+        label: str,
+        prop_dict: dict,
+    ):
+        """
+        This function takes a list of BioCypherEdges
+        and save them in self.graph.
+        It re-uses RDFWriter's machinery, hence the
+        misleading name.
+
+        Args:
+            edge_list (list): list of BioCypherEdges to be written
+
+            label (str): the label (type) of the edge
+
+            prop_dict (dict): properties of node class passed from parsing
+                function and their types
+
+        Returns:
+            bool: True for success, False otherwise.
+        """
+
+        # FIXME prop_dict is not used.
+
+        if not all(isinstance(n, BioCypherEdge) for n in edge_list):
+            logger.error("Edges must be passed as type BioCypherEdge.")
+            return False
+
+        for edge in edge_list:
+            rdf_subject = url_quote(edge.get_source_id())
+            rdf_object = url_quote(edge.get_target_id())
+            rdf_properties = edge.get_properties()
+
+            edge_label = url_quote(edge.get_label())
+            edge_uri = self.to_uri(edge_label)
+
+            if self.edge_model == "ObjectProperty":
+                # Add to the subject the property toward the object.
+                self.graph.add(
+                    (
+                        self.to_uri(rdf_subject),
+                        edge_uri,
+                        self.to_uri(rdf_object),
+                    )
+                )
+                logger.debug(f"Edge ObjectProperty: [{rdf_subject}]--({edge_label})->[{rdf_object}]")
+
+            elif self.edge_model == "Association":
+                # Modelling edges as Association allows for attaching
+                # data properties to an intermediate node.
+                logger.debug(f"EDGE Association: [{rdf_subject}]--({edge_label})->[{rdf_object}]")
+
+                if edge.get_id():
+                    rdf_id = url_quote(edge.get_id())
+                else:
+                    # We need an instance to attach properties.
+                    rdf_id = url_quote(f"{rdf_subject}--{edge.get_label()}--{rdf_object}")
+
+                # Add object class modelling the edge.
+                # NOTE (from https://www.w3.org/TR/owl-ref/):
+                # owl:Class is defined as a subclass of rdfs:Class. The rationale for
+                #  having a separate OWL class construct lies in the restrictions on
+                #  OWL DL (and thus also on OWL Lite), which imply that not all RDFS
+                #  classes are legal OWL DL classes. In OWL Full these restrictions
+                #  do not exist and therefore owl:Class and rdfs:Class are equivalent
+                #  in OWL Full.
+                self.graph.add((edge_uri, RDF.type, OWL.Class))
+                logger.debug(f"\tEdge object: [{edge_label}]--(type)->[Class]")
+
+                # Instantiate the edge object.
+                self.graph.add(
+                    (
+                        self.to_uri(rdf_id),
+                        RDF.type,
+                        edge_uri,
+                    )
+                )
+                logger.debug(f"\tEdge object instance: [{rdf_id}]--(type)->[{edge_label}]")
+
+                # ObjectProperties modelling the subject and object
+                # parts of the links around the object.
+                # edge_source and edge_target inherits from edge,
+                # and are in the biocypher namespace.
+                self.graph.add(
+                    (
+                        self.as_uri("edge", "biocypher"),
+                        RDF.type,
+                        OWL.ObjectProperty,
+                    )
+                )
+                logger.debug("\tBase ObjectProperty type: [edge]--(type)->[ObjectProperty]")
+
+                self.graph.add(
+                    (
+                        self.as_uri("edge_source", "biocypher"),
+                        RDFS.subPropertyOf,
+                        self.as_uri("edge", "biocypher"),
+                    )
+                )
+                logger.debug("\tLeft ObjectProperty type: [edge_source]--(type)->[edge]")
+
+                self.graph.add(
+                    (
+                        self.as_uri("edge_target", "biocypher"),
+                        RDFS.subPropertyOf,
+                        self.as_uri("edge", "biocypher"),
+                    )
+                )
+                logger.debug("\tRight ObjectProperty type: [edge_target]--(type)->[edge]")
+
+                self.graph.add(
+                    (
+                        self.to_uri(rdf_subject),
+                        self.as_uri("edge_source", "biocypher"),
+                        self.as_uri(rdf_id, "biocypher"),
+                    )
+                )
+                logger.debug(f"\tLeft ObjectProperty: [{rdf_subject}]--(edge_source)->[{rdf_id}]")
+
+                self.graph.add(
+                    (
+                        self.as_uri(rdf_id, "biocypher"),
+                        self.as_uri("edge_target", "biocypher"),
+                        self.to_uri(rdf_object),
+                    )
+                )
+                logger.debug(f"\tRight ObjectProperty: [{rdf_id}]--(edge_target)->[{rdf_object}]")
+
+                # Add properties to the edge modelled as an instance.
+                for key, value in rdf_properties.items():
+                    # only write value if it exists.
+                    if value:
+                        self.add_property_to_graph(self.graph, rdf_id, value, key)
+
+            else:
+                logger.debug(f"{self.edge_model} not in {self.edge_models}")
+                assert self.edge_model in self.edge_models
+
+        self._has_edges = True
+        return True
+
+    def write_nodes(self, nodes, batch_size: int = int(1e6), force: bool = False) -> bool:
+        """
+        Insert nodes in `self.graph`.
+
+        It calls _write_node_data, which calls _write_single_node_list_to_file.
+
+        Args:
+            nodes (list or generator): A list or generator of nodes in BioCypherNode format.
+            batch_size (int): The number of nodes to write in each batch.
+            force (bool): Flag to force the writing even if the output file already exists.
+
+        Returns:
+            bool: True if the writing is successful, False otherwise.
+        """
+        # Calls _write_single_node_list_to_file, which sets self.has_nodes.
+        if not super().write_nodes(nodes, batch_size, force):
+            return False
+
+        # Attempt at writing the file.
+        self._write_file()
+        return True
+
+    def write_edges(
+        self,
+        edges: Union[list, GeneratorType],
+        batch_size: int = int(1e6),
+    ) -> bool:
+        """
+        Insert edges in `self.graph`.
+
+        It calls _write_edge_data, which calls _write_single_edge_list_to_file.
+
+        Args:
+            edges (BioCypherEdge): a list or generator of edges in
+                :py:class:`BioCypherEdge` format
+            batch_size (int): The number of edges to write in each batch.
+
+        Returns:
+            bool: The return value. True for success, False otherwise.
+        """
+        # Calls _write_single_edge_list_to_file, which sets self.has_edges.
+        if not super().write_edges(edges, batch_size):
+            return False
+
+        # Attempt at writing the file.
+        self._write_file()
+        return True
+
+    def _write_file(self):
+        """
+        Write an OWL file if nodes and edges are ready in self.graph.
+        """
+        if self._has_nodes and self._has_edges:
+            file_name = os.path.join(self.outdir, f"{self.file_stem}.{self.extension}")
+            logger.info(f"Writing {len(self.graph)} terms to {file_name}")
+            self.graph.serialize(destination=file_name, format=self.rdf_format)

--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -30,12 +30,13 @@ from biocypher.output.write.graph._rdf import _RDFWriter
 
 
 class _OWLWriter(_RDFWriter):
-    """Class to write BioCypher's graph into a self-contained OWL file.
+    """Write BioCypher's graph into a self-contained OWL file.
+
     The resulting OWL file contains both the input vocabulary and
     the output instances.
 
-    The behavior rely mainly on the `edge_model` parameter,
-    which can takes two values:
+    The behavior relies mainly on the `edge_model` parameter,
+    which can take two values:
 
     - "ObjectProperty", which translates BioCypher's edges into
       OWL's object properties (if they are available under the
@@ -43,7 +44,7 @@ class _OWLWriter(_RDFWriter):
       to model edges in OWL, but they do not support annotation,
       thus being incompatible with having BioCypher's properties
       on edges.
-      As most of OWL files do not model a common term on top of both
+      As most OWL files do not model a common term on top of both
       owl:topObjectProperty and owl:Thing, you may need to ensure
       that the input OWL contains a common ancestor honoring both:
 
@@ -51,15 +52,16 @@ class _OWLWriter(_RDFWriter):
       - owl:topObjectProperty rdfs:subPropertyOf <root_node>
 
       and that you select it in your BioCypher configuration.
+
     - "Association" (the default), which translates BioCypher's
       edges into OWL's class instances. Those edges instances are
-      inserted inbetween the instances coming from BioCypher's nodes.
-      This allows to keep edges properties, but adds OWL instances
+      inserted in between the instances coming from BioCypher's nodes.
+      This allows to keep edge properties, but adds OWL instances
       to model relationships, which does not follow the classical
       OWL model. In this approach, all OWL instances are linked
       with a generic "edge_source" (linking source instance to
       the association instance) and "edge_target" (linking the association
-      instance to the target instance). Both of which inherits from "edge",
+      instance to the target instance). Both of which inherit from "edge",
       and are in the biocypher namespace.
 
     This class takes care of keeping the vocabulary underneath the
@@ -70,7 +72,7 @@ class _OWLWriter(_RDFWriter):
     To output a valid self-contained OWL file, it is required that
     you call *both* `write_nodes` *and* `write_edges`.
 
-    This class heavily rely on the _RDFWriter class interface and code.
+    This class heavily relies on the _RDFWriter class interface and code.
     """
 
     def __init__(
@@ -99,7 +101,7 @@ class _OWLWriter(_RDFWriter):
         file_stem: str = "biocypher",
         **kwargs,
     ):
-        """Constructor.
+        """Initialize the OWL writer.
 
         Args:
         ----
@@ -135,7 +137,8 @@ class _OWLWriter(_RDFWriter):
                 call.
 
             wipe:
-                Whether to force import (removing existing DB content). (Specific to Neo4j.)
+                Whether to force import (removing existing DB content).
+                    (Specific to Neo4j.)
 
             strict_mode:
                 Whether to enforce source, version, and license properties.
@@ -166,8 +169,9 @@ class _OWLWriter(_RDFWriter):
                 The namespaces for RDF.
 
             edge_model:
-                Whether to model an edge as OWL's "ObjectProperty" (discards edges properties)
-                or "Association" (adds an intermediate node that holds the edge properties).
+                Whether to model an edge as OWL's "ObjectProperty" (discards
+                edges properties) or "Association" (adds an intermediate node
+                that holds the edge properties).
 
             file_stem:
                 The stem (name without the path and extension) of the output
@@ -209,9 +213,9 @@ class _OWLWriter(_RDFWriter):
 
         self.edge_models = ["Association", "ObjectProperty"]
         if edge_model not in self.edge_models:
-            raise ValueError(
-                f"`edge_model` cannot be '{edge_model}', but should be either: {' or '.join(self.edge_models)}",
-            )
+            msg = f"`edge_model` cannot be '{edge_model}', but should be either: {' or '.join(self.edge_models)}"
+            logger.error(msg)
+            raise ValueError(msg)
         self.edge_model = edge_model
 
         self.file_stem = file_stem
@@ -222,14 +226,15 @@ class _OWLWriter(_RDFWriter):
         label: str,
         prop_dict: dict,
         labels: str,
-    ):
-        """This function takes a list of BioCypherNodes
-        and save them in self.graph.
-        It re-uses RDFWriter's machinery, hence the
-        misleading name.
+    ) -> bool:
+        """Save a list of BioCypherNodes in the graph.
 
-        Nodes are modelled as class instances, being
-        also owl:NamedIndividual.
+        This function takes a list of BioCypherNodes and saves them in
+        `self.graph`. It re-uses RDFWriter's machinery, hence the misleading
+        name.
+
+        Nodes are modelled as class instances, being also
+        owl:NamedIndividual.
 
         Args:
         ----
@@ -237,7 +242,8 @@ class _OWLWriter(_RDFWriter):
 
             label (str): The label (type) of the nodes.
 
-            prop_dict (dict): A dictionary of properties and their types for the node class.
+            prop_dict (dict): A dictionary of properties and their types for the
+                node class.
 
             labels (str): string of one or several concatenated labels
 
@@ -368,10 +374,11 @@ class _OWLWriter(_RDFWriter):
         label: str,
         prop_dict: dict,
     ):
-        """This function takes a list of BioCypherEdges
-        and save them in self.graph.
-        It re-uses RDFWriter's machinery, hence the
-        misleading name.
+        """Save a list of BioCypherEdges in the graph.
+
+        This function takes a list of BioCypherEdges and saves them in
+        `self.graph`. It re-uses RDFWriter's machinery, hence the misleading
+        name.
 
         Args:
         ----
@@ -513,9 +520,11 @@ class _OWLWriter(_RDFWriter):
 
         Args:
         ----
-            nodes (list or generator): A list or generator of nodes in BioCypherNode format.
+            nodes (list or generator): A list or generator of nodes in
+                BioCypherNode format.
             batch_size (int): The number of nodes to write in each batch.
-            force (bool): Flag to force the writing even if the output file already exists.
+            force (bool): Flag to force the writing even if the output file
+                already exists.
 
         Returns:
         -------

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -28,8 +28,9 @@ from biocypher.output.write._batch_writer import _BatchWriter
 
 
 class _RDFWriter(_BatchWriter):
-    """Class to write BioCypher's property graph into an RDF format using
-    rdflib and all the extensions it supports (RDF/XML, N3, NTriples,
+    """Write BioCypher's property graph into an RDF format.
+
+    Uses `rdflib` and all the extensions it supports (RDF/XML, N3, NTriples,
     N-Quads, Turtle, TriX, Trig and JSON-LD). By default the conversion
     is done keeping only the minimum information about node and edges,
     skipping all properties.
@@ -89,8 +90,9 @@ class _RDFWriter(_BatchWriter):
         self.namespaces = {}
 
     def _get_import_script_name(self) -> str:
-        """Returns the name of the RDF admin import script.
-        This function applicable for RDF export.
+        """Return the name of the RDF admin import script.
+
+        This function is used for RDF export.
 
         Returns
         -------
@@ -100,7 +102,7 @@ class _RDFWriter(_BatchWriter):
         return "rdf-import-call.sh"
 
     def _get_default_import_call_bin_prefix(self):
-        """Method to provide the default string for the import call bin prefix.
+        """Provide the default string for the import call bin prefix.
 
         Returns
         -------
@@ -110,7 +112,7 @@ class _RDFWriter(_BatchWriter):
         return "bin/"
 
     def _is_rdf_format_supported(self, rdf_format: str) -> bool:
-        """Function to check if the specified RDF format is supported.
+        """Check if the specified RDF format is supported.
 
         Args:
         ----
@@ -156,8 +158,7 @@ class _RDFWriter(_BatchWriter):
         label: str,
         prop_dict: dict,
     ):
-        """This function takes one list of biocypher edges and writes them
-        to an RDF file with the given format.
+        """Write a list of BioCypherEdges to an RDF file.
 
         Args:
         ----
@@ -301,7 +302,7 @@ class _RDFWriter(_BatchWriter):
             )
 
     def transform_string_to_list(self, string_list: str) -> list:
-        """Function to transform a string representation of a list into a list.
+        """Transform a string representation of a list into a list.
 
         Args:
         ----
@@ -321,8 +322,7 @@ class _RDFWriter(_BatchWriter):
         prop_dict: dict,
         labels: str,
     ):
-        """This function takes a list of BioCypherNodes and writes them
-        to an RDF file in the specified format.
+        """Write a list of BioCypherNodes to an RDF file.
 
         Args:
         ----
@@ -387,13 +387,15 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def write_nodes(self, nodes, batch_size: int = int(1e6), force: bool = False) -> bool:
-        """Wrapper for writing nodes in RDF format. It calls the _write_node_data() function, specifying the node data.
+        """Write nodes in RDF format.
 
         Args:
         ----
-            nodes (list or generator): A list or generator of nodes in BioCypherNode format.
+            nodes (list or generator): A list or generator of nodes in
+                BioCypherNode format.
             batch_size (int): The number of nodes to write in each batch.
-            force (bool): Flag to force the writing even if the output file already exists.
+            force (bool): Flag to force the writing even if the output file
+                already exists.
 
         Returns:
         -------
@@ -417,8 +419,7 @@ class _RDFWriter(_BatchWriter):
         edges: list | GeneratorType,
         batch_size: int = int(1e6),
     ) -> bool:
-        """Wrapper for writing edges in RDF format. It calls _write_edge_data()
-        functions specifying it's edge data.
+        """Write edges in RDF format.
 
         Args:
         ----
@@ -445,7 +446,8 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def _construct_import_call(self) -> bool:
-        """Function to write the import call.
+        """Write the import call.
+
         This function is not applicable for RDF.
 
         Returns
@@ -460,8 +462,8 @@ class _RDFWriter(_BatchWriter):
         return f"{self.quote}{value}{self.quote}"
 
     def _write_array_string(self, string_list):
-        """Abstract method to write the string representation of an array into a .csv file
-        as required by the RDF admin-import.
+        """Write the string representation of an array into a .csv file.
+
         This function is not applicable for RDF.
 
         Args:
@@ -476,8 +478,8 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def _write_node_headers(self):
-        """Abstract method that takes care of importing properties of a graph entity that is represented
-        as a node as per the definition in the `schema_config.yaml`
+        """Import properties of a graph entity.
+
         This function is not applicable for RDF.
 
         Returns
@@ -488,9 +490,8 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def _write_edge_headers(self):
-        """Abstract method to write a database import-file for a graph entity that is represented
-        as an edge as per the definition in the `schema_config.yaml`,
-        containing only the header for this type of edge.
+        """Write a database import-file for a graph entity.
+
         This function is not applicable for RDF.
 
         Returns
@@ -501,12 +502,22 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def as_uri(self, name: str, namespace: str = "") -> str:
-        """Returns an RDFlib object with the given namespace
-        transformed as a URI.
+        """Return an RDFlib object with the given namespace as a URI.
+
+        There is often a default for empty namespaces, which would have been
+        loaded with the ontology, and put in `self.namespace` by
+        `self._init_namespaces`.
+
+        Args:
+        ----
+            name (str): The name to be transformed.
+            namespace (str): The namespace to be used.
+
+        Returns:
+        -------
+            str: The URI for the given name and namespace.
+
         """
-        # There is often a default for empty namespaces,
-        # which would have been loaded with the ontology,
-        # and put in self.namespace by self._init_namespaces.
         if namespace in self.namespaces:
             return URIRef(self.namespaces[namespace][name])
         else:
@@ -517,11 +528,11 @@ class _RDFWriter(_BatchWriter):
             return URIRef(self.namespaces["biocypher"][name])
 
     def to_uri(self, subject: str) -> str:
-        """Extract the namespace from the given subject by
-        splitting its string on ":".
-        Then converts the subject to a proper URI,
-        if the namespace is known.
-        If namespace is unknown, defaults to the default prefix of the ontology.
+        """Extract the namespace from the given subject.
+
+        Split the subject's string on ":". Then convert the subject to a
+        proper URI, if the namespace is known. If namespace is unknown,
+        defaults to the default prefix of the ontology.
 
         Args:
         ----
@@ -558,10 +569,11 @@ class _RDFWriter(_BatchWriter):
             return None
 
     def property_to_uri(self, property_name: str) -> dict[str, str]:
-        """Converts a property name to its corresponding URI.
+        """Convert a property name to its corresponding URI.
 
-        This function takes a property name and searches for its corresponding URI in various namespaces.
-        It first checks the core namespaces for rdflib, including owl, rdf, rdfs, xsd, and xml.
+        This function takes a property name and searches for its corresponding
+        URI in various namespaces. It first checks the core namespaces for
+        rdflib, including owl, rdf, rdfs, xsd, and xml.
 
         Args:
         ----
@@ -604,9 +616,11 @@ class _RDFWriter(_BatchWriter):
     def _init_namespaces(self, graph: Graph):
         """Initialise the namespaces for the RDF graph.
 
-        This function adds the biocypher standard namespace to the `namespaces` attribute of the class.
-        If `namespaces` is empty, it sets it to the biocypher standard namespace. Otherwise, it merges
-        the biocypher standard namespace with the namespaces defined in the biocypher_config.yaml.
+        This function adds the biocypher standard namespace to the `namespaces`
+        attribute of the class. If `namespaces` is empty, it sets it to the
+        biocypher standard namespace. Otherwise, it merges the biocypher
+        standard namespace with the namespaces defined in the
+        biocypher_config.yaml.
 
         Args:
         ----

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -174,7 +174,9 @@ class _RDFWriter(_BatchWriter):
             bool: The return value. True for success, False otherwise.
 
         """
-        # FIXME prop_dict is not used.
+
+        # NOTE: prop_dict is not used.
+
         if not all(isinstance(n, BioCypherEdge) for n in edge_list):
             logger.error("Edges must be passed as type BioCypherEdge.")
             return False
@@ -339,7 +341,9 @@ class _RDFWriter(_BatchWriter):
             bool: True if the writing is successful, False otherwise.
 
         """
-        # FIXME labels and prop_dict are not used.
+
+        # NOTE: labels and prop_dict are not used.
+
         if not all(isinstance(n, BioCypherNode) for n in node_list):
             logger.error("Nodes must be passed as type BioCypherNode.")
             return False

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -1,11 +1,8 @@
-"""BioCypher 'offline' module. Handles the writing of node and edge representations
-suitable for import into a DBMS.
-"""
+"""Module to provide the RDF writer class."""
 
 import os
 
 from types import GeneratorType
-from typing import Optional
 
 from rdflib import (
     DC,
@@ -45,10 +42,10 @@ class _RDFWriter(_BatchWriter):
         delimiter: str,
         array_delimiter: str = ",",
         quote: str = '"',
-        output_directory: Optional[str] = None,
+        output_directory: str | None = None,
         db_name: str = "neo4j",
-        import_call_bin_prefix: Optional[str] = None,
-        import_call_file_prefix: Optional[str] = None,
+        import_call_bin_prefix: str | None = None,
+        import_call_file_prefix: str | None = None,
         wipe: bool = True,
         strict_mode: bool = False,
         skip_bad_relationships: bool = False,
@@ -176,7 +173,6 @@ class _RDFWriter(_BatchWriter):
             bool: The return value. True for success, False otherwise.
 
         """
-
         # FIXME prop_dict is not used.
         if not all(isinstance(n, BioCypherEdge) for n in edge_list):
             logger.error("Edges must be passed as type BioCypherEdge.")
@@ -215,14 +211,14 @@ class _RDFWriter(_BatchWriter):
                     self.as_uri(rdf_predicate, "biocypher"),
                     self.as_uri("subject", "biocypher"),
                     self.to_uri(rdf_subject),
-                )
+                ),
             )
             graph.add(
                 (
                     self.as_uri(rdf_predicate, "biocypher"),
                     self.as_uri("object", "biocypher"),
                     self.to_uri(rdf_object),
-                )
+                ),
             )
 
             # add properties to the transformed edge --> node
@@ -343,7 +339,6 @@ class _RDFWriter(_BatchWriter):
             bool: True if the writing is successful, False otherwise.
 
         """
-
         # FIXME labels and prop_dict are not used.
         if not all(isinstance(n, BioCypherNode) for n in node_list):
             logger.error("Nodes must be passed as type BioCypherNode.")
@@ -376,7 +371,7 @@ class _RDFWriter(_BatchWriter):
                     self.to_uri(rdf_subject),
                     RDF.type,
                     self.as_uri(class_name, "biocypher"),
-                )
+                ),
             )
             for key, value in properties.items():
                 # only write value if it exists.
@@ -461,10 +456,7 @@ class _RDFWriter(_BatchWriter):
         return ""
 
     def _quote_string(self, value: str) -> str:
-        """
-        Quote a string.
-        """
-
+        """Quote a string."""
         return f"{self.quote}{value}{self.quote}"
 
     def _write_array_string(self, string_list):
@@ -509,8 +501,7 @@ class _RDFWriter(_BatchWriter):
         return True
 
     def as_uri(self, name: str, namespace: str = "") -> str:
-        """
-        Returns an RDFlib object with the given namespace
+        """Returns an RDFlib object with the given namespace
         transformed as a URI.
         """
         # There is often a default for empty namespaces,
@@ -526,8 +517,7 @@ class _RDFWriter(_BatchWriter):
             return URIRef(self.namespaces["biocypher"][name])
 
     def to_uri(self, subject: str) -> str:
-        """
-        Extract the namespace from the given subject by
+        """Extract the namespace from the given subject by
         splitting its string on ":".
         Then converts the subject to a proper URI,
         if the namespace is known.
@@ -555,7 +545,7 @@ class _RDFWriter(_BatchWriter):
         uris = list(gen)
         if len(uris) > 1:
             logger.warning(
-                f"Found several terms matching `{regexp}`, I will consider only the first one: `{uris[0][0]}`"
+                f"Found several terms matching `{regexp}`, I will consider only the first one: `{uris[0][0]}`",
             )
             logger.debug("\tothers:")
             for u in uris[1:]:
@@ -640,7 +630,7 @@ class _RDFWriter(_BatchWriter):
                 logger.warning(
                     f"Namespace '{prefix}' was already loaded"
                     f"as '{self.namespaces[prefix]}',"
-                    f"I will overwrite it with '{ns}'."
+                    f"I will overwrite it with '{ns}'.",
                 )
             logger.debug(f"\t'{prefix}'\t=>\t'{ns}'")
             self.namespaces[prefix] = Namespace(ns)

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -31,7 +31,7 @@ class _RDFWriter(_BatchWriter):
     """Write BioCypher's property graph into an RDF format.
 
     Uses `rdflib` and all the extensions it supports (RDF/XML, N3, NTriples,
-    N-Quads, Turtle, TriX, Trig and JSON-LD). By default the conversion
+    N-Quads, Turtle, TriX, Trig and JSON-LD). By default, the conversion
     is done keeping only the minimum information about node and edges,
     skipping all properties.
     """
@@ -142,6 +142,7 @@ class _RDFWriter(_BatchWriter):
             "xml",
             "n3",
             "turtle",
+            "ttl",
             "nt",
             "pretty-xml",
             "trix",
@@ -152,16 +153,12 @@ class _RDFWriter(_BatchWriter):
         if file_format not in supported_formats:
             logger.error(
                 f"Incorrect or unsupported RDF format: '{file_format}',"
-                f"use one of the following: {', '.join(supported_formats)}."
+                f"use one of the following: {', '.join(supported_formats)}.",
             )
             return False
         else:
-            # RDF graph does not support 'ttl' format, only 'turtle' format.
-            # however, the preferred file extension is always '.ttl'
+            # Set the file extension to match the format
             if self.file_format == "turtle":
-                self.extension = "ttl"
-            elif self.file_format == "ttl":
-                self.file_format = "turtle"
                 self.extension = "ttl"
             else:
                 self.extension = self.file_format
@@ -189,8 +186,7 @@ class _RDFWriter(_BatchWriter):
             bool: The return value. True for success, False otherwise.
 
         """
-
-        # NOTE: prop_dict is not used.
+        # NOTE: prop_dict is not used. Remove in next refactor.
 
         if not all(isinstance(n, BioCypherEdge) for n in edge_list):
             logger.error("Edges must be passed as type BioCypherEdge.")
@@ -356,7 +352,6 @@ class _RDFWriter(_BatchWriter):
             bool: True if the writing is successful, False otherwise.
 
         """
-
         # NOTE: labels and prop_dict are not used.
 
         if not all(isinstance(n, BioCypherNode) for n in node_list):

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,4 @@
+
+.rst-content .highlight-default .highlight > pre {
+    line-height: 100% !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,11 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ["_static"]
+
+html_css_files = [
+    "css/custom.css",
+]
 
 # -- OpenGraph configuration -------------------------------------------------
 

--- a/docs/output/index.rst
+++ b/docs/output/index.rst
@@ -14,6 +14,7 @@ Currently supported are:
 * ``neo4j``
 * ``arangodb``
 * ``rdf``
+* ``owl``
 * ``postgres``
 * ``sqlite``
 * ``tabular``
@@ -52,6 +53,7 @@ supported output formats are described on the following pages:
     arangodb.md
     csv.md
     rdf.md
+    owl.md
     postgres.md
     sqlite.md
     networkx.md

--- a/docs/output/owl.md
+++ b/docs/output/owl.md
@@ -1,0 +1,172 @@
+# OWL
+
+The Web Ontology Language (OWL) is a (family of) knowledge representation
+language(s) for authoring ontologies. BioCypher can use taxonomies using OWL,
+butit can also output a knowledge graph in an OWL file.
+
+OWL is one of the most used knowledge representation language and it is built
+with the Resource Description Framework (RDF) and have some compatibility with
+the RDF Schema data model. It can be serialized in several formats (most known
+being XML and Turtle). The [Protégé](https://protege.stanford.edu/) software
+is the *de facto* standard graphical user interface to design OWL ontologies.
+
+In BioCypher, selecting the `owl` output format will call the `_OWLWriter` class
+and generate a sefl-contained OWL file. The file is said to be "self-contained"
+because it holds both the vocabulary (i.e. a part of the hierarchy of classes
+from the input ontology) and the instances (i.e. "nodes", for Biocypher).
+
+
+## Edge Model
+
+The behavior rely mainly on the `edge_model` parameter,
+which can takes two values: "ObjectProperty" or "Association".
+
+
+### ObjectProperty
+
+This edge model translates BioCypher's edges into
+OWL's object properties (if they are available under the
+selected root term). Object properties are the natural way
+to model edges in OWL, but they do not support annotation,
+thus being incompatible with having BioCypher's properties
+on edges.
+
+As most of OWL files do not model a common term on top of both
+owl:topObjectProperty and owl:Thing, you may need to ensure
+that the input OWL contains a "meta-root", that is a
+common ancestor honoring both:
+
+- owl:Thing rdfs:subClassOf <root_node>
+- owl:topObjectProperty rdfs:subPropertyOf <root_node>
+
+It is this meta-root that you should select as a `root_node` in your BioCypher
+configuration.
+
+
+### Association
+
+This edge model (the default) translates BioCypher's
+edges into OWL's class instances. Those edges instances are
+inserted inbetween the instances coming from BioCypher's nodes.
+This allows to keep edges properties, but adds OWL instances
+to model relationships, which does not follow the classical
+OWL model.
+
+In this approach, all OWL instances are linked
+with a generic "edge\_source" (linking source instance to
+the association instance) and "edge\_target" (linking the association
+instance to the target instance). Both of which inherits from "edge",
+and are in the biocypher namespace.
+
+If you use this edge model, you should select a `root_node` as one of
+the subclass of owl:Thing, and not select any part of the object property tree.
+
+
+## Taxonomy Management
+
+This class takes care of keeping the vocabulary underneath the
+selected root node and exports it along the instances in the
+resulting OWL file. It discards whatever terms are not in the
+tree below the selected root node.
+
+The configuration paramater `rdf_namespaces`, can be used to specify which
+namespaces exist in the input ontology (or the data). If the data contain IDs
+with a given prefix, they will be converted into valid Uniform Resource
+Identifiers (URI) to allow referencing. If no namespace are specified, BioCypher
+will search for them into the input ontology.
+
+
+## Settings
+
+Important parameters are:
+
+- `root_node`, which must be a meta-root on top of both owl:Thing and
+  owl:topObjectProperty.
+- `edge_model` heavily impacts the output ontology, most notably the graph
+  structure, and thus the queries that can be made on it (see above).
+- `file_stem` is the name of the output file (without the extension or the path)
+  which will be written in the output directory.
+- `rdf_format` is the output serialization format. Note that if set to "turtle",
+  the output file extension will be ".ttl", but you cannot indicate "ttl" as an
+  rdf_format.
+
+### For the OpjectProperty edge model
+
+```{code-block} yaml
+:caption: biocypher_config.yaml
+
+biocypher:
+    strict_mode: true
+    schema_config_path: config/schema_config.yaml
+    dbms: owl # <- Use the OWL output writer.
+
+    head_ontology:
+        url: file:///home/superb/owl_file.ttl
+        root_node: BioCypherRoot # <- The "meta-root" class.
+
+owl:
+    rdf_format: turtle # <- Note that this is not "ttl".
+    # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
+
+    edge_model: ObjectProperty
+    # Can also be: Association (the default)
+
+    file_stem: my_ontology # "biocypher" by default, do not put an extension
+
+    # Optional:
+    rdf_namespaces:
+        so: http://purl.obolibrary.org/obo/SO_
+        efo: http://www.ebi.ac.uk/efo/EFO_
+```
+
+### For the Association edge model
+
+```{code-block} yaml
+:caption: biocypher_config.yaml
+
+biocypher:
+    strict_mode: true
+    schema_config_path: config/schema_config.yaml
+    dbms: owl # <- Use the OWL output writer.
+
+    head_ontology:
+        url: file:///home/superb/owl_file.ttl
+        root_node: Entity # <- NOT the meta-root!
+
+owl:
+    rdf_format: turtle
+    # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
+
+    edge_model: Association
+
+    file_stem: my_ontology # "biocypher" by default, do not put an extension
+
+    # Optional:
+    rdf_namespaces:
+        so: http://purl.obolibrary.org/obo/SO_
+        efo: http://www.ebi.ac.uk/efo/EFO_
+```
+
+## Possible Issues
+
+Biocypher is not able to read all OWL ontologies, and not all of the terms
+hosted in an OWL ontology. Most notably, it only reads (a part of) the taxonomy
+to build up its input. Some logical predicates may also be incompatible with
+the selected edge model (especially "Association").
+
+Note that Protégé may show a couple of impediments:
+
+- It display owl:Entity as if it inherits from owl:Thing, but that is not
+  necessarily actually implemented by a predicate. You may have to add it
+  manually.
+- It displays all owl:ObjectProperty as if they inherit from
+  owl:topObjectProperty, but you may also have to add the predicate manually.
+- It gives no easy way to add a meta-root on top of both classes, and an
+  manually added one will appear as a *subclass* of both owl:Thing and
+  owl:topObjectProperty.
+
+Double-checking the ontology file source code itself should help you checking
+whether it fits Biocypher's constraints.
+
+Also, note that BioCypher requires that classes (and object properties) have an
+RDFS label, and will use it (and not the IRI) to find the necessary types.

--- a/docs/output/owl.md
+++ b/docs/output/owl.md
@@ -26,11 +26,40 @@ The behavior of edge creation in the RDF output relies mainly on the
 ### ObjectProperty
 
 This edge model translates BioCypher's edges into
-OWL's object properties (if they are available under the
+OWL's "object properties" (if they are available under the
 selected root term). Object properties are the natural way
 to model edges in OWL, but they do not support annotation,
-thus being incompatible with having BioCypher's properties
+thus being incompatible with having BioCypher's "properties"
 on edges.
+
+For instance, the following BioCypher triples (two nodes and one edge):
+```{code-block} python
+# Nodes:
+# ID           label           properties
+("My_source", "thisNodeType", {"my_prop":"this"}),
+("My_target", "thatNodeType", {}),
+
+# Edge:
+# ID         source ID    target ID    properties               label
+("My_edge", "My_source", "My_target", {"my_edge_prop":"that"}, "toward")
+```
+would be translated into the following OWL statements (here shown in the Turtle
+format, not showing the taxonomy ancestors):
+```{code-block} turtle
+# Declaration of types:
+:toward a owl:ObjectProperty ;
+    rdfs:range :thisNodeType ;
+    rdfs:domain :thatNodetype ;
+    rdfs:subPropertyOf owl:topObjectProperty ;
+
+# Actual data:
+:My_source a :thisNodeType, owl:NamedIndividual ;
+    biocypher:my_prop "this" ;
+    :toward :My_target
+
+:My_target a :thatNodeType, owl:NamedIndividual ;
+```
+Note how the properties of the edge are losts.
 
 As most of OWL files do not model a common term on top of both
 owl:topObjectProperty and owl:Thing, you may need to ensure
@@ -58,6 +87,45 @@ with a generic "edge\_source" (linking source instance to
 the association instance) and "edge\_target" (linking the association
 instance to the target instance). Both of which inherit from "edge",
 and are in the biocypher namespace.
+
+For instance, the following BioCypher triples (two nodes and one edge):
+```{code-block} python
+# Nodes:
+# ID           label           properties
+("My_source", "thisNodeType", {"my_prop":"this"}),
+("My_target", "thatNodeType", {}),
+
+# Edges:
+# ID         source ID    target ID    properties               label
+("My_edge", "My_source", "My_target", {"my_edge_prop":"that"}, "toward")
+```
+would be translated into the following OWL statements (here shown in the Turtle
+format, not showing the taxonomy ancestors):
+```{code-block} turtle
+# Declaration of Biocypher's generic edge types:
+biocypher:edge a owl:ObjectProperty ;
+    rdfs:subPropertyOf owl:topObjectProperty ;
+
+biocypher:edge_source a biocypher:edge ;
+
+biocypher:edge_target a biocypher:edge ;
+
+# The edge type becomes an OWL class:
+:toward a owl:Class ;
+
+# Actual data:
+:My_source a :thisNodeType, owl:NamedIndividual ;
+    biocypher:my_prop "this" ;
+
+:My_target a :thatNodeType, owl:NamedIndividual ;
+
+# An edge is an OWL individual, with properties:
+:My_edge a :toward, owl:NamedIndividual ;
+    biocypher:edge_source :My_source ;
+    biocypher:edge_target :My_target ;
+    biocypher:my_edge_prop "that" ;
+```
+Note how the properties of the edge are kept.
 
 If you use this edge model, you should select one of the subclasses of
 owl:Thing as a `root_node`, and not select any part of the object property tree.
@@ -91,7 +159,7 @@ Important parameters are:
   the output file extension will be ".ttl", but you cannot indicate "ttl" as an
   rdf_format.
 
-### For the OpjectProperty edge model
+### For the ObjectProperty edge model
 
 ```{code-block} yaml
 :caption: biocypher_config.yaml

--- a/docs/output/owl.md
+++ b/docs/output/owl.md
@@ -1,25 +1,26 @@
 # OWL
 
 The Web Ontology Language (OWL) is a (family of) knowledge representation
-language(s) for authoring ontologies. BioCypher can use taxonomies using OWL,
-butit can also output a knowledge graph in an OWL file.
+language(s) for authoring ontologies. BioCypher can use taxonomies written in
+OWL as an input, and it can also output a knowledge graph in an OWL file.
 
-OWL is one of the most used knowledge representation language and it is built
-with the Resource Description Framework (RDF) and have some compatibility with
+OWL is one of the most used knowledge representation languages and is built
+on the Resource Description Framework (RDF) and thus is partly compatible with
 the RDF Schema data model. It can be serialized in several formats (most known
 being XML and Turtle). The [Protégé](https://protege.stanford.edu/) software
 is the *de facto* standard graphical user interface to design OWL ontologies.
 
 In BioCypher, selecting the `owl` output format will call the `_OWLWriter` class
-and generate a sefl-contained OWL file. The file is said to be "self-contained"
+and generate a self-contained OWL file. The file is said to be "self-contained"
 because it holds both the vocabulary (i.e. a part of the hierarchy of classes
 from the input ontology) and the instances (i.e. "nodes", for Biocypher).
 
 
 ## Edge Model
 
-The behavior rely mainly on the `edge_model` parameter,
-which can takes two values: "ObjectProperty" or "Association".
+The behavior of edge creation in the RDF output relies mainly on the
+`edge_model` parameter, which can take two values: "ObjectProperty" or
+"Association".
 
 
 ### ObjectProperty
@@ -47,33 +48,33 @@ configuration.
 
 This edge model (the default) translates BioCypher's
 edges into OWL's class instances. Those edges instances are
-inserted inbetween the instances coming from BioCypher's nodes.
-This allows to keep edges properties, but adds OWL instances
+inserted in between the instances coming from BioCypher's nodes.
+This allows to retain edge properties, but adds OWL instances
 to model relationships, which does not follow the classical
 OWL model.
 
 In this approach, all OWL instances are linked
 with a generic "edge\_source" (linking source instance to
 the association instance) and "edge\_target" (linking the association
-instance to the target instance). Both of which inherits from "edge",
+instance to the target instance). Both of which inherit from "edge",
 and are in the biocypher namespace.
 
-If you use this edge model, you should select a `root_node` as one of
-the subclass of owl:Thing, and not select any part of the object property tree.
+If you use this edge model, you should select one of the subclasses of
+owl:Thing as a `root_node`, and not select any part of the object property tree.
 
 
 ## Taxonomy Management
 
 This class takes care of keeping the vocabulary underneath the
 selected root node and exports it along the instances in the
-resulting OWL file. It discards whatever terms are not in the
+resulting OWL file. It discards all terms that are not in the
 tree below the selected root node.
 
-The configuration paramater `rdf_namespaces`, can be used to specify which
+The configuration parameter `rdf_namespaces` can be used to specify which
 namespaces exist in the input ontology (or the data). If the data contain IDs
 with a given prefix, they will be converted into valid Uniform Resource
-Identifiers (URI) to allow referencing. If no namespace are specified, BioCypher
-will search for them into the input ontology.
+Identifiers (URI) to allow referencing. If no namespace is specified, BioCypher
+will search for them in the input ontology.
 
 
 ## Settings
@@ -156,17 +157,17 @@ the selected edge model (especially "Association").
 
 Note that Protégé may show a couple of impediments:
 
-- It display owl:Entity as if it inherits from owl:Thing, but that is not
+- It displays owl:Entity as if it inherits from owl:Thing, but that is not
   necessarily actually implemented by a predicate. You may have to add it
   manually.
 - It displays all owl:ObjectProperty as if they inherit from
   owl:topObjectProperty, but you may also have to add the predicate manually.
-- It gives no easy way to add a meta-root on top of both classes, and an
+- It provides no easy way to add a meta-root on top of both classes, and a
   manually added one will appear as a *subclass* of both owl:Thing and
   owl:topObjectProperty.
 
-Double-checking the ontology file source code itself should help you checking
-whether it fits Biocypher's constraints.
+Double-checking the ontology file source code itself should help you ensure
+compatibility with BioCypher's constraints.
 
 Also, note that BioCypher requires that classes (and object properties) have an
 RDFS label, and will use it (and not the IRI) to find the necessary types.

--- a/docs/output/owl.md
+++ b/docs/output/owl.md
@@ -249,9 +249,9 @@ Important parameters are:
   structure, and thus the queries that can be made on it (see above).
 - `file_stem` is the name of the output file (without the extension or the path)
   which will be written in the output directory.
-- `rdf_format` is the output serialization format. Note that if set to "turtle",
+- `file_format` is the output serialization format. Note that if set to "turtle",
   the output file extension will be ".ttl", but you cannot indicate "ttl" as an
-  rdf_format.
+  file_format.
 
 ### For the ObjectProperty edge model
 
@@ -268,7 +268,7 @@ biocypher:
         root_node: BioCypherRoot # <- The "meta-root" class.
 
 owl:
-    rdf_format: turtle # <- Note that this is not "ttl".
+    file_format: turtle # <- Note that this is not "ttl".
     # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
 
     edge_model: ObjectProperty
@@ -297,7 +297,7 @@ biocypher:
         root_node: Entity # <- NOT the meta-root!
 
 owl:
-    rdf_format: turtle
+    file_format: turtle
     # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
 
     edge_model: Association

--- a/docs/output/owl.md
+++ b/docs/output/owl.md
@@ -268,8 +268,8 @@ biocypher:
         root_node: BioCypherRoot # <- The "meta-root" class.
 
 owl:
-    file_format: turtle # <- Note that this is not "ttl".
-    # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
+    file_format: turtle
+    # Can be either: xml, n3, turtle or ttl, nt, pretty-xml, trix, trig, nquads, json-ld
 
     edge_model: ObjectProperty
     # Can also be: Association (the default)
@@ -298,7 +298,7 @@ biocypher:
 
 owl:
     file_format: turtle
-    # Can be either: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
+    # Can be either: xml, n3, turtle or ttl, nt, pretty-xml, trix, trig, nquads, json-ld
 
     edge_model: Association
 

--- a/docs/output/rdf.md
+++ b/docs/output/rdf.md
@@ -6,7 +6,7 @@ the `_RDFWriter` module.
 ## RDF settings
 
 To write your output to RDF, you have to specify some RDF settings in the
-biocypher_config.yaml. Using `rdf_format`, you can choose to export to xml,
+biocypher_config.yaml. Using `file_format`, you can choose to export to xml,
 turtle or any other format `rdflib` supports. The second configuration is the
 `rdf_namespaces`, where you can specify which namespaces exist in your data. If,
 for instance, your data contain SO (Sequence ontology) terms such as
@@ -27,7 +27,7 @@ biocypher:
 
 ### RDF configuration ###
 rdf:
-  rdf_format: turtle
+  file_format: turtle
   # options: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
   rdf_namespaces:
     so: http://purl.obolibrary.org/obo/SO_

--- a/docs/output/rdf.md
+++ b/docs/output/rdf.md
@@ -28,7 +28,7 @@ biocypher:
 ### RDF configuration ###
 rdf:
   file_format: turtle
-  # options: xml, n3, turtle, nt, pretty-xml, trix, trig, nquads, json-ld
+  # options: xml, n3, turtle or ttl, nt, pretty-xml, trix, trig, nquads, json-ld
   rdf_namespaces:
     so: http://purl.obolibrary.org/obo/SO_
     efo: http://www.ebi.ac.uk/efo/EFO_

--- a/test/fixtures/owl.py
+++ b/test/fixtures/owl.py
@@ -1,0 +1,23 @@
+import os
+
+import pytest
+
+from biocypher.output.write.graph._owl import _OWLWriter
+
+
+@pytest.fixture(scope="function")
+def bw_owl(translator, deduplicator, tmp_path_session):
+    bw_owl = _OWLWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        delimiter=",",
+        rdf_format="turtle",
+        file_stem="biocypher",
+    )
+
+    yield bw_owl
+
+    # teardown
+    for f in os.listdir(tmp_path_session):
+        os.remove(os.path.join(tmp_path_session, f))

--- a/test/fixtures/owl.py
+++ b/test/fixtures/owl.py
@@ -21,3 +21,21 @@ def bw_owl(translator, deduplicator, tmp_path_session):
     # teardown
     for f in os.listdir(tmp_path_session):
         os.remove(os.path.join(tmp_path_session, f))
+
+
+@pytest.fixture(scope="function")
+def bw_owl_ttl(translator, deduplicator, tmp_path_session):
+    """Fixture for OWL writer with ttl format."""
+    bw_owl_ttl = _OWLWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        delimiter=",",
+        file_format="ttl",  # Using ttl format directly instead of turtle
+        file_stem="biocypher",
+    )
+    yield bw_owl_ttl
+
+    # teardown
+    for f in os.listdir(tmp_path_session):
+        os.remove(os.path.join(tmp_path_session, f))

--- a/test/fixtures/owl.py
+++ b/test/fixtures/owl.py
@@ -12,7 +12,7 @@ def bw_owl(translator, deduplicator, tmp_path_session):
         deduplicator=deduplicator,
         output_directory=tmp_path_session,
         delimiter=",",
-        rdf_format="turtle",
+        file_format="turtle",
         file_stem="biocypher",
     )
 

--- a/test/fixtures/rdf.py
+++ b/test/fixtures/rdf.py
@@ -20,3 +20,21 @@ def bw_rdf(translator, deduplicator, tmp_path_session):
     # teardown
     for f in os.listdir(tmp_path_session):
         os.remove(os.path.join(tmp_path_session, f))
+
+
+@pytest.fixture(scope="function")
+def bw_rdf_ttl(translator, deduplicator, tmp_path_session):
+    """Fixture for RDF writer with ttl format."""
+    bw_rdf_ttl = _RDFWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        file_format="ttl",  # Using ttl format directly
+        rdf_namespaces={},
+        delimiter=",",
+    )
+    yield bw_rdf_ttl
+
+    # teardown
+    for f in os.listdir(tmp_path_session):
+        os.remove(os.path.join(tmp_path_session, f))

--- a/test/fixtures/rdf.py
+++ b/test/fixtures/rdf.py
@@ -11,10 +11,10 @@ def bw_rdf(translator, deduplicator, tmp_path_session):
         translator=translator,
         deduplicator=deduplicator,
         output_directory=tmp_path_session,
+        file_format="xml",
+        rdf_namespaces={},
         delimiter=",",
     )
-    bw_rdf.rdf_format = "xml"
-    bw_rdf.namespaces = {}
     yield bw_rdf
 
     # teardown

--- a/test/output/write/graph/test_owl.py
+++ b/test/output/write/graph/test_owl.py
@@ -1,0 +1,196 @@
+import glob
+import os
+
+import pytest
+
+from rdflib import (
+    OWL,
+    RDFS,
+    URIRef,
+)
+
+from rdflib import CSVW, RDF, Graph, Literal
+
+
+def fix_ontology(bw_owl):
+    entity = list(bw_owl.graph.triples((None, RDFS.subClassOf, OWL.Thing)))
+    if not entity:
+        # Manually add Entity as having an ancestor,
+        # or else Biocypher will not consider it.
+        # FIXME is this a bug of BioCypher?
+        bw_owl.graph.add((URIRef(bw_owl.namespaces["biocypher"]["Entity"]), RDFS.subClassOf, OWL.Thing))
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_owl_write_data(bw_owl, length, _get_nodes, _get_edges):
+    # See test/fixtures/owl.py
+    bw_owl.edge_model = "Association"
+
+    # logging.basicConfig()
+    # logger = logging.getLogger("biocypher")
+
+    nodes = _get_nodes
+    edges = _get_edges
+
+    fix_ontology(bw_owl)
+
+    nodes = bw_owl.write_nodes(nodes)
+    edges = bw_owl.write_edges(edges)
+
+    # check if the writing of the nodes went okay.
+    assert all([nodes, edges])
+
+    tmp_path = bw_owl.outdir
+
+    owl_file_path = os.path.join(tmp_path, "*.ttl")
+    owl_file = glob.glob(owl_file_path)
+    assert len(owl_file) == 1
+
+    graph = Graph()
+    with open(owl_file[0]) as f:
+        temp_graph = Graph().parse(data=f.read(), format="turtle")
+        graph += temp_graph
+
+    biocypher_namespace = bw_owl.namespaces["biocypher"]
+
+    # All nodes should have an identifier
+    assert len(set(graph.subjects(biocypher_namespace["id"]))) == 8
+
+    # everything should have a type assigned
+    assert len(set(graph.subjects(RDF.type))) == 1550
+
+    # check if all the nodes have assigned their properties
+    assert len(set(graph.subject_objects())) == 9890
+
+    # assert the classes
+    # FIXME it is strange that everything is a Class in the input ontology, why no types hierarchy?
+    assert (bw_owl.namespaces["biolink"]["Protein"], RDF.type, OWL.Class) in graph
+    assert (bw_owl.namespaces["biolink"]["MicroRNA"], RDF.type, OWL.Class) in graph
+    assert (
+        biocypher_namespace["PERTURBED_IN_DISEASE"],
+        RDF.type,
+        OWL.Class,
+    ) in graph
+    assert (biocypher_namespace["Is_Mutated_In"], RDF.type, OWL.Class) in graph
+
+    for i in range(4):
+        # assert the properties of the nodes
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["score"],
+            Literal(float("{:.6e}".format(4 / (i + 1)).replace(".000000", ""))),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            CSVW.name,
+            Literal("StringProperty1"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["taxon"],
+            Literal(9606),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["genes"],
+            Literal("gene1"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["genes"],
+            Literal("gene2"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["id"],
+            Literal(f"p{i + 1}"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            biocypher_namespace["preferred_id"],
+            Literal("uniprot"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"p{i + 1}"],
+            RDF.type,
+            biocypher_namespace["Protein"],
+        ) in graph
+
+        assert (
+            biocypher_namespace[f"m{i + 1}"],
+            CSVW.name,
+            Literal("StringProperty1"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"m{i + 1}"],
+            biocypher_namespace["taxon"],
+            Literal(9606),
+        ) in graph
+        assert (
+            biocypher_namespace[f"m{i + 1}"],
+            biocypher_namespace["id"],
+            Literal(f"m{i + 1}"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"m{i + 1}"],
+            biocypher_namespace["preferred_id"],
+            Literal("mirbase"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"m{i + 1}"],
+            RDF.type,
+            biocypher_namespace["MicroRNA"],
+        ) in graph
+
+        # assert the relationship of the nodes
+        assert (
+            biocypher_namespace[f"p{i}"],
+            biocypher_namespace["edge_source"],
+            biocypher_namespace[f"prel{i}"],
+        ) in graph
+        assert (
+            biocypher_namespace[f"prel{i}"],
+            biocypher_namespace["edge_target"],
+            biocypher_namespace[f"p{i + 1}"],
+        ) in graph
+        assert (
+            biocypher_namespace[f"prel{i}"],
+            biocypher_namespace["residue"],
+            Literal("T253"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"prel{i}"],
+            biocypher_namespace["level"],
+            Literal(4),
+        ) in graph
+        assert (
+            biocypher_namespace[f"prel{i}"],
+            RDF.type,
+            biocypher_namespace["PERTURBED_IN_DISEASE"],
+        ) in graph
+
+        assert (
+            biocypher_namespace[f"m{i}"],
+            biocypher_namespace["edge_source"],
+            biocypher_namespace[f"mrel{i}"],
+        ) in graph
+        assert (
+            biocypher_namespace[f"mrel{i}"],
+            biocypher_namespace["edge_target"],
+            biocypher_namespace[f"p{i + 1}"],
+        ) in graph
+        assert (
+            biocypher_namespace[f"mrel{i}"],
+            biocypher_namespace["site"],
+            Literal("3-UTR"),
+        ) in graph
+        assert (
+            biocypher_namespace[f"mrel{i}"],
+            biocypher_namespace["confidence"],
+            Literal(1),
+        ) in graph
+        assert (
+            biocypher_namespace[f"mrel{i}"],
+            RDF.type,
+            biocypher_namespace["Is_Mutated_In"],
+        ) in graph

--- a/test/output/write/graph/test_owl.py
+++ b/test/output/write/graph/test_owl.py
@@ -47,7 +47,7 @@ def test_owl_write_data(bw_owl, length, _get_nodes, _get_edges):
     assert len(owl_file) == 1
 
     graph = Graph()
-    with open(owl_file[0]) as f:
+    with open(owl_file[0], encoding="utf-8") as f:
         temp_graph = Graph().parse(data=f.read(), format="turtle")
         graph += temp_graph
 
@@ -78,7 +78,7 @@ def test_owl_write_data(bw_owl, length, _get_nodes, _get_edges):
         assert (
             biocypher_namespace[f"p{i + 1}"],
             biocypher_namespace["score"],
-            Literal(float("{:.6e}".format(4 / (i + 1)).replace(".000000", ""))),
+            Literal(float(f"{4 / (i + 1):.6e}".replace(".000000", ""))),
         ) in graph
         assert (
             biocypher_namespace[f"p{i + 1}"],

--- a/test/output/write/graph/test_rdf.py
+++ b/test/output/write/graph/test_rdf.py
@@ -204,7 +204,5 @@ def test_rdf_ttl_format(bw_rdf, length, _get_nodes, _get_edges):
     # Verify that the graph contains data
     assert len(graph) > 0
 
-    biocypher_namespace = Namespace("https://biocypher.org/biocypher#")
-
     # Basic verification that the graph contains expected data
     assert len(set(graph.subjects(RDF.type))) > 0


### PR DESCRIPTION
A writer able to output a self-contained populated OWL file:
- Based on RDFWriter.
- Embbed the input ontology within the output one.
- Using the input's namespaces.
- Allows two edge models:
    - using owl:ObjectProperty, but losing edge properties,
    - or using intermediate owl:Class, keeping edge properties.

Internal changes:
- Adds `get_rdf_graph` to Ontology.
- Rename _rdf:`subject_to_uri` to `to_uri`.
- Adds a compatible `as_uri` to deal with explicit namespaces.
- Adds `find_uri` for terms with unknown namespaces.