### PR TITLE
fix(sqlite): add set -e to import script; skip DB test when sqlite3 CLI absent

### DIFF
--- a/biocypher/output/write/relational/_sqlite.py
+++ b/biocypher/output/write/relational/_sqlite.py
@@ -25,7 +25,7 @@ class _SQLiteBatchWriter(_PostgreSQLBatchWriter):
         Returns:
             str: a bash command for sqlite import
         """
-        import_call = ""
+        import_call = "#!/bin/bash\nset -e\n\n"
 
         # create tables
         # At this point, csv files of nodes and edges do not require differentiation

--- a/test/output/write/relational/test_sqlite.py
+++ b/test/output/write/relational/test_sqlite.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import shutil
 import sqlite3
 import subprocess
 
@@ -45,6 +46,9 @@ def test_construct_import_call(bw_tab_sqlite, _get_nodes):
 
     write_result = bw_tab_sqlite.write_import_call()
     assert write_result
+
+    if shutil.which("sqlite3") is None:
+        pytest.skip("sqlite3 CLI not installed")
 
     import_script_path = os.path.join(bw_tab_sqlite.outdir, bw_tab_sqlite._get_import_script_name())
     system = platform.system()


### PR DESCRIPTION

## Summary

- `_construct_import_call()` in `_SQLiteBatchWriter` now prepends `#!/bin/bash\nset -e\n` to the generated import script, so a missing or failing `sqlite3` invocation exits non-zero and is visible to callers instead of silently succeeding.
- The end-to-end subprocess + database-verification block in `test_construct_import_call` is guarded with `shutil.which("sqlite3")`; the block is skipped (not failed) when the `sqlite3` CLI is not installed.

## Root cause

The generated bash script had no shebang and no `set -e`.  When the `sqlite3` binary was absent the shell printed `sqlite3: command not found` but continued executing `echo "Done!"`, so the script exited 0.  `subprocess.run(..., check=True)` therefore did not raise, the database was never populated, and the test failed with `AssertionError: assert 'protein' in []` — far from where the real problem was.

## Test plan

- [x] `test_construct_import_call[4]` passes when `sqlite3` CLI is installed (import script runs, tables are created, row counts are correct)
- [x] `test_construct_import_call[4]` is **skipped** (not failed) when `sqlite3` CLI is not installed
- [x] All other 331 tests continue to pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGDZCW7Z1wzswNtaEuTcwu)_