### PR TITLE
fix(batch_writer): infer typed array annotations for list properties not in schema

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -673,7 +673,11 @@ class _BatchWriter(_Writer, ABC):
                     # encode property type
                     for k, v in d.items():
                         if v is not None:
-                            d[k] = type(v).__name__
+                            if isinstance(v, list):
+                                elem_type = type(v[0]).__name__ if v else "str"
+                                d[k] = f"{elem_type}[]"
+                            else:
+                                d[k] = type(v).__name__
                 # else use first encountered node to define properties for
                 # checking; could later be by checking all nodes but much
                 # more complicated, particularly involving batch writing
@@ -958,7 +962,11 @@ class _BatchWriter(_Writer, ABC):
                     # encode property type
                     for k, v in d.items():
                         if v is not None:
-                            d[k] = type(v).__name__
+                            if isinstance(v, list):
+                                elem_type = type(v[0]).__name__ if v else "str"
+                                d[k] = f"{elem_type}[]"
+                            else:
+                                d[k] = type(v).__name__
                 # else use first encountered edge to define
                 # properties for checking; could later be by
                 # checking all edges but much more complicated,

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -363,12 +363,10 @@ def test_write_node_data_non_string_list_properties(bw):
     # rather than the bare "list" that type(v).__name__ would previously return.
     prop_types = bw.node_property_dict.get("post translational interaction", {})
     assert prop_types.get("scores") == "int[]", (
-        f"Expected 'int[]' but got {prop_types.get('scores')!r}; "
-        "list type inference is broken"
+        f"Expected 'int[]' but got {prop_types.get('scores')!r}; " "list type inference is broken"
     )
     assert prop_types.get("weights") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('weights')!r}; "
-        "list type inference is broken"
+        f"Expected 'float[]' but got {prop_types.get('weights')!r}; " "list type inference is broken"
     )
 
 
@@ -932,12 +930,10 @@ def test_write_edge_data_non_string_list_properties(bw):
     assert passed
     prop_types = bw.edge_property_dict.get("phosphorylation", {})
     assert prop_types.get("sites") == "str[]", (
-        f"Expected 'str[]' but got {prop_types.get('sites')!r}; "
-        "list type inference is broken for edges"
+        f"Expected 'str[]' but got {prop_types.get('sites')!r}; " "list type inference is broken for edges"
     )
     assert prop_types.get("scores") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('scores')!r}; "
-        "list type inference is broken for edges"
+        f"Expected 'float[]' but got {prop_types.get('scores')!r}; " "list type inference is broken for edges"
     )
 
 

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -359,6 +359,17 @@ def test_write_node_data_non_string_list_properties(bw):
     assert passed
     assert "1|2|3" in content
     assert "0.1|0.5|0.9" in content
+    # Verify that the inferred types in node_property_dict use "int[]" / "float[]"
+    # rather than the bare "list" that type(v).__name__ would previously return.
+    prop_types = bw.node_property_dict.get("post translational interaction", {})
+    assert prop_types.get("scores") == "int[]", (
+        f"Expected 'int[]' but got {prop_types.get('scores')!r}; "
+        "list type inference is broken"
+    )
+    assert prop_types.get("weights") == "float[]", (
+        f"Expected 'float[]' but got {prop_types.get('weights')!r}; "
+        "list type inference is broken"
+    )
 
 
 @pytest.mark.parametrize("length", [4], scope="module")
@@ -895,6 +906,39 @@ def test_write_edge_data_boolean_properties(bw):
     assert "false" in gene_gene
     assert "True" not in gene_gene
     assert "False" not in gene_gene
+
+
+def test_write_edge_data_non_string_list_properties(bw):
+    """List properties on edges must infer typed array annotations, not bare 'list'."""
+    edges = [
+        BioCypherEdge(
+            relationship_id="ph1",
+            source_id="p1",
+            target_id="p2",
+            relationship_label="phosphorylation",
+            properties={"sites": ["S100", "T200"], "scores": [0.8, 0.95]},
+        ),
+        BioCypherEdge(
+            relationship_id="ph2",
+            source_id="p3",
+            target_id="p4",
+            relationship_label="phosphorylation",
+            properties={"sites": ["Y50"], "scores": [0.6]},
+        ),
+    ]
+
+    passed = bw._write_edge_data(edges, batch_size=int(1e4))
+
+    assert passed
+    prop_types = bw.edge_property_dict.get("phosphorylation", {})
+    assert prop_types.get("sites") == "str[]", (
+        f"Expected 'str[]' but got {prop_types.get('sites')!r}; "
+        "list type inference is broken for edges"
+    )
+    assert prop_types.get("scores") == "float[]", (
+        f"Expected 'float[]' but got {prop_types.get('scores')!r}; "
+        "list type inference is broken for edges"
+    )
 
 
 @pytest.mark.parametrize("length", [8], scope="module")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.14.1"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

When a node or edge has list-typed properties that are **not** declared in the schema config, the batch writer falls back to runtime type inference:

```python
d[k] = type(v).__name__
```

For a list value, `type(v).__name__` returns `"list"` — but every batch-writer header implementation (Neo4j, PostgreSQL, …) expects strings like `"int[]"`, `"float[]"`, `"str[]"`. None of the `elif v in ["int[]", ...]` checks match `"list"`, so the property falls through to the untyped default (`props_list.append(f"{k}")`), losing array-type semantics in the import header entirely.

## Fix

At both the node and edge inference sites in `_batch_writer.py`, detect list values and build the correct `"{element_type}[]"` string from the first element:

```python
if isinstance(v, list):
    elem_type = type(v[0]).__name__ if v else "str"
    d[k] = f"{elem_type}[]"
else:
    d[k] = type(v).__name__
```

This makes inferred list properties produce `"int[]"`, `"float[]"`, `"str[]"`, `"bool[]"` etc., which the existing header-writer logic already knows how to translate to Neo4j types (`long[]`, `double[]`, `string[]`, `boolean[]`).

## Tests

- Extended `test_write_node_data_non_string_list_properties` to assert that `bw.node_property_dict` contains `"int[]"` / `"float[]"` (not `"list"`) after writing nodes with runtime-inferred list properties.
- Added `test_write_edge_data_non_string_list_properties` with the same check for edges (`"str[]"` / `"float[]"`).

## Scope

Pure logic fix — no schema changes, no API changes, no behaviour change for properties that *are* declared in the schema (those continue to use the schema-provided type string).


---
_Generated by [Claude Code](https://claude.ai/code/session_016t7NMN5efZFosp6DBNKbZU)_