### PR TITLE
fix: handle empty iterables in write_nodes/write_edges without crashing

### DIFF
--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -59,9 +59,14 @@ class Translator:
 
     def translate_entities(self, entities):
         entities = peekable(entities)
-        if isinstance(entities.peek(), BioCypherEdge | BioCypherNode | BioCypherRelAsNode):
+        try:
+            first = entities.peek()
+        except StopIteration:
+            logger.warning("No entities provided; returning empty iterator.")
+            return (x for x in [])
+        if isinstance(first, BioCypherEdge | BioCypherNode | BioCypherRelAsNode):
             translated_entities = entities
-        elif len(entities.peek()) < 4:
+        elif len(first) < 4:
             translated_entities = self.translate_nodes(entities)
         else:
             translated_entities = self.translate_edges(entities)

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -576,3 +576,20 @@ def test_strict_mode_property_filter(translator):
     assert "source" in translated_protein_node[0].get_properties().keys()
     assert "licence" in translated_protein_node[0].get_properties().keys()
     assert "version" in translated_protein_node[0].get_properties().keys()
+
+
+def test_translate_entities_empty_iterable(translator):
+    """translate_entities with an empty iterable should warn and return an empty iterator (issue #493)."""
+    result = list(translator.translate_entities([]))
+    assert result == []
+
+
+def test_translate_entities_empty_generator(translator):
+    """translate_entities with an empty generator should warn and return an empty iterator (issue #493)."""
+
+    def empty_gen():
+        return
+        yield  # make it a generator
+
+    result = list(translator.translate_entities(empty_gen()))
+    assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.1"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #493.

`write_nodes([])` and `write_edges([])` raised an unhandled `StopIteration` because `translate_entities` called `peekable.peek()` directly on the input without guarding against an empty iterable.

- Wrap `peek()` in a `try/except StopIteration` block in `Translator.translate_entities`
- Log a `WARNING` when an empty iterable is detected (as agreed in the issue discussion)
- Return an empty generator so downstream writers receive a valid iterable and don't crash

## Test plan

- [x] `test_translate_entities_empty_iterable` — passes `[]` to `translate_entities`, asserts empty result
- [x] `test_translate_entities_empty_generator` — passes an empty generator, asserts empty result
- [x] Existing `test_translate_*` suite passes unchanged

https://claude.ai/code/session_01VA4TAZ9kr9dJSLc6utCbCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA4TAZ9kr9dJSLc6utCbCQ)_