### PR TITLE
fix(translate): handle empty iterables in write_nodes/write_edges with a warning

### DIFF
--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -59,9 +59,16 @@ class Translator:
 
     def translate_entities(self, entities):
         entities = peekable(entities)
-        if isinstance(entities.peek(), BioCypherEdge | BioCypherNode | BioCypherRelAsNode):
+        try:
+            first = entities.peek()
+        except StopIteration:
+            logger.warning(
+                "Received empty iterable in translate_entities. No entities will be written."
+            )
+            return (x for x in [])
+        if isinstance(first, BioCypherEdge | BioCypherNode | BioCypherRelAsNode):
             translated_entities = entities
-        elif len(entities.peek()) < 4:
+        elif len(first) < 4:
             translated_entities = self.translate_nodes(entities)
         else:
             translated_entities = self.translate_edges(entities)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -140,3 +141,17 @@ def test_get_writer_in_online_mode(core):
         with pytest.raises(NotImplementedError) as e:
             core._initialize_writer()
         assert str(e.value) == "Cannot get writer in online mode."
+
+
+def test_write_nodes_empty_iterable(core, caplog):
+    with caplog.at_level(logging.WARNING):
+        core.write_nodes([])
+
+    assert any("empty iterable" in msg.lower() for msg in caplog.messages)
+
+
+def test_write_edges_empty_iterable(core, caplog):
+    with caplog.at_level(logging.WARNING):
+        core.write_edges([])
+
+    assert any("empty iterable" in msg.lower() for msg in caplog.messages)

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -576,3 +576,13 @@ def test_strict_mode_property_filter(translator):
     assert "source" in translated_protein_node[0].get_properties().keys()
     assert "licence" in translated_protein_node[0].get_properties().keys()
     assert "version" in translated_protein_node[0].get_properties().keys()
+
+
+def test_translate_entities_empty_iterable(translator, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        result = translator.translate_entities([])
+
+    assert list(result) == []
+    assert any("empty iterable" in msg.lower() for msg in caplog.messages)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.1"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #493.

Calling `write_nodes([])` or `write_edges([])` with an empty iterable previously raised an unhandled `StopIteration` from `peekable.peek()` deep inside `translate_entities`, giving users an opaque crash with no guidance.

- Wrap the `entities.peek()` call in a `try/except StopIteration` block in `Translator.translate_entities`
- On empty input, emit a `logger.warning` and return an empty generator so the pipeline completes cleanly
- Add tests in `test_translate.py` (unit) and `test_core.py` (integration) confirming the warning fires and no exception is raised

## Test plan

- [x] `test/test_translate.py::test_translate_entities_empty_iterable` — verifies the translator emits a warning and returns an empty result for `[]`
- [x] `test/test_core.py::test_write_nodes_empty_iterable` — verifies `BioCypher.write_nodes([])` does not raise and emits a warning
- [x] `test/test_core.py::test_write_edges_empty_iterable` — same for `write_edges([])`
- [x] Full `test/test_translate.py` and `test/test_core.py` suites pass with no regressions (33 tests)

https://claude.ai/code/session_01GEd9QdN9YoZQwf7JhdC5Tv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEd9QdN9YoZQwf7JhdC5Tv)_