### PR TITLE
fix(batch_writer): prevent schema mutation in strict-mode edge writes; fix f-string in translate error

### DIFF
--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -120,7 +120,7 @@ class Translator:
                 except AttributeError as err:
                     msg = (
                         f"Error: {err} "
-                        "while getting properties from {_ontology_class}. "
+                        f"while getting properties from {_ontology_class}. "
                         "Maybe you mistyped your properties. "
                         "Please ensure the `properties` section is a dictionary, not a list."
                     )

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -858,7 +858,7 @@ class _BatchWriter(_Writer, ABC):
                                     )
                                     break
                     if cprops:
-                        d = cprops
+                        d = dict(cprops)
 
                         # add strict mode properties
                         if self.strict_mode:

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1072,6 +1072,32 @@ def test_write_strict(bw_strict):
     assert "BiologicalEntity" in protein
 
 
+def test_write_strict_edge_does_not_mutate_schema(bw_strict):
+    """In strict mode, writing edges must not modify the schema properties dict.
+
+    Previously, `d = cprops` (a reference) was used instead of `d = dict(cprops)`
+    (a copy), so strict-mode keys ("source", "version", "licence") were injected
+    permanently into the extended_schema on the first write of each edge label.
+    """
+    schema = bw_strict.translator.ontology.mapping.extended_schema
+    original_props = dict(schema["gene to gene association"]["properties"])
+
+    edge = BioCypherEdge(
+        source_id="g1",
+        target_id="g2",
+        relationship_label="gene to gene association",
+        properties={"directional": True, "curated": False, "score": 0.9},
+    )
+
+    bw_strict._write_edge_data([edge], batch_size=int(1e4))
+
+    mutated_props = schema["gene to gene association"]["properties"]
+    assert "source" not in mutated_props, "strict-mode key 'source' was injected into schema"
+    assert "version" not in mutated_props, "strict-mode key 'version' was injected into schema"
+    assert "licence" not in mutated_props, "strict-mode key 'licence' was injected into schema"
+    assert mutated_props == original_props, "schema properties were modified by _write_edge_data"
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_tab_delimiter(bw_tab, _get_nodes):
     passed = bw_tab.write_nodes(_get_nodes)

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Two small bugs fixed in a single commit.

### Bug 1 — Schema mutation in strict-mode edge writes (`_batch_writer.py`)

**Root cause:** In `_write_edge_data`, schema properties were fetched and then aliased:

```python
# Before (bug)
d = cprops          # d is the SAME dict object as the one inside extended_schema
if self.strict_mode:
    d["source"] = "str"   # permanently mutates the schema!
    d["version"] = "str"
    d["licence"] = "str"
```

Because `d` was a reference — not a copy — every call to `_write_edge_data` in strict mode would inject `"source"`, `"version"`, and `"licence"` into the live `extended_schema` properties dict for each edge label the first time it was seen. Subsequent reads of the schema (e.g. for validation or a second write pass) would find those spurious keys there.

The equivalent code in `_write_node_data` already does this correctly:

```python
# _write_node_data already used a copy (correct)
d = dict(cprops)
```

**Fix:** Apply the same `dict(cprops)` copy in `_write_edge_data`.

---

### Bug 2 — Uninterpolated `{_ontology_class}` in error message (`_translate.py`)

In `translate_nodes`, the multi-line error message string had an f-prefix only on the first line; the second line was a plain string literal, so `{_ontology_class}` was printed verbatim instead of the actual class name:

```python
# Before (bug) — second line is NOT an f-string
msg = (
    f"Error: {err} "
    "while getting properties from {_ontology_class}. "   # literal brace
    ...
)

# After (fix)
msg = (
    f"Error: {err} "
    f"while getting properties from {_ontology_class}. "  # interpolated
    ...
)
```

---

## Test plan

- [x] `test_write_strict` — existing test confirming strict-mode node writes still work
- [x] `test_write_strict_edge_does_not_mutate_schema` — **new** test: snapshots the schema properties dict before a strict-mode edge write and asserts they are unchanged afterwards (would have failed before the fix)
- [x] All 39 existing `test_neo4j.py` tests pass
- [x] All 32 `test_translate.py` + `test_core.py` tests pass

https://claude.ai/code/session_01Y3Fcj9twUBXXbkJ9HpB5ez

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3Fcj9twUBXXbkJ9HpB5ez)_