### PR TITLE
fix(core): _add_edges called non-existent method and wrong driver method

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -444,9 +444,7 @@ class BioCypher:
                 self._initialize_in_memory_kg()
             passed = self._in_memory_kg.add_edges(translated_edges)
         else:
-            if not self._driver:
-                self._initialize_driver()
-            passed = self._driver.add_biocypher_nodes(translated_edges)
+            passed = self._get_driver().add_biocypher_edges(translated_edges)
 
         return passed
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -140,6 +141,22 @@ def test_get_writer_in_online_mode(core):
         with pytest.raises(NotImplementedError) as e:
             core._initialize_writer()
         assert str(e.value) == "Cannot get writer in online mode."
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_online_add_edges_calls_add_biocypher_edges(core, _get_edges):
+    """_add_edges must call add_biocypher_edges (not add_biocypher_nodes) on the driver."""
+    mock_driver = MagicMock()
+    mock_driver.add_biocypher_edges.return_value = True
+
+    core._offline = False
+    core._dbms = "neo4j"
+
+    with patch.object(core, "_get_driver", return_value=mock_driver):
+        core.write_edges(_get_edges)
+
+    mock_driver.add_biocypher_edges.assert_called_once()
+    mock_driver.add_biocypher_nodes.assert_not_called()
 
 
 def test_pandas_and_tabular_work_in_offline_mode(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

The online (non-in-memory) branch of `_add_edges` had two bugs that would cause a runtime `AttributeError` whenever edges are written in online Neo4j mode:

1. **`self._initialize_driver()` does not exist.** The method was never defined; the correct method is `_get_driver()`.
2. **`self._driver.add_biocypher_nodes(translated_edges)` passes edges to the nodes method.** The correct method for edges is `add_biocypher_edges()`.

The buggy code:
```python
# _add_edges — online branch (before fix)
if not self._driver:
    self._initialize_driver()          # AttributeError: no such method
passed = self._driver.add_biocypher_nodes(translated_edges)  # wrong method
```

Fixed to match the pattern already used correctly in `_add_nodes`:
```python
# _add_edges — online branch (after fix)
passed = self._get_driver().add_biocypher_edges(translated_edges)
```

## Test plan

- [x] New regression test `test_online_add_edges_calls_add_biocypher_edges` mocks `_get_driver` and asserts `add_biocypher_edges` is called exactly once and `add_biocypher_nodes` is never called
- [x] All 13 existing `test_core.py` tests continue to pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABKfswoJ563S26RvwSyjic)_