### PR TITLE
feat(batch_writer): stream edge processing in offline mode to eliminate unbounded memory usage

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -6,11 +6,9 @@ import re
 
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from types import GeneratorType
+from collections.abc import Iterable
 
 import networkx
-
-from more_itertools import peekable
 
 from biocypher._create import BioCypherEdge, BioCypherNode, BioCypherRelAsNode
 from biocypher._deduplicate import Deduplicator
@@ -355,7 +353,7 @@ class _BatchWriter(_Writer, ABC):
             logger.error(msg)
             raise ValueError(msg)
 
-        elif self.labels_order != "None":
+        if self.labels_order != "None":
             if self.edge_labels_order != self.labels_order or self.node_labels_order != self.labels_order:
                 msg = (
                     f"`labels_order`=`{self.labels_order}` "
@@ -366,12 +364,12 @@ class _BatchWriter(_Writer, ABC):
                 logger.info(msg)
 
             if self.node_labels_order == "None":
-                msg = "`node_labels_order` set to `labels_order`=" f"`{self.labels_order}`."
+                msg = f"`node_labels_order` set to `labels_order`=`{self.labels_order}`."
                 self.node_labels_order = self.labels_order
                 logger.info(msg)
 
             if self.edge_labels_order == "None":
-                msg = "`node_labels_order` set to `labels_order`=" f"`{self.labels_order}`."
+                msg = f"`node_labels_order` set to `labels_order`=`{self.labels_order}`."
                 self.edge_labels_order = self.labels_order
                 logger.info(msg)
 
@@ -383,8 +381,7 @@ class _BatchWriter(_Writer, ABC):
         """Property for output directory path."""
         if self._import_call_file_prefix is None:
             return self.outdir
-        else:
-            return self._import_call_file_prefix
+        return self._import_call_file_prefix
 
     def _process_delimiter(self, delimiter: str) -> str:
         """Process a delimited to escape correctly.
@@ -401,8 +398,7 @@ class _BatchWriter(_Writer, ABC):
         if delimiter == "\\t":
             return "\t", "\\t"
 
-        else:
-            return delimiter, delimiter
+        return delimiter, delimiter
 
     def write_nodes(self, nodes, batch_size: int = int(1e6), force: bool = False):
         """Write nodes and their headers.
@@ -440,7 +436,7 @@ class _BatchWriter(_Writer, ABC):
 
     def write_edges(
         self,
-        edges: list | GeneratorType,
+        edges: Iterable,
         batch_size: int = int(1e6),
     ) -> bool:
         """Write edges and their headers.
@@ -457,36 +453,39 @@ class _BatchWriter(_Writer, ABC):
 
         """
         passed = False
-        edges = list(edges)  # force evaluation to handle empty generator
-        if edges:
-            nodes_flat = []
-            edges_flat = []
-            for edge in edges:
-                if isinstance(edge, BioCypherRelAsNode):
-                    # check if relationship has already been written, if so skip
-                    if self.deduplicator.rel_as_node_seen(edge):
-                        continue
+        empty = True
+        has_node = False
 
-                    nodes_flat.append(edge.get_node())
-                    edges_flat.append(edge.get_source_edge())
-                    edges_flat.append(edge.get_target_edge())
+        nodes_proceed, nodes_flush = self._create_write_node_data_handles(batch_size)
+        edges_proceed, edges_flush = self._crete_write_edge_data_handles(batch_size)
+        for edge in edges:
+            empty = False
+            if isinstance(edge, BioCypherRelAsNode):
+                # check if relationship has already been written, if so skip
+                if self.deduplicator.rel_as_node_seen(edge):
+                    continue
 
-                else:
-                    # check if relationship has already been written, if so skip
-                    if self.deduplicator.edge_seen(edge):
-                        continue
-
-                    edges_flat.append(edge)
-
-            if nodes_flat and edges_flat:
-                passed = self.write_nodes(nodes_flat) and self._write_edge_data(
-                    edges_flat,
-                    batch_size,
+                passed = (
+                    nodes_proceed(edge.get_node())
+                    and edges_proceed(edge.get_source_edge())
+                    and edges_proceed(edge.get_target_edge())
                 )
-            else:
-                passed = self._write_edge_data(edges_flat, batch_size)
+                if not passed:
+                    break
 
-        else:
+                has_node = True
+            else:
+                # check if relationship has already been written, if so skip
+                if self.deduplicator.edge_seen(edge):
+                    continue
+
+                passed = edges_proceed(edge)
+                if not passed:
+                    break
+
+        passed = passed and nodes_flush() and edges_flush()
+
+        if empty:
             # is this a problem? if the generator or list is empty, we
             # don't write anything.
             logger.debug(
@@ -496,6 +495,14 @@ class _BatchWriter(_Writer, ABC):
         if not passed:
             logger.error("Error while writing edge data.")
             return False
+
+        if has_node:
+            # pass property data to header writer per node type written
+            passed = self._write_node_headers()
+            if not passed:
+                logger.error("Error while writing node headers.")
+                return False
+
         # pass property data to header writer per edge type written
         passed = self._write_edge_headers()
         if not passed:
@@ -540,7 +547,7 @@ class _BatchWriter(_Writer, ABC):
                 case _:
                     # In case someone touched _label_orders after constructor.
                     if labels_order not in self._labels_orders:
-                        msg = f"Invalid labels_order: {labels_order}. " f"Must be one of {self._labels_orders}"
+                        msg = f"Invalid labels_order: {labels_order}. Must be one of {self._labels_orders}"
                         raise ValueError(msg)
             # concatenate with array delimiters
             all_labels = self._write_array_string(all_labels)
@@ -563,99 +570,148 @@ class _BatchWriter(_Writer, ABC):
             nodes (BioCypherNode): a list or generator of nodes in
                 :py:class:`BioCypherNode` format
 
+            batch_size (int): The number of nodes per type to buffer before
+                flushing a CSV part file.
+
+            force (bool): Whether to bypass ontology lookups for labels while
+                writing node labels.
+
         Returns:
         -------
             bool: The return value. True for success, False otherwise.
 
         """
-        if isinstance(nodes, GeneratorType | peekable):
-            logger.debug("Writing node CSV from generator.")
+        if not isinstance(nodes, Iterable):
+            logger.error("Nodes must be passed as an iterable.")
+            return False
 
-            bins = defaultdict(list)  # dict to store a list for each
-            # label that is passed in
-            bin_l = {}  # dict to store the length of each list for
-            # batching cutoff
-            reference_props = defaultdict(
-                dict,
-            )  # dict to store a dict of properties
-            # for each label to check for consistency and their type
-            # for now, relevant for `int`
-            labels = {}  # dict to store the additional labels for each
-            # primary graph constituent from biolink hierarchy
-            for node in nodes:
-                # check if node has already been written, if so skip
-                if self.deduplicator.node_seen(node):
-                    continue
+        proceed, flush = self._create_write_node_data_handles(batch_size, force)
+        for node in nodes:
+            if not proceed(node):
+                return False
+        return flush()
 
-                _id = node.get_id()
-                label = node.get_label()
+    def _create_write_node_data_handles(self, batch_size, force: bool = False):
+        """Create node-writing closures for streamed input.
 
-                # check for non-id
-                if not _id:
-                    logger.warning(f"Node {label} has no id; skipping.")
-                    continue
+        The returned `proceed` closure consumes one
+        :py:class:`BioCypherNode` at a time and flushes full batches to disk.
+        The returned `flush` closure writes remaining buffered nodes and stores
+        discovered node properties in :py:attr:`self.node_property_dict`.
 
-                if label not in bins.keys():
-                    # start new list
-                    bins[label].append(node)
-                    bin_l[label] = 1
+        Args:
+        ----
+            batch_size (int): The number of nodes per type to buffer before
+                writing a part file.
 
-                    # get properties from config if present
-                    if label in self.translator.ontology.mapping.extended_schema:
-                        cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
-                            "properties",
-                        )
-                    else:
-                        cprops = None
-                    if cprops:
-                        d = dict(cprops)
+            force (bool): Whether to bypass ontology lookups for labels while
+                writing node labels.
 
-                        # add id and preferred id to properties; these are
-                        # created in node creation (`_create.BioCypherNode`)
-                        d["id"] = "str"
-                        d["preferred_id"] = "str"
+        Returns:
+        -------
+            tuple[Callable, Callable]: `(proceed, flush)` where `proceed`
+                processes one node and `flush` writes all remaining buffers.
 
-                        # add strict mode properties
-                        if self.strict_mode:
-                            d["source"] = "str"
-                            d["version"] = "str"
-                            d["licence"] = "str"
+        """
+        empty = True
+        bins = defaultdict(list)  # dict to store a list for each
+        # label that is passed in
+        bin_l = {}  # dict to store the length of each list for
+        # batching cutoff
+        reference_props = defaultdict(
+            dict,
+        )  # dict to store a dict of properties
+        # for each label to check for consistency and their type
+        # for now, relevant for `int`
+        labels = {}  # dict to store the additional labels for each
 
-                    else:
-                        d = dict(node.get_properties())
-                        # encode property type
-                        for k, v in d.items():
-                            if d[k] is not None:
-                                d[k] = type(v).__name__
-                    # else use first encountered node to define properties for
-                    # checking; could later be by checking all nodes but much
-                    # more complicated, particularly involving batch writing
-                    # (would require "do-overs"). for now, we output a warning
-                    # if node properties diverge from reference properties (in
-                    # write_single_node_list_to_file) TODO if it occurs, ask
-                    # user to select desired properties and restart the process
+        # primary graph constituent from biolink hierarchy
+        def proceed(node):
+            nonlocal empty
+            if empty:
+                logger.debug("Writing node CSV from generator.")
+                empty = False
 
-                    reference_props[label] = d
-                    labels[label] = self._get_all_labels(label, self.node_labels_order, force)
+            # check if node has already been written, if so skip
+            if self.deduplicator.node_seen(node):
+                return True
+
+            _id = node.get_id()
+            label = node.get_label()
+
+            # check for non-id
+            if not _id:
+                logger.warning(f"Node {label} has no id; skipping.")
+                return True
+
+            if label not in bins:
+                # start new list
+                bins[label].append(node)
+                bin_l[label] = 1
+
+                # get properties from config if present
+                if label in self.translator.ontology.mapping.extended_schema:
+                    cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
+                        "properties",
+                    )
+                else:
+                    cprops = None
+                if cprops:
+                    d = dict(cprops)
+
+                    # add id and preferred id to properties; these are
+                    # created in node creation (`_create.BioCypherNode`)
+                    d["id"] = "str"
+                    d["preferred_id"] = "str"
+
+                    # add strict mode properties
+                    if self.strict_mode:
+                        d["source"] = "str"
+                        d["version"] = "str"
+                        d["licence"] = "str"
 
                 else:
-                    # add to list
-                    bins[label].append(node)
-                    bin_l[label] += 1
-                    if not bin_l[label] < batch_size:
-                        # batch size controlled here
-                        passed = self._write_single_node_list_to_file(
-                            bins[label],
-                            label,
-                            reference_props[label],
-                            labels[label],
-                        )
+                    d = dict(node.get_properties())
+                    # encode property type
+                    for k, v in d.items():
+                        if v is not None:
+                            d[k] = type(v).__name__
+                # else use first encountered node to define properties for
+                # checking; could later be by checking all nodes but much
+                # more complicated, particularly involving batch writing
+                # (would require "do-overs"). for now, we output a warning
+                # if node properties diverge from reference properties (in
+                # write_single_node_list_to_file) TODO if it occurs, ask
+                # user to select desired properties and restart the process
 
-                        if not passed:
-                            return False
+                reference_props[label] = d
+                labels[label] = self._get_all_labels(label, self.node_labels_order, force)
 
-                        bins[label] = []
-                        bin_l[label] = 0
+            else:
+                # add to list
+                bins[label].append(node)
+                bin_l[label] += 1
+                if not bin_l[label] < batch_size:
+                    # batch size controlled here
+                    passed = self._write_single_node_list_to_file(
+                        bins[label],
+                        label,
+                        reference_props[label],
+                        labels[label],
+                    )
+
+                    if not passed:
+                        return False
+
+                    bins[label] = []
+                    bin_l[label] = 0
+
+            return True
+
+        def flush():
+            nonlocal empty
+            if empty:
+                return True
 
             # after generator depleted, write remainder of bins
             for label, nl in bins.items():
@@ -675,19 +731,12 @@ class _BatchWriter(_Writer, ABC):
             # properties in the generator pass
 
             # save config or first-node properties to instance attribute
-            for label in reference_props.keys():
+            for label in reference_props:
                 self.node_property_dict[label] = reference_props[label]
 
             return True
-        elif not isinstance(nodes, list):
-            logger.error("Nodes must be passed as list or generator.")
-            return False
-        else:
 
-            def gen(nodes):
-                yield from nodes
-
-            return self._write_node_data(gen(nodes), batch_size=batch_size)
+        return proceed, flush
 
     def _write_single_node_list_to_file(
         self,
@@ -781,25 +830,36 @@ class _BatchWriter(_Writer, ABC):
 
         return True
 
-    # FIXME why does _write_node_data has a `force` arg, and not _write_edge_data?
     def _write_edge_data(self, edges, batch_size):
-        """Write biocypher edges to CSV.
+        if not isinstance(edges, Iterable):
+            logger.error("Edges must be passed as iterable.")
+            return False
 
-        Writes biocypher edges to CSV conforming to the headers created
-        with `_write_edge_headers()`, and is actually required to be run
-        before calling `_write_node_headers()` to set the
-        :py:attr:`self.edge_property_dict` for passing the edge
-        properties to the instance. Expects list or generator of edges
-        from the :py:class:`BioCypherEdge` class.
+        proceed, flush = self._crete_write_edge_data_handles(batch_size)
+        for edge in edges:
+            if not proceed(edge):
+                return False
+        return flush()
+
+    # FIXME why does _write_node_data has a `force` arg, and not _write_edge_data?
+    def _crete_write_edge_data_handles(self, batch_size):
+        """Create edge-writing closures for streamed input.
+
+        The returned `proceed` closure consumes one
+        :py:class:`BioCypherEdge` at a time and flushes full batches to disk.
+        The returned `flush` closure writes remaining buffered edges and stores
+        discovered edge properties in :py:attr:`self.edge_property_dict`.
+        This must run before `_write_edge_headers()`.
 
         Args:
         ----
-            edges (BioCypherEdge): a list or generator of edges in
-                :py:class:`BioCypherEdge` format
+            batch_size (int): The number of edges per type to buffer before
+                writing a part file.
 
         Returns:
         -------
-            bool: The return value. True for success, False otherwise.
+            tuple[Callable, Callable]: `(proceed, flush)` where `proceed`
+                processes one edge and `flush` writes all remaining buffers.
 
         Todo:
         ----
@@ -807,99 +867,110 @@ class _BatchWriter(_Writer, ABC):
               called on one iterable containing one type of edge only
 
         """
-        if isinstance(edges, GeneratorType):
-            logger.debug("Writing edge CSV from generator.")
+        empty = True
+        bins = defaultdict(list)  # dict to store a list for each
+        # label that is passed in
+        bin_l = {}  # dict to store the length of each list for
+        # batching cutoff
+        reference_props = defaultdict(
+            dict,
+        )  # dict to store a dict of properties
 
-            bins = defaultdict(list)  # dict to store a list for each
-            # label that is passed in
-            bin_l = {}  # dict to store the length of each list for
-            # batching cutoff
-            reference_props = defaultdict(
-                dict,
-            )  # dict to store a dict of properties
-            # for each label to check for consistency and their type
-            # for now, relevant for `int`
-            for edge in edges:
-                if not (edge.get_source_id() and edge.get_target_id()):
-                    logger.error(
-                        f"Edge must have source and target node. Caused by: {edge}",
+        # for each label to check for consistency and their type
+        # for now, relevant for `int`
+        def proceed(edge):
+            nonlocal empty
+            if empty:
+                logger.debug("Writing edge CSV from generator.")
+                empty = False
+
+            if not (edge.get_source_id() and edge.get_target_id()):
+                logger.error(
+                    f"Edge must have source and target node. Caused by: {edge}",
+                )
+                return True
+
+            label = edge.get_label()
+
+            if label not in bins:
+                # start new list
+                bins[label].append(edge)
+                bin_l[label] = 1
+
+                # get properties from config if present
+
+                # check whether label is in ontology_adapter.leaves
+                # (may not be if it is an edge that carries the
+                # "label_as_edge" property)
+                cprops = None
+                if label in self.translator.ontology.mapping.extended_schema:
+                    cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
+                        "properties",
                     )
-                    continue
+                else:
+                    # try via "label_as_edge"
+                    for (
+                        k,
+                        v,
+                    ) in self.translator.ontology.mapping.extended_schema.items():
+                        if isinstance(v, dict):
+                            if v.get("label_as_edge") == label:
+                                cprops = v.get("properties")
+                                logger.warning(
+                                    "`label_as_edge` will be deprecated in a future version,"
+                                    "please use edge types that exists in your ontology's taxonomy.",
+                                )
+                                break
+                if cprops:
+                    d = dict(cprops)
 
-                label = edge.get_label()
-
-                if label not in bins.keys():
-                    # start new list
-                    bins[label].append(edge)
-                    bin_l[label] = 1
-
-                    # get properties from config if present
-
-                    # check whether label is in ontology_adapter.leaves
-                    # (may not be if it is an edge that carries the
-                    # "label_as_edge" property)
-                    cprops = None
-                    if label in self.translator.ontology.mapping.extended_schema:
-                        cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
-                            "properties",
-                        )
-                    else:
-                        # try via "label_as_edge"
-                        for (
-                            k,
-                            v,
-                        ) in self.translator.ontology.mapping.extended_schema.items():
-                            if isinstance(v, dict):
-                                if v.get("label_as_edge") == label:
-                                    cprops = v.get("properties")
-                                    logger.warning(
-                                        "`label_as_edge` will be deprecated in a future version,"
-                                        "please use edge types that exists in your ontology's taxonomy."
-                                    )
-                                    break
-                    if cprops:
-                        d = dict(cprops)
-
-                        # add strict mode properties
-                        if self.strict_mode:
-                            d["source"] = "str"
-                            d["version"] = "str"
-                            d["licence"] = "str"
-
-                    else:
-                        d = dict(edge.get_properties())
-                        # encode property type
-                        for k, v in d.items():
-                            if d[k] is not None:
-                                d[k] = type(v).__name__
-                    # else use first encountered edge to define
-                    # properties for checking; could later be by
-                    # checking all edges but much more complicated,
-                    # particularly involving batch writing (would
-                    # require "do-overs"). for now, we output a warning
-                    # if edge properties diverge from reference
-                    # properties (in write_single_edge_list_to_file)
-                    # TODO
-
-                    reference_props[label] = d
+                    # add strict mode properties
+                    if self.strict_mode:
+                        d["source"] = "str"
+                        d["version"] = "str"
+                        d["licence"] = "str"
 
                 else:
-                    # add to list
-                    bins[label].append(edge)
-                    bin_l[label] += 1
-                    if not bin_l[label] < batch_size:
-                        # batch size controlled here
-                        passed = self._write_single_edge_list_to_file(
-                            bins[label],
-                            label,
-                            reference_props[label],
-                        )
+                    d = dict(edge.get_properties())
+                    # encode property type
+                    for k, v in d.items():
+                        if v is not None:
+                            d[k] = type(v).__name__
+                # else use first encountered edge to define
+                # properties for checking; could later be by
+                # checking all edges but much more complicated,
+                # particularly involving batch writing (would
+                # require "do-overs"). for now, we output a warning
+                # if edge properties diverge from reference
+                # properties (in write_single_edge_list_to_file)
+                # TODO
 
-                        if not passed:
-                            return False
+                reference_props[label] = d
 
-                        bins[label] = []
-                        bin_l[label] = 0
+            else:
+                # add to list
+                bins[label].append(edge)
+                bin_l[label] += 1
+                if not bin_l[label] < batch_size:
+                    # batch size controlled here
+                    passed = self._write_single_edge_list_to_file(
+                        bins[label],
+                        label,
+                        reference_props[label],
+                    )
+
+                    if not passed:
+                        return False
+
+                    bins[label] = []
+                    bin_l[label] = 0
+
+            return True
+
+        def flush():
+            nonlocal empty
+            if empty:
+                return True
 
             # after generator depleted, write remainder of bins
             for label, nl in bins.items():
@@ -918,19 +989,12 @@ class _BatchWriter(_Writer, ABC):
             # properties in the generator pass
 
             # save first-edge properties to instance attribute
-            for label in reference_props.keys():
+            for label in reference_props:
                 self.edge_property_dict[label] = reference_props[label]
 
             return True
-        elif not isinstance(edges, list):
-            logger.error("Edges must be passed as list or generator.")
-            return False
-        else:
 
-            def gen(edges):
-                yield from edges
-
-            return self._write_edge_data(gen(edges), batch_size=batch_size)
+        return proceed, flush
 
     def _write_single_edge_list_to_file(
         self,
@@ -1031,7 +1095,7 @@ class _BatchWriter(_Writer, ABC):
                     self.translator.ontology.mapping.extended_schema.get(
                         schema_label,
                     ).get("use_id")
-                    == False  # noqa: E712 (seems to not work with 'not')
+                    == False
                 ):
                     skip_id = True
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -452,7 +452,7 @@ class _BatchWriter(_Writer, ABC):
             bool: The return value. True for success, False otherwise.
 
         """
-        passed = False
+        passed = True
         empty = True
         has_node = False
 
@@ -486,8 +486,6 @@ class _BatchWriter(_Writer, ABC):
         passed = passed and flush_nodes() and flush_edges()
 
         if empty:
-            # is this a problem? if the generator or list is empty, we
-            # don't write anything.
             logger.debug(
                 "No edges to write, possibly due to no matched Biolink classes.",
             )

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -405,7 +405,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            nodes (BioCypherNode): a literable of nodes in
+            nodes (BioCypherNode): an iterable of nodes in
                 :py:class:`BioCypherNode` format
 
             batch_size (int): The batch size for writing nodes.
@@ -443,7 +443,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            edges (BioCypherEdge): a literable of edges in
+            edges (BioCypherEdge): an iterable of edges in
                 :py:class:`BioCypherEdge` or :py:class:`BioCypherRelAsNode`
                 format
 
@@ -456,8 +456,8 @@ class _BatchWriter(_Writer, ABC):
         empty = True
         has_node = False
 
-        nodes_proceed, nodes_flush = self._create_write_node_data_handles(batch_size)
-        edges_proceed, edges_flush = self._crete_write_edge_data_handles(batch_size)
+        consume_nodes, flush_nodes = self._create_write_node_data_handlers(batch_size)
+        consume_edges, flush_edges = self._create_write_edge_data_handlers(batch_size)
         for edge in edges:
             empty = False
             if isinstance(edge, BioCypherRelAsNode):
@@ -466,9 +466,9 @@ class _BatchWriter(_Writer, ABC):
                     continue
 
                 passed = (
-                    nodes_proceed(edge.get_node())
-                    and edges_proceed(edge.get_source_edge())
-                    and edges_proceed(edge.get_target_edge())
+                    consume_nodes(edge.get_node())
+                    and consume_edges(edge.get_source_edge())
+                    and consume_edges(edge.get_target_edge())
                 )
                 if not passed:
                     break
@@ -479,11 +479,11 @@ class _BatchWriter(_Writer, ABC):
                 if self.deduplicator.edge_seen(edge):
                     continue
 
-                passed = edges_proceed(edge)
+                passed = consume_edges(edge)
                 if not passed:
                     break
 
-        passed = passed and nodes_flush() and edges_flush()
+        passed = passed and flush_nodes() and flush_edges()
 
         if empty:
             # is this a problem? if the generator or list is empty, we
@@ -567,7 +567,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            nodes (BioCypherNode): a literable of nodes in
+            nodes (BioCypherNode): an iterable of nodes in
                 :py:class:`BioCypherNode` format
 
             batch_size (int): The number of nodes per type to buffer before
@@ -585,16 +585,16 @@ class _BatchWriter(_Writer, ABC):
             logger.error("Nodes must be passed as an iterable.")
             return False
 
-        proceed, flush = self._create_write_node_data_handles(batch_size, force)
+        consume, flush = self._create_write_node_data_handlers(batch_size, force)
         for node in nodes:
-            if not proceed(node):
+            if not consume(node):
                 return False
         return flush()
 
-    def _create_write_node_data_handles(self, batch_size, force: bool = False):
+    def _create_write_node_data_handlers(self, batch_size, force: bool = False):
         """Create node-writing closures for streamed input.
 
-        The returned `proceed` closure consumes one
+        The returned `consume` closure consumes one
         :py:class:`BioCypherNode` at a time and flushes full batches to disk.
         The returned `flush` closure writes remaining buffered nodes and stores
         discovered node properties in :py:attr:`self.node_property_dict`.
@@ -609,7 +609,7 @@ class _BatchWriter(_Writer, ABC):
 
         Returns:
         -------
-            tuple[Callable, Callable]: `(proceed, flush)` where `proceed`
+            tuple[Callable, Callable]: `(consume, flush)` where `consume`
                 processes one node and `flush` writes all remaining buffers.
 
         """
@@ -626,7 +626,7 @@ class _BatchWriter(_Writer, ABC):
         labels = {}  # dict to store the additional labels for each
 
         # primary graph constituent from biolink hierarchy
-        def proceed(node):
+        def consume(node):
             nonlocal empty
             if empty:
                 logger.debug("Writing node CSV from generator.")
@@ -736,7 +736,7 @@ class _BatchWriter(_Writer, ABC):
 
             return True
 
-        return proceed, flush
+        return consume, flush
 
     def _write_single_node_list_to_file(
         self,
@@ -842,7 +842,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            edges (BioCypherEdge): a literable of edges in
+            edges (BioCypherEdge): an iterable of edges in
                 :py:class:`BioCypherEdge` format
 
         Returns:
@@ -859,17 +859,18 @@ class _BatchWriter(_Writer, ABC):
             logger.error("Edges must be passed as iterable.")
             return False
 
-        proceed, flush = self._crete_write_edge_data_handles(batch_size)
+        consume, flush = self._create_write_edge_data_handlers(batch_size)
         for edge in edges:
-            if not proceed(edge):
+            if not consume(edge):
                 return False
         return flush()
 
-    # FIXME why does _write_node_data has a `force` arg, and not _write_edge_data?
-    def _crete_write_edge_data_handles(self, batch_size):
+    # No `force` arg: only nodes need to bypass ontology lookup, for the
+    # synthetic `schema_info` node written by `_core.py`.
+    def _create_write_edge_data_handlers(self, batch_size):
         """Create edge-writing closures for streamed input.
 
-        The returned `proceed` closure consumes one
+        The returned `consume` closure consumes one
         :py:class:`BioCypherEdge` at a time and flushes full batches to disk.
         The returned `flush` closure writes remaining buffered edges and stores
         discovered edge properties in :py:attr:`self.edge_property_dict`.
@@ -882,7 +883,7 @@ class _BatchWriter(_Writer, ABC):
 
         Returns:
         -------
-            tuple[Callable, Callable]: `(proceed, flush)` where `proceed`
+            tuple[Callable, Callable]: `(consume, flush)` where `consume`
                 processes one edge and `flush` writes all remaining buffers.
 
         Todo:
@@ -902,7 +903,7 @@ class _BatchWriter(_Writer, ABC):
 
         # for each label to check for consistency and their type
         # for now, relevant for `int`
-        def proceed(edge):
+        def consume(edge):
             nonlocal empty
             if empty:
                 logger.debug("Writing edge CSV from generator.")
@@ -1018,7 +1019,7 @@ class _BatchWriter(_Writer, ABC):
 
             return True
 
-        return proceed, flush
+        return consume, flush
 
     def _write_single_edge_list_to_file(
         self,

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -1119,7 +1119,7 @@ class _BatchWriter(_Writer, ABC):
                     self.translator.ontology.mapping.extended_schema.get(
                         schema_label,
                     ).get("use_id")
-                    == False
+                    == False  # noqa: E712 (seems to not work with 'not')
                 ):
                     skip_id = True
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -405,7 +405,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            nodes (BioCypherNode): a list or generator of nodes in
+            nodes (BioCypherNode): a literable of nodes in
                 :py:class:`BioCypherNode` format
 
             batch_size (int): The batch size for writing nodes.
@@ -443,7 +443,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            edges (BioCypherEdge): a list or generator of edges in
+            edges (BioCypherEdge): a literable of edges in
                 :py:class:`BioCypherEdge` or :py:class:`BioCypherRelAsNode`
                 format
 
@@ -567,7 +567,7 @@ class _BatchWriter(_Writer, ABC):
 
         Args:
         ----
-            nodes (BioCypherNode): a list or generator of nodes in
+            nodes (BioCypherNode): a literable of nodes in
                 :py:class:`BioCypherNode` format
 
             batch_size (int): The number of nodes per type to buffer before
@@ -831,6 +831,30 @@ class _BatchWriter(_Writer, ABC):
         return True
 
     def _write_edge_data(self, edges, batch_size):
+        """Write biocypher edges to CSV.
+
+        Writes biocypher edges to CSV conforming to the headers created
+        with `_write_edge_headers()`, and is actually required to be run
+        before calling `_write_node_headers()` to set the
+        :py:attr:`self.edge_property_dict` for passing the edge
+        properties to the instance. Expects list or generator of edges
+        from the :py:class:`BioCypherEdge` class.
+
+        Args:
+        ----
+            edges (BioCypherEdge): a literable of edges in
+                :py:class:`BioCypherEdge` format
+
+        Returns:
+        -------
+            bool: The return value. True for success, False otherwise.
+
+        Todo:
+        ----
+            - currently works for mixed edges but in practice often is
+              called on one iterable containing one type of edge only
+
+        """
         if not isinstance(edges, Iterable):
             logger.error("Edges must be passed as iterable.")
             return False

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -969,13 +969,6 @@ def test_write_duplicate_edges(bw, _get_edges):
 
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_edges_all_duplicates(bw, _get_edges):
-    """Second call with the same edges is a full no-op after dedup.
-
-    Reproduces a regression in the streaming refactor where
-    ``write_edges`` returns ``False`` (and logs an error) when every
-    incoming edge has already been seen by the deduplicator, even
-    though there is nothing to do and no failure occurred.
-    """
     edges = _get_edges
 
     first = bw.write_edges(edges)

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -968,6 +968,24 @@ def test_write_duplicate_edges(bw, _get_edges):
 
 
 @pytest.mark.parametrize("length", [4], scope="module")
+def test_write_edges_all_duplicates(bw, _get_edges):
+    """Second call with the same edges is a full no-op after dedup.
+
+    Reproduces a regression in the streaming refactor where
+    ``write_edges`` returns ``False`` (and logs an error) when every
+    incoming edge has already been seen by the deduplicator, even
+    though there is nothing to do and no failure occurred.
+    """
+    edges = _get_edges
+
+    first = bw.write_edges(edges)
+    second = bw.write_edges(edges)
+
+    assert first
+    assert second, "all-deduplicated write_edges call should succeed, not error"
+
+
+@pytest.mark.parametrize("length", [4], scope="module")
 def test_BioCypherRelAsNode_implementation(bw, _get_rel_as_nodes):
     trips = _get_rel_as_nodes
 

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
### Problem

The current edge-writing implementation forces exhaustive materialisation of generators for two reasons:

1. To determine whether the generator is empty.
2. To collect all nodes and edges produced when resolving relationships-as-nodes.

This design results in unbounded memory usage, limiting BioCypher's ability to scale to large datasets.

### Improvement

For the emptiness check, a simple boolean flag set during iteration is sufficient. Although evaluated repeatedly, the overhead is negligible in practice and compares favourably to alternative approaches in both performance and code simplicity.

For relationships-as-nodes processing, entities are now resolved incrementally rather than accumulated upfront. Each resolved node and edge is passed directly to downstream processing as soon as it is produced, eliminating the need to store the entire result set in memory.

To support this, `_write_node_data` and `_write_edge_data` have been refactored and renamed. Conceptually, they now operate in a streaming fashion. Instead of processing an entire collection of nodes or edges, each function returns two handles (closures):

* One for processing individual items as they are produced.
* One for flushing any remaining buffered data at the end of the sequence.

This allows callers to stream resolved nodes and edges immediately without intermediate accumulation. Wrapper functions preserve the original `_write_node_data` and `_write_edge_data` interfaces, maintaining full backwards compatibility.

### Other Changes

The original implementation accepted `Generator` as the input type. Since the input is only iterated over and does not rely on generator-specific behaviour, `Iterable` is a more appropriate and less restrictive interface. The relevant type annotations have therefore been updated accordingly.

### Remarks
Testing on the Open Targets dataset shows that memory usage stabilises with this optimisation in place. Combined with [https://github.com/biocypher/biocypher/pull/537](https://github.com/biocypher/biocypher/pull/537), BioCypher should now be able to process datasets of arbitrary size without memory consumption growing with the total input size.

As this change only affects implementation details and does not modify external behaviour, no additional tests should be required.