### PR TITLE
fix(get): preserve query params in cache filenames; hash full URL when too long

### DIFF
--- a/biocypher/_get.py
+++ b/biocypher/_get.py
@@ -457,7 +457,10 @@ class Downloader:
     def _trim_filename(self, url: str, max_length: int = 150) -> str:
         """Create a trimmed filename from a URL.
 
-        If the URL exceeds max_length, create a hash of the filename.
+        Preserves query parameters (sanitised) so that requests to the same
+        endpoint with different parameters produce distinct cache files.  When
+        the sanitised name would exceed ``max_length`` the *full* URL is hashed
+        to keep the name short while still guaranteeing uniqueness.
 
         Args:
         ----
@@ -469,18 +472,18 @@ class Downloader:
             str: A valid filename derived from the URL, trimmed if necessary
 
         """
-        # Extract the filename from the URL
+        import hashlib
+
+        # Extract path segment + query string after the last slash
         fname = url[url.rfind("/") + 1 :]
 
-        # Remove query parameters if present
-        if "?" in fname:
-            fname = fname.split("?")[0]
+        # Replace characters that are invalid or problematic in filenames
+        for ch in '?&=:*|<>"\\()[]{}; ':
+            fname = fname.replace(ch, "_")
 
         if len(fname) > max_length:
-            import hashlib
+            # Hash the *full* URL so that different query strings on the same
+            # endpoint always produce distinct, fixed-length filenames.
+            fname = hashlib.md5(url.encode()).hexdigest()
 
-            fname_trimmed = hashlib.md5(fname.encode()).hexdigest()
-        else:
-            fname_trimmed = fname
-
-        return fname_trimmed
+        return fname

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -410,3 +410,59 @@ def test_download_file_with_long_url(mock_get):
     with open(paths[0], "rb") as f:
         content = f.read()
         assert b"test file content" in content
+
+
+@patch("requests.get")
+def test_api_request_long_query_string(mock_get):
+    """Regression test for issue #433: short path + long query string → ENAMETOOLONG."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json = lambda: {"data": "test content"}
+    mock_response.raise_for_status = Mock()
+    mock_get.return_value = mock_response
+
+    # Reproduce the real-world pattern: short endpoint name, many query params
+    conditions = [f"linear_sequence.ilike.*SEQ{i}*" for i in range(20)]
+    query = "or=(" + ",".join(conditions) + ")"
+    long_url = f"https://query-api.example.org/epitope_search?{query}"
+
+    downloader = Downloader(cache_dir=None)
+    resource = APIRequest(name="iedb_test", url_s=long_url, lifetime=1)
+    paths = downloader.download(resource)
+
+    assert os.path.exists(paths[0])
+    filename = os.path.basename(paths[0])
+    assert len(filename) <= 150, f"Filename too long: {len(filename)} chars"
+
+
+@patch("requests.get")
+def test_api_request_multiple_urls_distinct_cache_files(mock_get):
+    """Multiple URLs to the same endpoint with different query params must not share a cache file.
+
+    Regression test for issue #433: stripping query params caused every URL
+    to the same path to collide on the same cached filename.
+    """
+    call_count = [0]
+
+    def side_effect(url, **kwargs):
+        call_count[0] += 1
+        resp = Mock()
+        resp.status_code = 200
+        resp.json = lambda n=call_count[0]: {"result": n}
+        resp.raise_for_status = Mock()
+        return resp
+
+    mock_get.side_effect = side_effect
+
+    url_a = "https://example.com/api/search?filter=alpha"
+    url_b = "https://example.com/api/search?filter=beta"
+
+    downloader = Downloader(cache_dir=None)
+    resource = APIRequest(name="search_test", url_s=[url_a, url_b], lifetime=1)
+    paths = downloader.download(resource)
+
+    # Each URL must produce a distinct cache file
+    assert len(paths) == 2
+    assert paths[0] != paths[1], "Different query params produced the same cache file"
+    assert os.path.exists(paths[0])
+    assert os.path.exists(paths[1])

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.4"
+version = "0.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #433 — `[Errno 36] File name too long` when an `APIRequest` URL has many query parameters.

### Root cause

`_trim_filename` stripped query parameters _before_ checking length, which introduced two bugs:

1. **ENAMETOOLONG not always fixed** — if the query string itself was the long part (e.g. `endpoint?very=long&list=of&params=...`), stripping it produced a short path-segment name that looked safe but discarded all the info.
2. **Cache collision** — when a single `APIRequest` is given a list of URLs that all hit the same endpoint but with different parameters (e.g. `url_s=["search?a=1", "search?a=2"]`), stripping query params caused every URL to resolve to the same filename, so each response overwrote the previous one.
3. **Non-unique hash** — when hashing _was_ triggered it hashed only the stripped filename, not the full URL, so different query strings on the same endpoint still produced the same hash.

### Fix (`biocypher/_get.py`)

- Replace filename-unsafe characters (`?`, `&`, `=`, `:`, `*`, …) with underscores so query parameters remain visible and distinguishable in the cache directory.
- When the sanitised name exceeds `max_length`, hash the **full URL** (MD5 hex) to guarantee uniqueness regardless of query string differences.

### Tests (`test/test_get.py`)

Two new regression tests:

| Test | What it checks |
|---|---|
| `test_api_request_long_query_string` | Short endpoint name + very long query string → no `ENAMETOOLONG`, filename ≤ 150 chars |
| `test_api_request_multiple_urls_distinct_cache_files` | `APIRequest(url_s=[url_a, url_b])` where both URLs share an endpoint but differ in query params → each lands in its own cache file |

---
_Generated by [Claude Code](https://claude.ai/code/session_018e8rT7vH5zD73Ch5QYZbTh)_