### PR TITLE
fix(create): replace elif with if for reserved keyword checks in BioCypherEdge

### DIFF
--- a/biocypher/_create.py
+++ b/biocypher/_create.py
@@ -193,14 +193,14 @@ class BioCypherEdge:
             )
             # self.properties["type"] = self.properties[":TYPE"]
             del self.properties[":TYPE"]
-        elif "id" in self.properties.keys():
+        if "id" in self.properties.keys():
             logger.debug(
                 "Keyword 'id' is reserved for Neo4j. Removing from properties.",
                 # "Renaming to 'type'."
             )
             # self.properties["type"] = self.properties[":TYPE"]
             del self.properties["id"]
-        elif "_ID" in self.properties.keys():
+        if "_ID" in self.properties.keys():
             logger.debug(
                 "Keyword '_ID' is reserved for Postgres. Removing from properties.",
                 # "Renaming to 'type'."

--- a/test/test_create.py
+++ b/test/test_create.py
@@ -40,6 +40,24 @@ def test_rel_as_node_invalid_node():
         BioCypherRelAsNode("str", 1, 2.5122)
 
 
+def test_edge_all_reserved_keywords_removed():
+    """BioCypherEdge must remove all reserved keywords, not just the first one found.
+
+    Previously the keyword checks used elif chains, so if :TYPE was present,
+    the 'id' and '_ID' checks were silently skipped.
+    """
+    edge = BioCypherEdge(
+        source_id="s1",
+        target_id="t1",
+        relationship_label="rel",
+        properties={":TYPE": "foo", "id": "bar", "_ID": "baz", "score": 0.9},
+    )
+    assert ":TYPE" not in edge.properties
+    assert "id" not in edge.properties
+    assert "_ID" not in edge.properties
+    assert edge.properties["score"] == 0.9
+
+
 def test_node_list_property_with_non_string_values():
     """BioCypherNode must not crash when a list property contains non-string values.
 

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.6"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

`BioCypherEdge.__post_init__` checks for three reserved property keywords that must be stripped before the edge is used downstream:

| Keyword | Backend |
|---------|---------|
| `:TYPE` | Neo4j   |
| `id`    | Neo4j   |
| `_ID`   | PostgreSQL |

The original code chained all three checks with `elif`:

```python
if ":TYPE" in self.properties.keys():
    del self.properties[":TYPE"]
elif "id" in self.properties.keys():   # ← skipped if :TYPE matched
    del self.properties["id"]
elif "_ID" in self.properties.keys():  # ← skipped if :TYPE or id matched
    del self.properties["_ID"]
```

Because they were `elif`, finding `:TYPE` prevented `id` and `_ID` from being checked. Since the three keywords belong to different backends and are logically independent, each check must be a standalone `if`.

## Fix

Changed the two `elif` statements to `if`. Each reserved keyword is now always checked and removed regardless of whether any other reserved keyword was also present.

## Test plan

- [x] `test_edge_all_reserved_keywords_removed` — constructs an edge whose properties contain all three reserved keywords at once and asserts all three are absent after construction
- [x] All 6 existing `test_create.py` tests continue to pass

---
_Generated by [Claude Code](https://claude.ai/code/session_016SMxhAcgqQm7S8iWqZyAcB)_