### PR TITLE
docs(create): fix BioCypherEdge docstring inaccuracies

### DIFF
--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -165,27 +165,22 @@ class BioCypherNode:
 @dataclass(frozen=True)
 class BioCypherEdge:
     """
-    Handoff class to represent biomedical relationships in Neo4j.
+    Handoff class to represent biomedical relationships as graph edges.
 
-    Has source and target ids, label, property dict; ids and label (in
-    the Neo4j sense of a label, ie, the entity descriptor after the
-    colon, such as ":TARGETS") are non-optional and called source_id,
-    target_id, and relationship_label to avoid confusion with properties
-    called "label", which usually denotes the human-readable form.
-    Relationship labels are written in UPPERCASE and as verbs, as per
-    Neo4j consensus.
+    Has source and target ids, label, and property dict. The ids and
+    label are non-optional and called source_id, target_id, and
+    relationship_label to avoid confusion with properties called "label",
+    which usually denotes the human-readable form. Relationship labels
+    are written in UPPERCASE and as verbs.
 
     Args:
-
-        source_id (string): consensus "best" id for biological entity
-
-        target_id (string): consensus "best" id for biological entity
-
-        relationship_label (string): type of interaction, UPPERCASE
-
+        source_id (str): consensus "best" id for the source biological entity
+        target_id (str): consensus "best" id for the target biological entity
+        relationship_label (str): type of interaction, UPPERCASE
+        relationship_id (str, optional): unique identifier for this
+            relationship instance; defaults to None
         properties (dict): collection of all other properties of the
-        respective edge
-
+            respective edge
     """
 
     source_id: str
@@ -223,10 +218,10 @@ class BioCypherEdge:
 
     def get_id(self) -> Union[str, None]:
         """
-        Returns primary node identifier or None.
+        Returns the relationship identifier or None.
 
         Returns:
-            str: node_id
+            str or None: relationship_id
         """
 
         return self.relationship_id


### PR DESCRIPTION
Closes #391

## Summary

Three inaccuracies in the `BioCypherEdge` docstring are fixed:

- **Neo4j-specific class description** — the class is a general handoff used across all output backends (Neo4j, Postgres, RDF, BioPathNet, …), not Neo4j-specific. Removed references to Neo4j syntax (`:TARGETS` colon-notation) and "as per Neo4j consensus".
- **Missing `relationship_id` in Args** — the field existed in the dataclass but was absent from the class-level Args section, making it invisible to anyone reading the docstring.
- **Incorrect `get_id()` return description** — the method returned `self.relationship_id` but the docstring said "Returns primary **node** identifier" and listed the return type as `str: node_id`. Corrected to "Returns the relationship identifier or None" with `str or None: relationship_id`.

## Test plan

- [x] `BioCypherEdge` still instantiates and behaves correctly (smoke-tested)
- [x] No logic changes — purely docstring corrections

https://claude.ai/code/session_01N8rkojrKYFsChiiVCtfyCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8rkojrKYFsChiiVCtfyCr)_