### PR TITLE
fix(batch_writer): write boolean properties as lowercase true/false for Neo4j

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -754,6 +754,8 @@ class _BatchWriter(_Writer, ABC):
                     p = n_props.get(k)
                     if p is None:  # TODO make field empty instead of ""?
                         plist.append("")
+                    elif v in ["bool", "boolean"]:
+                        plist.append(str(p).lower())
                     elif v in [
                         "int",
                         "integer",
@@ -761,8 +763,6 @@ class _BatchWriter(_Writer, ABC):
                         "float",
                         "double",
                         "dbl",
-                        "bool",
-                        "boolean",
                     ]:
                         plist.append(str(p))
                     elif isinstance(p, list):
@@ -991,6 +991,8 @@ class _BatchWriter(_Writer, ABC):
                 p = e_props.get(k)
                 if p is None:  # TODO make field empty instead of ""?
                     plist.append("")
+                elif v in ["bool", "boolean"]:
+                    plist.append(str(p).lower())
                 elif v in [
                     "int",
                     "integer",
@@ -998,8 +1000,6 @@ class _BatchWriter(_Writer, ABC):
                     "float",
                     "double",
                     "dbl",
-                    "bool",
-                    "boolean",
                 ]:
                     plist.append(str(p))
                 elif isinstance(p, list):

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -801,6 +801,40 @@ def test_write_edge_data_from_list_no_props(bw):
     assert "\n" in is_mutated_in
 
 
+def test_write_edge_data_boolean_properties(bw):
+    """Boolean properties must be written as lowercase 'true'/'false' for Neo4j admin import."""
+    edges = [
+        BioCypherEdge(
+            relationship_id="gg1",
+            source_id="g1",
+            target_id="g2",
+            relationship_label="gene to gene association",
+            properties={"directional": True, "curated": False, "score": 0.9},
+        ),
+        BioCypherEdge(
+            relationship_id="gg2",
+            source_id="g3",
+            target_id="g4",
+            relationship_label="gene to gene association",
+            properties={"directional": False, "curated": True, "score": 0.5},
+        ),
+    ]
+
+    passed = bw._write_edge_data(edges, batch_size=int(1e4))
+
+    tmp_path = bw.outdir
+    gene_gene_csv = os.path.join(tmp_path, "GeneToGeneAssociation-part000.csv")
+
+    with open(gene_gene_csv) as f:
+        gene_gene = f.read()
+
+    assert passed
+    assert "true" in gene_gene
+    assert "false" in gene_gene
+    assert "True" not in gene_gene
+    assert "False" not in gene_gene
+
+
 @pytest.mark.parametrize("length", [8], scope="module")
 def test_write_edge_data_headers_import_call(bw, _get_nodes, _get_edges):
     edges = _get_edges
@@ -902,7 +936,7 @@ def test_BioCypherRelAsNode_implementation(bw, _get_rel_as_nodes):
     assert "p2;" in is_target_of
     assert "IS_TARGET_OF" in is_target_of
     assert "\n" in is_target_of
-    assert "i1;True;-1;'i1';'id'" in post_translational_interaction
+    assert "i1;true;-1;'i1';'id'" in post_translational_interaction
     assert "Association" in post_translational_interaction
     assert "\n" in post_translational_interaction
 

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -299,6 +299,38 @@ def test_write_node_data_from_list(bw, _get_nodes):
     assert "ChemicalEntity" in micro_rna
 
 
+def test_write_node_data_boolean_properties(bw):
+    """Boolean node properties must be written as lowercase 'true'/'false' for Neo4j admin import."""
+    nodes = [
+        BioCypherNode(
+            node_id="i1",
+            node_label="post translational interaction",
+            properties={"directed": True, "effect": -1},
+        ),
+        BioCypherNode(
+            node_id="i2",
+            node_label="post translational interaction",
+            properties={"directed": False, "effect": 1},
+        ),
+    ]
+
+    passed = bw._write_node_data(nodes, batch_size=int(1e4))
+
+    post_translational_interaction_csv = os.path.join(
+        bw.outdir,
+        "PostTranslationalInteraction-part000.csv",
+    )
+
+    with open(post_translational_interaction_csv) as f:
+        post_translational_interaction = f.read()
+
+    assert passed
+    assert "i1;true;-1;'i1';'id'" in post_translational_interaction
+    assert "i2;false;1;'i2';'id'" in post_translational_interaction
+    assert "True" not in post_translational_interaction
+    assert "False" not in post_translational_interaction
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, _get_nodes_non_compliant_names):
     nodes = _get_nodes_non_compliant_names

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #368

- Python's `str(True)` produces `'True'` (capital T), which Neo4j admin import does not recognise as a boolean value, causing all boolean properties to be silently imported as `false`.
- Fix: use `str(p).lower()` for `bool`/`boolean` property types so the CSV output contains lowercase `'true'`/`'false'` as required by Neo4j.
- The fix applies in both `_write_node_data` and `_write_edge_data` in `_batch_writer.py` (and consequently `_ArangoDBBatchWriter` which inherits from the Neo4j writer).

## Changes

- `biocypher/output/write/_batch_writer.py`: split the numeric/boolean type branch so `bool`/`boolean` values are serialised with `.lower()`.
- `test/output/write/graph/test_neo4j.py`:
  - Update existing `test_BioCypherRelAsNode_implementation` assertion from `"True"` to `"true"` to match correct output.
  - Add `test_write_edge_data_boolean_properties` which explicitly creates edges with `True`/`False` boolean properties and asserts that the CSV contains lowercase `"true"`/`"false"` and does **not** contain Python-style `"True"`/`"False"`.

## Test plan

- [x] `test_BioCypherRelAsNode_implementation` passes (asserts `true` in node CSV)
- [x] `test_write_edge_data_boolean_properties` passes (new test)
- [x] All 39 existing Neo4j writer tests pass
- [x] ArangoDB writer tests pass

https://claude.ai/code/session_01Qo13wdZz9PfFR6i9DHy9u9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qo13wdZz9PfFR6i9DHy9u9)_