### PR TITLE
Bump version: 0.9.5 → 0.9.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.5
+current_version = 0.9.6
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/biocypher/_metadata.py
+++ b/biocypher/_metadata.py
@@ -10,7 +10,7 @@ import pathlib
 
 import toml
 
-_VERSION = "0.9.5"
+_VERSION = "0.9.6"
 
 
 def get_metadata():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "biocypher"
-version = "0.9.5"
+version = "0.9.6"
 description = "A unifying framework for biomedical research knowledge graphs"
 authors = [
     "Sebastian Lobentanzer <sebastian.lobentanzer@gmail.com>",
@@ -59,7 +59,7 @@ hypothesis = "^6.50.1"
 ipython = "^8.7.0"
 ipykernel = "^6.23.1"
 coverage-badge = "^1.1.0"
-nbsphinx = "^0.9.5"
+nbsphinx = "^0.9.6"
 ruff = "^0.2.0"
 mike = "^2.1.3"
 


### PR DESCRIPTION
This PR has been created to in order to solve the uncommited changes when run `bumpversion patch` due to user permissions.

Modified files:
- .bumpversion.cfg
- biocypher/_metadata.py
- pyproject.toml 

All the files were modified by bump2version, however, some file weren't committed automatically.