### PR TITLE
fix(neo4j): "escape" colons in property names

### DIFF
--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -64,8 +64,20 @@ class _Neo4jBatchWriter(_BatchWriter):
         return "bin/"
 
     def _quote_string(self, value: str) -> str:
-        """Quote a string. Quote character is escaped by doubling it."""
+        """Quote a value string. Quote character is escaped by doubling it."""
         return f"{self.quote}{value.replace(self.quote, self.quote * 2)}{self.quote}"
+
+    def _escape_string(self, value: str) -> str:
+        """Escape function for property names."""
+        # FIXME: Neo4j's docs says property names can be escaped with backticks:
+        #        https://neo4j.com/docs/cypher-manual/current/syntax/naming/
+        #        However, this does not takes precedence over the colon, which
+        #        is used to indicate the property type.
+        # Thus, escaping a string with backquotes hoping that
+        # it capture the colon won't work: return f"`{value}`"
+        # Similarly, double-quoting or \: don't work either.
+        # And we are left only with replacing colon with a placeholder:
+        return value.replace(":", "_COLON_")
 
     def _write_array_string(self, string_list):
         """Abstract method to output.write the string representation of an array into a .csv file
@@ -121,7 +133,8 @@ class _Neo4jBatchWriter(_BatchWriter):
 
             # concatenate key:value in props
             props_list = []
-            for k, v in props.items():
+            for key, v in props.items():
+                k = self._escape_string(key)
                 if v in ["int", "long", "integer"]:
                     props_list.append(f"{k}:long")
                 elif v in ["int[]", "long[]", "integer[]"]:
@@ -198,7 +211,8 @@ class _Neo4jBatchWriter(_BatchWriter):
 
             # concatenate key:value in props
             props_list = []
-            for k, v in props.items():
+            for key, v in props.items():
+                k = self._escape_string(key)
                 if v in ["int", "long", "integer"]:
                     props_list.append(f"{k}:long")
                 elif v in ["int[]", "long[]", "integer[]"]:

--- a/docs/reference/outputs/neo4j-output.md
+++ b/docs/reference/outputs/neo4j-output.md
@@ -253,6 +253,7 @@ configuration specified in the [schema-config.yaml](../schema-config.md).
     in your Neo4j instance. If APOC is not available, BioCypher will raise a
     clear error message. For offline mode, APOC is not required.
 
+
 ## Note on labels order
 
 Neo4j does not support managing the hierarchy of types of the vocabulary given
@@ -271,3 +272,14 @@ information, hence making it impossible to query the graph on high-level types.
 
 Note that the Neo4j database doesn't allow attaching multiple type labels to
 edges. Hence, it is always set to "Leaves" for edges.
+
+
+## Note on property names
+
+Neo4j does not support having the colon character in property names.
+For instance, it would be impossible to use a raw IRI (like an URL) as a
+property name in a Neo4j database import script.
+
+BioCypher will thus take care of replacing any colon it finds in a property
+name with the placeholder: `_COLON_`. You may thus find that property names
+set from an IRI will look like: `https_COLON_//domain.tld/prop`.


### PR DESCRIPTION
Neo4j's docs says property names can be escaped with backticks: https://neo4j.com/docs/cypher-manual/current/syntax/naming/
However, this does not take precedence over the colon, which
is used to indicate the property type.

Thus, escaping a string with back quotes hoping that
it captures the colon won't work.
Similarly, double-quoting or \: don't work either.
And we are left only with replacing colon with a `_COLON_`  placeholder.