### PR TITLE
fix(parse_label): guard against IndexError when label has no compliant characters

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -1169,6 +1169,10 @@ def parse_label(label: str) -> str:
     def first_character_compliant(character: str) -> bool:
         return character.isalpha() or character == "$"
 
+    if not matches:
+        logger.warning("Label contains only non-compliant characters and will be empty.")
+        return ""
+
     if not first_character_compliant(matches[0]):
         for c in matches:
             if first_character_compliant(c):

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1202,7 +1202,9 @@ def test_check_label_name():
 
     # Additional test case: label with dot and non-compliant characters
     assert parse_label("In.valid.Label@1") == "In.valid.Label1"
-    # Assert warning log is written
+
+    # Test case: label contains only non-compliant characters (would previously crash with IndexError)
+    assert parse_label("@#^&") == ""
 
 
 def make_labels(bw, order):

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.13.6"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

`parse_label` in `_batch_writer.py` raises an unhandled `IndexError` when passed a label whose every character is non-compliant with Neo4j naming rules (e.g. `"@#^&"`).

## Root cause

```python
allowed_chars = r"a-zA-Z0-9_$ ."
matches = re.findall(f"[{allowed_chars}]", label)   # empty list for "@#^&"
...
if not first_character_compliant(matches[0]):        # IndexError: list index out of range
```

`matches[0]` is accessed unconditionally. When every character is filtered out, `matches` is an empty list and the access crashes the writer with `IndexError: list index out of range`.

## Fix

Add an early-return guard before the `matches[0]` access:

```python
if not matches:
    logger.warning("Label contains only non-compliant characters and will be empty.")
    return ""
```

This mirrors the graceful handling already in place for the partial-non-compliance case (non-empty `matches` that starts with a non-alpha character).

## Test plan

- [x] `test_check_label_name` extended with `parse_label("@#^&") == ""` — previously crashed with `IndexError`, now returns `""` with a warning
- [x] All 6 existing `parse_label` assertions continue to pass

https://claude.ai/code/session_01Yaus79Fy7q5YqMcqHqNoMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yaus79Fy7q5YqMcqHqNoMq)_