### PR TITLE
docs(config): add merge_nodes example to tail_ontologies in biocypher_config.yaml

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -57,6 +57,10 @@ biocypher:
   # cache_directory: .cache
 
   ## Optional tail ontologies
+  ## merge_nodes (bool, default true): if true, head and tail join nodes are
+  ## merged into a single node; if false, the tail join node is added as a
+  ## child of the head join node (useful when the concept does not already
+  ## exist in the head ontology).
 
   # tail_ontologies:
   #   so:
@@ -64,11 +68,13 @@ biocypher:
   #     head_join_node: sequence variant
   #     tail_join_node: sequence_variant
   #     switch_label_and_id: true
+  #     merge_nodes: true  # (default) merge head and tail join nodes into one
   #   mondo:
   #     url: test/ontologies/mondo.owl
   #     head_join_node: disease
-  #     tail_join_node: disease
+  #     tail_join_node: human disease
   #     switch_label_and_id: true
+  #     merge_nodes: false  # attach tail join node as child of head join node
 
 ### DBMS configuration ###
 

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Closes #394

The `merge_nodes` parameter controls whether the head and tail join nodes are merged into one (default `true`) or whether the tail join node is attached as a child of the head join node (`false`). It was fully implemented and documented in the tutorial, but absent from the reference config file, making it hard to discover.

### Changes

- Added a 4-line comment block above `tail_ontologies` explaining what `merge_nodes` does and when to use each value.
- Added `merge_nodes: true` (with inline comment) to the `so` example.
- Added `merge_nodes: false` (with inline comment) to the `mondo` example.
- Corrected the `mondo` `tail_join_node` value from `disease` to `human disease`, matching the tutorial and the actual Mondo ontology root used in tests.

## Test plan

- [x] Existing `test_config.py` and `test_misc.py` tests continue to pass (7 passed)
- [x] No functional code changed — this is a documentation/config comment addition only

---
_Generated by [Claude Code](https://claude.ai/code/session_016UtfVh9hceMhUbRMqVev8b)_