### PR TITLE
docs: document write_schema_info() workflow for BioChatter integration

### DIFF
--- a/docs/biocypher-project/biochatter-integration.md
+++ b/docs/biocypher-project/biochatter-integration.md
@@ -18,3 +18,64 @@ BioChatter is a Python package implementing a generic backend library for the co
     [:octicons-arrow-right-24: To BioChatter Repository](https://github.com/biocypher/biochatter)
 
 </div>
+
+## Connecting via Schema Info
+
+To enable BioChatter to understand the structure of your knowledge graph, BioCypher
+provides the `write_schema_info()` method. This generates a `schema_info.yaml` file
+that extends your `schema_config.yaml` with runtime information about the actual
+contents of the built KG.
+
+The generated schema info includes:
+
+- **`is_schema_info: true`** -- distinguishes this from a regular schema config
+- **`present_in_knowledge_graph: true/false`** -- marks which entities were actually
+  written during the build
+- **`is_relationship: true/false`** -- indicates whether an entity is a relationship
+  (important when relationships are represented as nodes via `label_as_edge`)
+
+### Usage
+
+Call `write_schema_info()` **after** writing all nodes and edges:
+
+```python
+from biocypher import BioCypher
+
+bc = BioCypher()
+
+# Build the knowledge graph
+bc.write_nodes(node_generator())
+bc.write_edges(edge_generator())
+
+# Generate schema info as a YAML file
+bc.write_schema_info()
+
+# Generate the database import script
+bc.write_import_call()
+```
+
+This writes a `schema_info.yaml` file to the output directory. You can then
+point BioChatter to this file so it understands the KG structure for query
+generation.
+
+#### Writing Schema Info as a KG Node
+
+Alternatively, you can embed the schema info directly into the knowledge graph
+as a queryable node. This allows BioChatter to retrieve the schema by querying
+the graph itself:
+
+```python
+bc.write_schema_info(as_node=True)
+```
+
+When `as_node=True`, a node with label `schema_info` is added to the KG, storing
+the full schema as a JSON property. This also automatically re-runs
+`write_import_call()` to include the new node in the import script.
+
+!!! note
+    `write_schema_info()` only works in offline mode or with in-memory DBMS
+    (e.g., `pandas`, `networkx`). It requires data from the deduplication step,
+    so it must be called after `write_nodes()` and `write_edges()`.
+
+For more details on how BioChatter uses this information for LLM-powered
+knowledge graph querying, see the [BioChatter documentation](https://biochatter.org/).

--- a/docs/learn/quickstart.md
+++ b/docs/learn/quickstart.md
@@ -261,6 +261,20 @@ To retrieve the dataframe once all entities are in the graph, we can call
 df = bc.to_df()
 ```
 
+After writing all nodes and edges, you can finalize the build:
+
+```python
+bc.write_import_call()    # generate database import script (offline mode)
+bc.write_schema_info()    # generate schema info for BioChatter (optional)
+```
+
+The `write_schema_info()` method creates a `schema_info.yaml` file that
+describes the structure of your knowledge graph, which can be used by
+[BioChatter](../biocypher-project/biochatter-integration.md) to enable
+LLM-powered querying. See the [BioChatter integration
+page](../biocypher-project/biochatter-integration.md#connecting-via-schema-info)
+for details.
+
 For more information on the usage of these functions, please refer to the
 [Tutorial](../learn/tutorials/tutorial001_basics.md) section and the [full API documentation](../reference/source/index.md).
 

--- a/docs/learn/tutorials/tutorial_basics_neo4j_offline/tutorial_004_neo4j_offline.md
+++ b/docs/learn/tutorials/tutorial_basics_neo4j_offline/tutorial_004_neo4j_offline.md
@@ -1202,7 +1202,15 @@ Finally, write the functions that read the data as a DataFrame and override the 
         bc.write_import_call()
         ```
 
-6. Print summary
+6. (Optional) Generate schema info for [BioChatter](../../../biocypher-project/biochatter-integration.md) integration
+
+    ??? example "**File: `create_knowledge_graph.py`**"
+        ```python
+        # Generate schema info for LLM-powered querying via BioChatter
+        bc.write_schema_info()
+        ```
+
+7. Print summary
 
     ??? example "**File: `create_knowledge_graph.py`**"
         ```python
@@ -1283,6 +1291,9 @@ Finally, write the functions that read the data as a DataFrame and override the 
 
     # Generate assets for Neo4j exportation
     bc.write_import_call()
+
+    # (Optional) Generate schema info for BioChatter
+    bc.write_schema_info()
 
     # Print a summary when
     bc.summary()

--- a/docs/reference/outputs/index.md
+++ b/docs/reference/outputs/index.md
@@ -38,7 +38,9 @@ Furthermore, you can specify whether to use the `offline` or `online` mode.
   knowledge graph to files in a designated output folder (standard being
   `biocypher-out/` and the current datetime). Furthermore, you can generate a
   bash script to insert the knowledge graph files into the specified `dbms` by
-  running `bc.write_import_call()`.
+  running `bc.write_import_call()`. You can also generate a schema info file
+  for use with [BioChatter](../../biocypher-project/biochatter-integration.md)
+  by calling `bc.write_schema_info()` after writing nodes and edges.
 
 !!! warning "Warning"
 	The `online` mode is currently only supported for `neo4j`, `tabular`,

--- a/docs/reference/outputs/neo4j-output.md
+++ b/docs/reference/outputs/neo4j-output.md
@@ -167,6 +167,20 @@ header and data files for each entity type, the import call conveniently
 aggregates this information into one command, detailing the location of all
 files on disk, so no data need to be copied around.
 
+!!! tip "Schema Info for BioChatter"
+    To enable LLM-powered querying of your knowledge graph via
+    [BioChatter](../../biocypher-project/biochatter-integration.md), you can
+    generate a schema info file that describes the structure of the built KG:
+
+    ```python
+    bc.write_schema_info()                # writes schema_info.yaml to output directory
+    bc.write_schema_info(as_node=True)    # also adds a schema_info node to the KG
+    ```
+
+    When using `as_node=True`, the import call is automatically regenerated to
+    include the schema info node. Call this **after** `write_nodes()` and
+    `write_edges()`.
+
 !!! note "Note"
     The generated import call differs between Neo4j version 4 and 5.
     Starting from major version 5, Neo4j `import` command needs the


### PR DESCRIPTION
## Summary

- Add a new "Connecting via Schema Info" section to the BioChatter integration page explaining what `write_schema_info()` does, how to use it (file vs. node mode), and its constraints
- Add `write_schema_info()` to the quickstart, Neo4j offline tutorial, and output reference pages wherever `write_import_call()` was already shown

## Context

The `write_schema_info()` method is the key bridge between BioCypher and BioChatter, but it was only discoverable via the API reference. Users had no guidance on when to call it, what it produces, or how BioChatter uses the output.

## Test plan

- [ ] Verify pages render correctly with `mkdocs serve`
- [ ] Check all internal links resolve
- [ ] Review code examples for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)