### PR TITLE
fix(get): treat lifetime=0 as permanent cache (never re-download)

### DIFF
--- a/biocypher/_get.py
+++ b/biocypher/_get.py
@@ -188,6 +188,8 @@ class Downloader:
         """
         cache_record = self._get_cache_record(resource)
         if cache_record:
+            if resource.lifetime == 0:
+                return False
             download_time = datetime.strptime(cache_record.get("date_downloaded"), "%Y-%m-%d %H:%M:%S.%f")
             lifetime = timedelta(days=resource.lifetime)
             expired = download_time + lifetime < datetime.now()

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -123,6 +123,34 @@ def test_downloader(downloader):
     indirect=True,
 )
 @patch("biocypher._get.pooch.retrieve", side_effect=_mock_retrieve)
+def test_permanent_cache_never_expires(mock_retrieve, downloader):
+    """lifetime=0 means permanent cache: the resource must not be re-downloaded."""
+    resource = FileDownload(
+        "test_permanent",
+        "https://github.com/biocypher/biocypher/raw/main/biocypher/_config/test_config.yaml",
+        lifetime=0,
+    )
+    paths = downloader.download(resource)
+    initial_mtime = os.path.getmtime(paths[0])
+    assert len(paths) == 1
+
+    # Second download must serve from cache even with a backdated timestamp.
+    downloader.cache_dict["test_permanent"]["date_downloaded"] = str(datetime.now() - timedelta(days=3650))
+    paths = downloader.download(resource)
+    assert len(paths) == 1
+    assert os.path.getmtime(paths[0]) == initial_mtime, "Permanent resource was re-downloaded"
+    assert mock_retrieve.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "downloader",
+    [
+        "downloader_without_specified_cache_dir",
+        "downloader_with_specified_cache_dir",
+    ],
+    indirect=True,
+)
+@patch("biocypher._get.pooch.retrieve", side_effect=_mock_retrieve)
 def test_download_file(mock_retrieve, downloader):
     resource = FileDownload(
         "test_resource",

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.6"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

- `Resource(lifetime=0)` is documented as "cached indefinitely / permanent", but the cache expiry check treated it as immediately expired — causing the file to be re-downloaded on every call.
- One-line fix in `_is_cache_expired`: return `False` early when `lifetime == 0` and a cache record already exists.
- Regression test added that backdates the cached `date_downloaded` by 10 years and confirms the resource is not re-fetched.

## Root cause

`_is_cache_expired` computed:

```python
lifetime = timedelta(days=resource.lifetime)          # timedelta(0)
expired = download_time + lifetime < datetime.now()   # always True
```

`timedelta(days=0)` is zero duration, so `download_time + 0 < now` is always `True` for any past download. This silently defeated the "permanent cache" semantic.

## Fix

```python
if resource.lifetime == 0:
    return False   # permanent — never expires once cached
```

## Test plan

- [x] `test_permanent_cache_never_expires` — downloads once, backdates timestamp by 3 650 days, asserts `pooch.retrieve` is called exactly once and the file mtime is unchanged.
- [x] All 20 existing `test_get.py` tests continue to pass (1 intentionally skipped).


---
_Generated by [Claude Code](https://claude.ai/code/session_012k5APwoKhNicNRW9xg4GtY)_