### PR TITLE
Fix neo4j import script not correctly generated due to problematic writer instance management

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -301,7 +301,7 @@ class BioCypher:
 
         return self._translator
 
-    def _get_writer(self):
+    def _initialize_writer(self) -> None:
         """Create writer if not online.
 
         Set as instance variable `self._writer`.
@@ -327,8 +327,6 @@ class BioCypher:
         else:
             msg = "Cannot get writer in online mode."
             raise NotImplementedError(msg)
-
-        return self._writer
 
     def _get_driver(self):
         """Create driver if not exists.
@@ -385,7 +383,9 @@ class BioCypher:
         translated_nodes = self._translator.translate_entities(nodes)
 
         if self._offline:
-            passed = self._get_writer().write_nodes(
+            if not self._writer:
+                self._initialize_writer()
+            passed = self._writer.write_nodes(
                 translated_nodes,
                 batch_size=batch_size,
                 force=force,

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -138,5 +138,5 @@ def test_get_writer_in_online_mode(core):
         core._dbms = dbms
         core._offline = False
         with pytest.raises(NotImplementedError) as e:
-            core._get_writer()
+            core._initialize_writer()
         assert str(e.value) == "Cannot get writer in online mode."


### PR DESCRIPTION
When the output is set to be neo4j offline, the generated import script is incorrect. The commands inside will only import one node type. After investigation, this is because a new writer is repeatedly created which makes BioCypher lose track of the CSV files created.

Another bug was found along the way that `write_edges` never creates a writer so that one cannot update an existing KG.

This PR fixes both of them.

I am not sure `main` is the branch I should target but it seems that `dev` is abandoned. In addition, `test_sqlite` does not pass because the script generated in the test is incorrect on Windows platform.