### PR TITLE
feat(translate): deprecate label_as_edge; add synonym_for support for edges

### DIFF
--- a/biocypher/_config/test_schema_config_edge_synonym.yaml
+++ b/biocypher/_config/test_schema_config_edge_synonym.yaml
@@ -1,0 +1,41 @@
+Title: BioCypher graph schema configuration file for edge synonym_for tests
+
+# ---
+# "Named Things"
+# ---
+
+protein:
+  represented_as: node
+  preferred_id: uniprot
+  input_label: protein
+  properties:
+    name: str
+    score: float
+
+gene:
+  represented_as: node
+  preferred_id: hgnc
+  input_label: hgnc
+
+disease:
+  represented_as: node
+  preferred_id: doid
+  input_label: Disease
+
+# ---
+# Associations using synonym_for (preferred over label_as_edge)
+# ---
+
+# Instead of:
+#   gene to disease association:
+#     represented_as: edge
+#     label_as_edge: PERTURBED_IN_DISEASE
+# Use synonym_for to keep the edge type grounded in the ontology hierarchy:
+
+PERTURBED_IN_DISEASE:
+  synonym_for: gene to disease association
+  represented_as: edge
+  input_label: [protein_disease, gene_disease]
+  exclude_properties: accession
+  properties:
+    score: float

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -5,6 +5,7 @@ BioCypherNode and BioCypherEdge objects.
 """
 
 import warnings
+
 from collections.abc import Generator, Iterable
 from typing import Any
 

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -4,6 +4,7 @@ Responsible for translating between the raw input data and the
 BioCypherNode and BioCypherEdge objects.
 """
 
+import warnings
 from collections.abc import Generator, Iterable
 from typing import Any
 
@@ -384,6 +385,15 @@ class Translator:
                     self._ontology_mapping[label] = key
 
             if value.get("label_as_edge"):
+                warnings.warn(
+                    f"Schema entry '{key}' uses `label_as_edge`, which is deprecated. "
+                    "Use `synonym_for` on the desired edge label instead (e.g., "
+                    f"rename '{key}' to '{value['label_as_edge']}' and add "
+                    f"`synonym_for: {key}`). This keeps the edge type grounded in "
+                    "the ontology hierarchy.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 self._add_translation_mappings(labels, value["label_as_edge"])
 
             else:

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -944,8 +944,9 @@ class _BatchWriter(_Writer, ABC):
                             if v.get("label_as_edge") == label:
                                 cprops = v.get("properties")
                                 logger.warning(
-                                    "`label_as_edge` will be deprecated in a future version,"
-                                    "please use edge types that exists in your ontology's taxonomy.",
+                                    f"`label_as_edge` is deprecated. Use `synonym_for` instead: "
+                                    f"rename '{k}' to '{label}' in your schema and add "
+                                    f"`synonym_for: {k}` to keep the edge grounded in the ontology.",
                                 )
                                 break
                 if cprops:

--- a/test/fixtures/ontology.py
+++ b/test/fixtures/ontology.py
@@ -71,6 +71,22 @@ def simple_ontology(simple_ontology_mapping):
 
 
 @pytest.fixture(scope="module")
+def edge_synonym_ontology_mapping():
+    return OntologyMapping(config_file="biocypher/_config/test_schema_config_edge_synonym.yaml")
+
+
+@pytest.fixture(scope="module")
+def edge_synonym_ontology(edge_synonym_ontology_mapping):
+    return Ontology(
+        head_ontology={
+            "url": "https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl",
+            "root_node": "entity",
+        },
+        ontology_mapping=edge_synonym_ontology_mapping,
+    )
+
+
+@pytest.fixture(scope="module")
 def biolink_adapter():
     return OntologyAdapter(
         "https://github.com/biolink/biolink-model/raw/v3.2.1/biolink-model.owl.ttl",

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -87,6 +87,21 @@ def test_ontology_functions(hybrid_ontology):
     assert "macromolecular complex" not in hybrid_ontology._nx_graph.nodes
 
 
+def test_edge_synonym_for_in_ontology(edge_synonym_ontology):
+    """synonym_for renames edge types in the ontology graph, just like nodes.
+
+    When a schema entry uses `synonym_for: gene to disease association` on an
+    edge, the biolink class should be renamed to the schema key in the NX
+    graph so that ancestry lookups remain functional.
+    """
+    assert "PERTURBED_IN_DISEASE" in edge_synonym_ontology._nx_graph.nodes
+    assert "gene to disease association" not in edge_synonym_ontology._nx_graph.nodes
+    # Confirm the renamed node still has ancestors (graph is connected)
+    ancestors = list(edge_synonym_ontology.get_ancestors("PERTURBED_IN_DISEASE"))
+    assert "PERTURBED_IN_DISEASE" in ancestors
+    assert "association" in ancestors
+
+
 def test_show_ontology(hybrid_ontology):
     treevis = hybrid_ontology.show_ontology_structure()
     assert treevis is not None

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -1,4 +1,3 @@
-import warnings
 from unittest.mock import MagicMock
 
 import pytest

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -1,6 +1,10 @@
+import warnings
+from unittest.mock import MagicMock
+
 import pytest
 
 from biocypher._create import BioCypherEdge, BioCypherNode
+from biocypher._translate import Translator
 
 
 def test_translate_nodes(translator):
@@ -619,3 +623,43 @@ def test_translate_entities_empty_generator(translator):
 
     result = list(translator.translate_entities(empty_gen()))
     assert result == []
+
+
+def test_label_as_edge_deprecation_warning():
+    """label_as_edge should emit a DeprecationWarning on Translator init.
+
+    Users should switch to synonym_for on the desired edge label key.
+    """
+    mock_ontology = MagicMock()
+    mock_ontology.mapping.extended_schema = {
+        "gene to disease association": {
+            "represented_as": "edge",
+            "label_as_edge": "PERTURBED_IN_DISEASE",
+            "input_label": "gene_disease",
+            "preferred_id": "id",
+        }
+    }
+
+    with pytest.warns(DeprecationWarning, match="label_as_edge"):
+        Translator(mock_ontology)
+
+
+def test_edge_synonym_for_translation(edge_synonym_ontology):
+    """synonym_for on an edge entry translates to the schema key as edge label.
+
+    When a schema uses `PERTURBED_IN_DISEASE: synonym_for: gene to disease
+    association`, edges with input_label gene_disease or protein_disease should
+    be translated to BioCypherEdges with label PERTURBED_IN_DISEASE, just as
+    label_as_edge would have produced — but keeping the type grounded in the
+    ontology hierarchy.
+    """
+    translator = Translator(edge_synonym_ontology)
+
+    edges = [
+        ("e1", "CHAT", "AD", "gene_disease", {"score": 0.9}),
+        ("e2", "CHRNA4", "AD", "protein_disease", {"score": 0.7}),
+    ]
+    translated = list(translator.translate_edges(edges))
+
+    assert all(isinstance(e, BioCypherEdge) for e in translated)
+    assert all(e.get_label() == "PERTURBED_IN_DISEASE" for e in translated)


### PR DESCRIPTION
## Summary

Closes #435

`synonym_for` already renames nodes in the ontology NX graph — the exact same mechanism works for **edge types** (associations). This PR makes that explicit and deprecates the older `label_as_edge` field in favour of it.

### The problem with `label_as_edge`

When a schema entry uses `label_as_edge: PERTURBED_IN_DISEASE`, the KG output uses `PERTURBED_IN_DISEASE` as the relationship type, but the ontology graph still contains the original node `gene to disease association`. The two are now disconnected: ancestor look-ups on `PERTURBED_IN_DISEASE` fail with a `NetworkXError`, so the `_batch_writer` has to catch that error and fall back to a flat label. This is the exact issue that @jdreo flagged — `label_as_edge` allows a disconnected taxonomy graph.

### The fix — `synonym_for` for edges

```yaml
# Old (deprecated):
gene to disease association:
  represented_as: edge
  label_as_edge: PERTURBED_IN_DISEASE
  input_label: [protein_disease, gene_disease]

# New (preferred):
PERTURBED_IN_DISEASE:
  synonym_for: gene to disease association
  represented_as: edge
  input_label: [protein_disease, gene_disease]
```

With the new form, `_add_properties()` renames the `gene to disease association` node in the NX graph to `PERTURBED_IN_DISEASE`, just as it does for node synonyms (e.g., `complex: synonym_for: macromolecular complex`). The renamed node stays in the graph, so ancestry traversals work correctly.

## Changes

- **`biocypher/_translate.py`**: emit `DeprecationWarning` in `_update_ontology_types()` for every schema entry that uses `label_as_edge`, with an actionable message showing the `synonym_for` equivalent.
- **`biocypher/output/write/_batch_writer.py`**: update the existing `logger.warning` fallback message to also point to `synonym_for`.
- **`biocypher/_config/test_schema_config_edge_synonym.yaml`**: new minimal test schema demonstrating `synonym_for` on an edge type.
- **`test/fixtures/ontology.py`**: add module-scoped `edge_synonym_ontology` fixture using the new schema.
- **`test/test_ontology.py`**: `test_edge_synonym_for_in_ontology` — verifies the biolink class is renamed to the schema key and ancestors are reachable.
- **`test/test_translate.py`**:
  - `test_label_as_edge_deprecation_warning` — mock-based; confirms `DeprecationWarning` is raised when a schema has `label_as_edge`.
  - `test_edge_synonym_for_translation` — end-to-end; edges translate to the synonym key label without any `label_as_edge` present.

## Test plan

- [x] `test_label_as_edge_deprecation_warning` passes (DeprecationWarning emitted)
- [x] `test_edge_synonym_for_in_ontology` passes (synonym node in graph, original gone, ancestors reachable)
- [x] `test_edge_synonym_for_translation` passes (edges get synonym as label)
- [x] All 22 existing `test_translate.py` tests continue to pass
- [x] All `test_config.py` and `test_misc.py` tests continue to pass

https://claude.ai/code/session_01TFZuhRwAkZu8iDv5mAPqXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFZuhRwAkZu8iDv5mAPqXJ)_