### PR TITLE
fix(batch_writer): stringify list elements before joining in _write_array_string

### DIFF
--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -80,7 +80,7 @@ class _Neo4jBatchWriter(_BatchWriter):
             str: The string representation of an array for the neo4j admin import
 
         """
-        string = self.adelim.join(string_list)
+        string = self.adelim.join(str(x) for x in string_list)
         return self._quote_string(string)
 
     def _write_node_headers(self):

--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -77,7 +77,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
             str: The string representation of an array for postgres COPY
 
         """
-        string = ",".join(string_list)
+        string = ",".join(str(x) for x in string_list)
         string = f'"{{{string}}}"'
         return string
 

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -331,6 +331,36 @@ def test_write_node_data_boolean_properties(bw):
     assert "False" not in post_translational_interaction
 
 
+def test_write_node_data_non_string_list_properties(bw):
+    """List properties with non-string elements must not raise TypeError during write."""
+    nodes = [
+        BioCypherNode(
+            node_id="i1",
+            node_label="post translational interaction",
+            properties={"scores": [1, 2, 3], "weights": [0.1, 0.5, 0.9]},
+        ),
+        BioCypherNode(
+            node_id="i2",
+            node_label="post translational interaction",
+            properties={"scores": [4, 5, 6], "weights": [0.2, 0.6, 1.0]},
+        ),
+    ]
+
+    passed = bw._write_node_data(nodes, batch_size=int(1e4))
+
+    csv_path = os.path.join(
+        bw.outdir,
+        "PostTranslationalInteraction-part000.csv",
+    )
+
+    with open(csv_path) as f:
+        content = f.read()
+
+    assert passed
+    assert "1|2|3" in content
+    assert "0.1|0.5|0.9" in content
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, _get_nodes_non_compliant_names):
     nodes = _get_nodes_non_compliant_names


### PR DESCRIPTION
## Summary

- Fix `TypeError` crash when writing list-valued node/edge properties that contain non-string elements (ints, floats, booleans) to Neo4j or PostgreSQL CSV output.
- Apply the same one-line fix to both `_Neo4jBatchWriter._write_array_string` and `_PostgreSQLBatchWriter._write_array_string`.

## Root cause

PR #518 (`fix(create): skip .replace() for non-string items in list properties`) correctly stopped sanitising non-string list elements in `BioCypherNode.__post_init__`, leaving ints, floats, and booleans as their native types.  However, the downstream serialisation step was not updated.  Both writers' `_write_array_string` implementations call `str.join()` directly on the raw list:

```python
# Neo4j (_neo4j.py)
string = self.adelim.join(string_list)   # TypeError for non-str elements

# PostgreSQL (_postgresql.py)
string = ",".join(string_list)           # same crash
```

`str.join()` requires every element to already be a `str`; passing `[1, 2, 3]` raises:

```
TypeError: sequence item 0: expected str instance, int found
```

## Fix

Convert each element to `str` inside a generator expression before joining:

```python
string = self.adelim.join(str(x) for x in string_list)
```

This is the minimal, targeted change needed; it mirrors Python's own `str()` coercion and is consistent with how the rest of the batch-writer already serialises scalar numeric values.

## Test plan

- [x] New test `test_write_node_data_non_string_list_properties` passes: writes nodes whose list properties contain `int` and `float` values and asserts the joined strings appear in the CSV output.
- [x] All 42 existing `test_neo4j.py` tests continue to pass.

https://claude.ai/code/session_01BgYnuBth3hchVfJi2KQAmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgYnuBth3hchVfJi2KQAmA)_