### PR TITLE
fix(mapping): deprecate 'label_in_input' in favour of 'input_label'

### DIFF
--- a/biocypher/_config/test_schema_config_disconnected.yaml
+++ b/biocypher/_config/test_schema_config_disconnected.yaml
@@ -1,3 +1,3 @@
 disconnected:
   represented_as: node
-  label_in_input: disconnected
+  input_label: disconnected

--- a/biocypher/_mapping.py
+++ b/biocypher/_mapping.py
@@ -81,6 +81,16 @@ class OntologyMapping:
             else:
                 v["preferred_id"] = "id"
 
+            # `input_label` is the preferred field name; `label_in_input` is deprecated
+            if v.get("input_label") is None and v.get("label_in_input") is not None:
+                warnings.warn(
+                    f"The 'label_in_input' field in schema config entry '{k}' is "
+                    "deprecated. Please use 'input_label' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                v["input_label"] = v.pop("label_in_input")
+
             # k is an entity that is present in the ontology
             if "is_a" not in v:
                 extended_schema[k] = v
@@ -164,14 +174,13 @@ class OntologyMapping:
         """
         Create virtual leaves for multiple preferred id types or sources.
 
-        If we create virtual leaves, input_label/label_in_input always has to be
-        a list.
+        If we create virtual leaves, input_label always has to be a list.
         """
 
         leaves = {}
 
         preferred_id = value["preferred_id"]
-        input_label = value.get("input_label") or value["label_in_input"]
+        input_label = value.get("input_label")
         represented_as = value["represented_as"]
 
         # adjust lengths
@@ -226,7 +235,6 @@ class OntologyMapping:
                     "is_a",
                     "preferred_id",
                     "input_label",
-                    "label_in_input",
                     "represented_as",
                 ]:
                     svalue[k] = v
@@ -239,14 +247,13 @@ class OntologyMapping:
         """
         Create virtual leaves for multiple sources.
 
-        If we create virtual leaves, input_label/label_in_input always has to be
-        a list.
+        If we create virtual leaves, input_label always has to be a list.
         """
 
         leaves = {}
 
         source = value["source"]
-        input_label = value.get("input_label") or value["label_in_input"]
+        input_label = value.get("input_label")
         represented_as = value["represented_as"]
 
         # adjust lengths
@@ -295,7 +302,6 @@ class OntologyMapping:
                     "is_a",
                     "source",
                     "input_label",
-                    "label_in_input",
                     "represented_as",
                 ]:
                     svalue[k] = v

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -363,7 +363,7 @@ class Translator:
         self._ontology_mapping = {}
 
         for key, value in self.ontology.mapping.extended_schema.items():
-            labels = value.get("input_label") or value.get("label_in_input")
+            labels = value.get("input_label")
 
             if isinstance(labels, str):
                 self._ontology_mapping[labels] = key
@@ -381,15 +381,13 @@ class Translator:
     def _get_ontology_mapping(self, label: str) -> str | None:
         """Find the ontology class for the given input type.
 
-        For each given input type ("input_label" or "label_in_input"), find the
-        corresponding ontology class in the leaves dictionary (from the
-        `schema_config.yam`).
+        For each given input type ("input_label"), find the corresponding
+        ontology class in the leaves dictionary (from the `schema_config.yaml`).
 
         Args:
         ----
             label:
-                The input type to find (`input_label` or `label_in_input` in
-                `schema_config.yaml`).
+                The input type to find (`input_label` in `schema_config.yaml`).
 
         """
         # FIXME does not seem like a necessary function.

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -60,3 +60,43 @@ def test_preferred_id_in_schema_emits_deprecation_warning():
     assert "preferred_id" in str(dep_warnings[0].message)
     assert "namespace" in str(dep_warnings[0].message)
     assert extended["protein"]["preferred_id"] == "uniprot"
+
+
+def test_input_label_accepted_as_label_in_input():
+    """Schema entries using 'input_label' work without any warning."""
+    m = OntologyMapping()
+    m.schema = {
+        "protein": {
+            "represented_as": "node",
+            "input_label": "protein",
+        }
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        extended = m._extend_schema(d=m.schema)
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep_warnings) == 0
+    assert extended["protein"]["input_label"] == "protein"
+
+
+def test_label_in_input_emits_deprecation_warning():
+    """Schema entries using the old 'label_in_input' field trigger a DeprecationWarning."""
+    m = OntologyMapping()
+    m.schema = {
+        "protein": {
+            "represented_as": "node",
+            "label_in_input": "protein",
+        }
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        extended = m._extend_schema(d=m.schema)
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep_warnings) == 1
+    assert "label_in_input" in str(dep_warnings[0].message)
+    assert "input_label" in str(dep_warnings[0].message)
+    # field is normalised to 'input_label' after the warning
+    assert extended["protein"].get("input_label") == "protein"
+    assert "label_in_input" not in extended["protein"]


### PR DESCRIPTION
## Summary

The `label_in_input` field in `schema_config.yaml` was silently accepted as a fallback for `input_label` with no warning to users. This is confusing: the maintainer noted in #461 that `label_in_input` is old syntax and was replaced by `input_label` long ago, but users (including LLM-assisted tooling) keep generating the old form because there's no signal it's wrong.

This PR mirrors the existing `preferred_id` → `namespace` deprecation pattern:

- **`_extend_schema()` now normalises `label_in_input` → `input_label` early** with a `DeprecationWarning` naming both the old and new field, so users get an actionable message.
- Downstream code in `_horizontal_inheritance_pid`, `_horizontal_inheritance_source`, and `_translate._update_ontology_types` no longer needs its own `label_in_input` fallback — they simply use `input_label`.
- `test_schema_config_disconnected.yaml` updated to the current field name.
- Docstrings and comments that still referenced `label_in_input` as a live alternative are updated.

## Changes

- `biocypher/_mapping.py`: add `label_in_input` → `input_label` normalisation with `DeprecationWarning` in `_extend_schema()`; remove `label_in_input` fallbacks from the two horizontal-inheritance helpers and their exclusion lists.
- `biocypher/_translate.py`: drop `label_in_input` fallback in `_update_ontology_types()`; update docstring.
- `biocypher/_config/test_schema_config_disconnected.yaml`: use `input_label`.
- `test/test_mapping.py`: add `test_input_label_accepted_as_label_in_input` (no warning) and `test_label_in_input_emits_deprecation_warning` (warning + normalisation).

## Test plan

- [x] `test_label_in_input_emits_deprecation_warning` — warning raised, field normalised to `input_label`, old key absent
- [x] `test_input_label_accepted_as_label_in_input` — no warning when correct field is used
- [x] All 8 existing `test_mapping.py` tests pass
- [x] All 44 `test_translate.py` + `test_ontology.py` tests pass

https://claude.ai/code/session_019RQxQ1Vk58qmcbG2FuRCYC

---
_Generated by [Claude Code](https://claude.ai/code/session_019RQxQ1Vk58qmcbG2FuRCYC)_