### PR TITLE
feat(mapping): accept 'namespace' as alias for 'preferred_id'; deprecate 'preferred_id' in schema config

### DIFF
--- a/biocypher/_mapping.py
+++ b/biocypher/_mapping.py
@@ -3,6 +3,7 @@ BioCypher 'mapping' module. Handles the mapping of user-defined schema to the
 underlying ontology.
 """
 
+import warnings
 from typing import Optional
 from urllib.request import urlopen
 
@@ -66,8 +67,17 @@ class OntologyMapping:
             if "represented_as" not in v:
                 continue
 
-            # preferred_id optional: if not provided, use `id`
-            if not v.get("preferred_id"):
+            # `namespace` is the preferred field name; `preferred_id` is deprecated
+            if v.get("namespace") is not None:
+                v["preferred_id"] = v.pop("namespace")
+            elif v.get("preferred_id") is not None:
+                warnings.warn(
+                    f"The 'preferred_id' field in schema config entry '{k}' is "
+                    "deprecated. Please use 'namespace' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
                 v["preferred_id"] = "id"
 
             # k is an entity that is present in the ontology

--- a/biocypher/_mapping.py
+++ b/biocypher/_mapping.py
@@ -4,6 +4,7 @@ underlying ontology.
 """
 
 import warnings
+
 from typing import Optional
 from urllib.request import urlopen
 

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -1,3 +1,9 @@
+import warnings
+
+import pytest
+
+from biocypher._mapping import OntologyMapping
+
 # TODO migrate as appropriate from test translate
 
 
@@ -19,3 +25,39 @@ def test_preferred_id_optional(ontology_mapping):
     pti = ontology_mapping.extended_schema.get("post translational interaction")
 
     assert pti.get("preferred_id") == "id"
+
+
+def test_namespace_accepted_as_preferred_id():
+    """Schema entries using 'namespace' are normalised to 'preferred_id' internally."""
+    m = OntologyMapping()
+    m.schema = {
+        "protein": {
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "protein",
+        }
+    }
+    extended = m._extend_schema(d=m.schema)
+    assert extended["protein"]["preferred_id"] == "uniprot"
+    assert "namespace" not in extended["protein"]
+
+
+def test_preferred_id_in_schema_emits_deprecation_warning():
+    """Schema entries still using 'preferred_id' trigger a DeprecationWarning."""
+    m = OntologyMapping()
+    m.schema = {
+        "protein": {
+            "represented_as": "node",
+            "preferred_id": "uniprot",
+            "input_label": "protein",
+        }
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        extended = m._extend_schema(d=m.schema)
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep_warnings) == 1
+    assert "preferred_id" in str(dep_warnings[0].message)
+    assert "namespace" in str(dep_warnings[0].message)
+    assert extended["protein"]["preferred_id"] == "uniprot"

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -1,6 +1,5 @@
 import warnings
 
-import pytest
 
 from biocypher._mapping import OntologyMapping
 


### PR DESCRIPTION
## Summary

Closes #389

`preferred_id` in `schema_config.yaml` is not self-explanatory to new users. The conventional term for this concept is `namespace`. This PR begins the deprecation transition as requested in the issue.

### What changed

**`biocypher/_mapping.py`** — in `_extend_schema()`, the first-pass normalisation of `preferred_id` now handles three cases:

| Schema entry contains | Behaviour |
|---|---|
| `namespace: <value>` | Normalised to `preferred_id` internally; no warning |
| `preferred_id: <value>` | Kept as-is; `DeprecationWarning` emitted pointing to `namespace` |
| neither | Default `"id"` assigned as before |

All downstream code (`_translate.py`, `_batch_writer.py`, `BioCypherNode`, etc.) continues to use `preferred_id` internally — no other files needed to change.

### Example migration

```yaml
# Before (deprecated)
protein:
  represented_as: node
  preferred_id: uniprot
  input_label: protein

# After
protein:
  represented_as: node
  namespace: uniprot
  input_label: protein
```

### Warning message

```
DeprecationWarning: The 'preferred_id' field in schema config entry 'protein' is
deprecated. Please use 'namespace' instead.
```

## Test plan

- [x] `test_namespace_accepted_as_preferred_id` — schema entry using `namespace` is normalised to `preferred_id` internally, and the `namespace` key is removed from the extended schema
- [x] `test_preferred_id_in_schema_emits_deprecation_warning` — schema entry using `preferred_id` triggers exactly one `DeprecationWarning` mentioning both `preferred_id` and `namespace`; the value is still accessible as `preferred_id`
- [x] All 6 existing `test_mapping.py` tests pass
- [x] All 34 `test_translate.py` + `test_core.py` + `test_config.py` tests pass

https://claude.ai/code/session_0196w1byj1FevczGW1qFYEnT

---
_Generated by [Claude Code](https://claude.ai/code/session_0196w1byj1FevczGW1qFYEnT)_