### PR TITLE
fix(core): allow pandas and tabular as dbms aliases in offline mode

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -118,15 +118,6 @@ class BioCypher:
         else:
             self._offline = offline
 
-        # Check if pandas/tabular is being used in offline mode
-        if self._offline and self._dbms.lower() in ["pandas", "tabular"]:
-            msg = (
-                f"The '{self._dbms}' DBMS is only available in online mode. "
-                f"If you want to write CSV files, use 'csv' as the DBMS. "
-                f"If you want to use pandas, set 'offline: false' in your configuration."
-            )
-            raise ValueError(msg)
-
         if strict_mode is None:
             self._strict_mode = self.base_config["strict_mode"]
         else:
@@ -369,12 +360,12 @@ class BioCypher:
         objects. Depending on the configuration the translated nodes are then
         passed to the
 
-        - `_writer`: if `_offline` is set to `False`
+        - `_writer`: if `_offline` is set to `True`
 
         - `_in_memory_kg`: if `_offline` is set to `False` and the `_dbms` is an
             `IN_MEMORY_DBMS`
 
-        - `_driver`: if `_offline` is set to `True` and the `_dbms` is not an
+        - `_driver`: if `_offline` is set to `False` and the `_dbms` is not an
             `IN_MEMORY_DBMS`
 
         """
@@ -404,12 +395,12 @@ class BioCypher:
         objects. Depending on the configuration the translated edges are then
         passed to the
 
-        - `_writer`: if `_offline` is set to `False`
+        - `_writer`: if `_offline` is set to `True`
 
         - `_in_memory_kg`: if `_offline` is set to `False` and the `_dbms` is an
             `IN_MEMORY_DBMS`
 
-        - `_driver`: if `_offline` is set to `True` and the `_dbms` is not an
+        - `_driver`: if `_offline` is set to `False` and the `_dbms` is not an
             `IN_MEMORY_DBMS`
 
         """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -140,3 +140,16 @@ def test_get_writer_in_online_mode(core):
         with pytest.raises(NotImplementedError) as e:
             core._initialize_writer()
         assert str(e.value) == "Cannot get writer in online mode."
+
+
+def test_pandas_and_tabular_work_in_offline_mode(tmp_path):
+    """pandas and tabular are aliases for csv and should work in offline mode."""
+    for dbms in ["pandas", "tabular"]:
+        bc = BioCypher(
+            dbms=dbms,
+            offline=True,
+            schema_config_path="biocypher/_config/test_schema_config.yaml",
+            output_directory=str(tmp_path),
+        )
+        assert bc._dbms == dbms
+        assert bc._offline

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Closes #471

`pandas` and `tabular` are registered aliases for `csv` in `DBMS_TO_CLASS` — all three resolve to `_PandasCSVWriter`. However, `_core.py` blocked `pandas` and `tabular` from being used in `offline=True` mode with a `ValueError`, while `csv` worked fine. This inconsistency was the root cause of the documentation discrepancy reported in #471.

**Changes:**

- Remove the `ValueError` guard in `BioCypher.__init__` that rejected `pandas`/`tabular` when `offline=True`; all three aliases now behave identically (write CSV files offline, return an in-memory `PandasKG` online).
- Fix inverted `_offline` True/False descriptions in the `_add_nodes` and `_add_edges` docstrings (they had the writer/driver conditions swapped).

## Test plan

- [x] `test_pandas_and_tabular_work_in_offline_mode` — new test confirms `BioCypher(dbms="pandas", offline=True)` and `BioCypher(dbms="tabular", offline=True)` construct without raising an error.
- [x] All 12 existing `test_core.py` tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjhbqQh2USqNEuEC98bRr5)_