### PR TITLE
fix(translate): require 'version' and accept 'license' for edges in strict mode

### DIFF
--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -232,6 +232,10 @@ class Translator:
         for _id, _src, _tar, _type, _props in edge_tuples:
             # check for strict mode requirements
             if self.strict_mode:
+                # rename 'license' to 'licence' in _props
+                if _props.get("license"):
+                    _props["licence"] = _props.pop("license")
+
                 if "source" not in _props:
                     msg = (
                         f"Edge {_id if _id else (_src, _tar)} does not have a `source` property."
@@ -242,6 +246,13 @@ class Translator:
                 if "licence" not in _props:
                     msg = (
                         f"Edge {_id if _id else (_src, _tar)} does not have a `licence` property."
+                        " This is required in strict mode.",
+                    )
+                    logger.error(msg)
+                    raise ValueError(msg)
+                if "version" not in _props:
+                    msg = (
+                        f"Edge {_id if _id else (_src, _tar)} does not have a `version` property."
                         " This is required in strict mode.",
                     )
                     logger.error(msg)

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -551,10 +551,36 @@ def test_strict_mode_error(translator):
 
     assert list(translator.translate_edges([edge_1])) is not None
 
+    # test 'license' instead of 'licence' for edges (mirrors node behaviour)
+    edge_license = (
+        "n1",
+        "n2",
+        "Test",
+        {
+            "prop": "val",
+            "source": "test",
+            "license": "test",
+            "version": "test",
+        },
+    )
+
+    assert list(translator.translate_edges([edge_license])) is not None
+
     edge_2 = ("n1", "n2", "Test", {"prop": "val"})
 
     with pytest.raises(ValueError):
         list(translator.translate_edges([edge_1, edge_2]))
+
+    # version is required for edges in strict mode (was missing before)
+    edge_no_version = (
+        "n1",
+        "n2",
+        "Test",
+        {"prop": "val", "source": "test", "licence": "test"},
+    )
+
+    with pytest.raises(ValueError):
+        list(translator.translate_edges([edge_no_version]))
 
 
 def test_strict_mode_property_filter(translator):


### PR DESCRIPTION
## Summary

`translate_nodes()` enforces three required properties in strict mode — `source`, `licence`, and `version` — and silently renames the American spelling `license` to `licence`. `translate_edges()` was doing neither:

- **`version` was never checked** for edges, so an edge missing `version` silently passed strict mode even though the equivalent node would raise `ValueError`.
- **`license` was never renamed** for edges, so users who spelled it the American way got an error on edges but not on nodes.

## Root cause

```python
# nodes (_translate.py ~line 99-111)
required_props = ["source", "licence", "version"]
if _props.get("license"):
    _props["licence"] = _props.pop("license")   # ← rename present
for prop in required_props:                      # ← version checked
    ...

# edges (_translate.py ~line 234-248, before fix)
if "source" not in _props: ...
if "licence" not in _props: ...
# version never checked, 'license' never renamed
```

## Fix

Added the `license`→`licence` rename and the `version` existence check to `translate_edges()`, mirroring the existing node logic exactly.

## Test plan

- [x] `test_strict_mode_error` extended with:
  - `edge_license`: edge using `"license"` spelling is accepted (rename works)
  - `edge_no_version`: edge missing `"version"` raises `ValueError`
- [x] All 21 existing `test_translate.py` tests continue to pass

https://claude.ai/code/session_01KoywtGy21Jieka9cSS95t2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoywtGy21Jieka9cSS95t2)_