### PR TITLE
fix(config): properly merge all three config levels in read_config()

### DIFF
--- a/biocypher/_config/__init__.py
+++ b/biocypher/_config/__init__.py
@@ -82,13 +82,19 @@ def read_config() -> dict:
     local = _read_yaml("biocypher_config.yaml") or _read_yaml("config/biocypher_config.yaml") or {}
 
     for key in defaults:
-        value = local[key] if key in local else user[key] if key in user else None
-
-        if value is not None:
-            if isinstance(defaults[key], str):  # first level config (like title)
-                defaults[key] = value
+        # Apply user-level settings on top of defaults first
+        if key in user and user[key] is not None:
+            if isinstance(defaults[key], dict):
+                defaults[key].update(user[key])
             else:
-                defaults[key].update(value)
+                defaults[key] = user[key]
+
+        # Apply local settings on top (local takes precedence over user)
+        if key in local and local[key] is not None:
+            if isinstance(defaults[key], dict):
+                defaults[key].update(local[key])
+            else:
+                defaults[key] = local[key]
 
     return defaults
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -41,6 +41,6 @@ def test_read_config_merges_user_and_local(monkeypatch):
 
     result = read_config()
 
-    assert result["neo4j"]["uri"] == "neo4j://myserver:7687"   # from user
+    assert result["neo4j"]["uri"] == "neo4j://myserver:7687"  # from user
     assert result["neo4j"]["database_name"] == "my_project_db"  # from local
-    assert result["neo4j"]["password"] == "neo4j"               # from defaults
+    assert result["neo4j"]["password"] == "neo4j"  # from defaults

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,6 +1,8 @@
 import pytest
 
-from biocypher._config import _read_yaml
+import biocypher._config as cfg_module
+
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE
 
 
 def test_read_yaml():
@@ -12,3 +14,33 @@ def test_read_yaml():
 def test_for_special_characters():
     with pytest.warns(UserWarning):
         _read_yaml("biocypher/_config/test_config.yaml")
+
+
+def test_read_config_merges_user_and_local(monkeypatch):
+    """User-level and local config settings for the same top-level key should both be applied.
+
+    Previously, if a key existed in the local config, the user-level settings
+    for that same key were silently dropped. This test verifies all three config
+    levels are merged: defaults <- user <- local.
+    """
+    from biocypher._config import read_config
+
+    user_config = {"neo4j": {"uri": "neo4j://myserver:7687"}}
+    local_config = {"neo4j": {"database_name": "my_project_db"}}
+
+    _orig = cfg_module._read_yaml
+
+    def patched(path):
+        if path == _USER_CONFIG_FILE:
+            return user_config
+        if path in ("biocypher_config.yaml", "config/biocypher_config.yaml"):
+            return local_config
+        return _orig(path)
+
+    monkeypatch.setattr(cfg_module, "_read_yaml", patched)
+
+    result = read_config()
+
+    assert result["neo4j"]["uri"] == "neo4j://myserver:7687"   # from user
+    assert result["neo4j"]["database_name"] == "my_project_db"  # from local
+    assert result["neo4j"]["password"] == "neo4j"               # from defaults

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes a bug in `read_config()` where user-level config settings were silently dropped whenever the same top-level key also appeared in the local project config.

**The docstring says:**
> "Read and merge the built-in default, the user level and directory level configuration, with the later taking precedence over the former."

**What actually happened (before this fix):**

```python
# Old logic — picks ONE source per top-level key
value = local[key] if key in local else user[key] if key in user else None
```

If a user had `neo4j.uri` in `~/.config/biocypher/conf.yaml` AND the project had a local `biocypher_config.yaml` with only `neo4j.database_name`, the user's `uri` was silently lost because `local` "won" the whole `neo4j` section.

**What happens now:**

All three levels are applied in precedence order (defaults → user → local), so each setting is overridden only by a more specific config level:

```python
# Apply user settings on top of defaults first
if key in user and user[key] is not None:
    defaults[key].update(user[key])   # or replace for scalar values

# Apply local settings on top (local wins)
if key in local and local[key] is not None:
    defaults[key].update(local[key])
```

## Changes

- `biocypher/_config/__init__.py`: replace the single-source selection with two sequential merge steps
- `test/test_config.py`: add `test_read_config_merges_user_and_local` — asserts that settings from user config, local config, and defaults are all present in the result

## Test plan

- [x] `test_read_config_merges_user_and_local` — new test confirming the three-way merge works correctly
- [x] `test_read_yaml` and `test_for_special_characters` continue to pass
- [x] `test_core.py`, `test_translate.py`, `test_mapping.py` — 36 tests, all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED6bEPZmitZTANpkftQsZj)_