### PR TITLE
fix(create): skip .replace() for non-string items in list properties

### DIFF
--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -89,15 +89,9 @@ class BioCypherNode:
 
             elif isinstance(v, list):
                 self.properties[k] = [
-                    val.replace(
-                        os.linesep,
-                        " ",
-                    )
-                    .replace(
-                        "\n",
-                        " ",
-                    )
-                    .replace("\r", " ")
+                    val.replace(os.linesep, " ").replace("\n", " ").replace("\r", " ")
+                    if isinstance(val, str)
+                    else val
                     for val in v
                 ]
 

--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -89,9 +89,7 @@ class BioCypherNode:
 
             elif isinstance(v, list):
                 self.properties[k] = [
-                    val.replace(os.linesep, " ").replace("\n", " ").replace("\r", " ")
-                    if isinstance(val, str)
-                    else val
+                    val.replace(os.linesep, " ").replace("\n", " ").replace("\r", " ") if isinstance(val, str) else val
                     for val in v
                 ]
 

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -38,3 +38,29 @@ def test_rel_as_node(rel_as_node):
 def test_rel_as_node_invalid_node():
     with pytest.raises(TypeError):
         BioCypherRelAsNode("str", 1, 2.5122)
+
+
+def test_node_list_property_with_non_string_values():
+    """BioCypherNode must not crash when a list property contains non-string values.
+
+    Previously the newline-sanitisation loop called .replace() on every list
+    element without checking the type, causing AttributeError for ints, floats,
+    booleans, and None values.
+    """
+    node = BioCypherNode(
+        node_id="n1",
+        node_label="Test",
+        properties={
+            "int_list": [1, 2, 3],
+            "float_list": [1.1, 2.2],
+            "bool_list": [True, False],
+            "mixed_list": ["a", 1, None],
+            "str_list": ["hello\nworld", "foo\rbar"],
+        },
+    )
+    assert node.properties["int_list"] == [1, 2, 3]
+    assert node.properties["float_list"] == [1.1, 2.2]
+    assert node.properties["bool_list"] == [True, False]
+    assert node.properties["mixed_list"] == ["a", 1, None]
+    # string entries still get newlines sanitised
+    assert node.properties["str_list"] == ["hello world", "foo bar"]


### PR DESCRIPTION
## Summary

Fixes a crash in `BioCypherNode.__post_init__` when a node has a list-valued property containing non-string elements (integers, floats, booleans, `None`, etc.).

**Root cause:** The newline-sanitisation loop unconditionally called `.replace()` on every element of a list property, without checking whether the element was actually a string:

```python
# Before (bug) — crashes if val is not a str
self.properties[k] = [
    val.replace(os.linesep, " ").replace("\n", " ").replace("\r", " ")
    for val in v
]
```

Any node with `properties={"tags": [1, 2, 3]}` would raise:

```
AttributeError: 'int' object has no attribute 'replace'
```

**Fix:** Guard with `isinstance(val, str)` so non-string values are passed through unchanged while string values are still sanitised:

```python
# After (fix)
self.properties[k] = [
    val.replace(os.linesep, " ").replace("\n", " ").replace("\r", " ")
    if isinstance(val, str)
    else val
    for val in v
]
```

## Test plan

- [x] `test_node_list_property_with_non_string_values` — new test covering `int`, `float`, `bool`, `None`, and mixed lists; previously raised `AttributeError`, now passes
- [x] All 5 existing `test_create.py` tests continue to pass

https://claude.ai/code/session_01GiWk42b1cNckwdfxNVVW4b

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiWk42b1cNckwdfxNVVW4b)_