### PR TITLE
Remove unused Python shebangs from example scripts

### DIFF
--- a/examples/agent_integration_example.py
+++ b/examples/agent_integration_example.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """BioCypher Agent Integration Example
 
 This example demonstrates how LLM agents can use BioCypher to create and

--- a/examples/unified_graph_example.py
+++ b/examples/unified_graph_example.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Unified Graph Example - Simplified Knowledge Representation
 
 This example demonstrates how the unified Graph class streamlines knowledge


### PR DESCRIPTION
Closes #383.

The two example scripts still carried a `#!/usr/bin/env python3` line
even though they are not marked executable and the docs invoke them as
`python examples/<name>.py`. The shebangs are dead code, so drop them
per the direction in #383.

Sweep confirmation:

```bash
$ rg '^#!/' --glob '*.py' --glob '*.pyi'
examples/unified_graph_example.py:1:#!/usr/bin/env python3
examples/agent_integration_example.py:1:#!/usr/bin/env python3
```

After this PR, no Python file in the repo starts with a shebang. The
companion request in #383 ("copyright comments from the top of modules")
already appears to be clean - I could not find any author/copyright
headers in any `*.py` file.

### Verification

Both files still parse cleanly after the edit (docstring is now the
module's first statement).

```bash
$ python -c 'import ast; ast.parse(open("examples/unified_graph_example.py").read()); ast.parse(open("examples/agent_integration_example.py").read())'
```