### PR TITLE
Docs/add directed property to schema config

### DIFF
--- a/docs/reference/schema-config.md
+++ b/docs/reference/schema-config.md
@@ -84,6 +84,9 @@ ligand receptor interaction:
 
 ### `directed`
 - **Description:** For relationships (edges or reified as nodes), specifies whether the relationship is directed. If `true`, directionality is preserved and two edge types are created: `IS_SOURCE_OF` and `IS_TARGET_OF`. If `false` or omitted, both edges are labeled as `IS_PART_OF`, and directionality is not preserved.
+- **Possible values:**
+  - `true`
+  - `false`
 
 ### `exclude_properties`
 - **Description:** Specifies properties that should be excluded from the current entity or relation, preventing them from being inherited or used.


### PR DESCRIPTION
This pull request updates the schema configuration documentation to clarify how directionality is handled for ligand-receptor interactions and introduces a new field reference for the `directed` property. The changes improve the documentation for users defining relationships in the schema.

Schema documentation improvements:

* Added an additional block to the `schema-config.yaml` example in the `EDGES AS NODES` section to clarify that the `directed` field is part of the properties.
* Introduced a detailed description for the `directed` property in the Fields reference, explaining its effect on relationship directionality and edge labeling.