### PR TITLE
fix(mapping): correctly merge parent exclude_properties in vertical inheritance

### DIFF
--- a/biocypher/_mapping.py
+++ b/biocypher/_mapping.py
@@ -154,16 +154,25 @@ class OntologyMapping:
                 if "properties" not in v:
                     v["properties"] = {}
                 if "exclude_properties" not in v:
-                    v["exclude_properties"] = {}
+                    v["exclude_properties"] = []
 
                 # update properties of child
                 parent_props = self.schema[parent].get("properties", {})
                 if parent_props:
                     v["properties"].update(parent_props)
 
-                parent_excl_props = self.schema[parent].get("exclude_properties", {})
+                parent_excl_props = self.schema[parent].get("exclude_properties")
                 if parent_excl_props:
-                    v["exclude_properties"].update(parent_excl_props)
+                    if isinstance(parent_excl_props, str):
+                        parent_excl_props = [parent_excl_props]
+                    child_excl = v["exclude_properties"]
+                    if isinstance(child_excl, str):
+                        child_excl = [child_excl]
+                    merged = list(child_excl)
+                    for p in parent_excl_props:
+                        if p not in merged:
+                            merged.append(p)
+                    v["exclude_properties"] = merged
 
                 # update schema (d)
                 d[k] = v

--- a/test/test_mapping.py
+++ b/test/test_mapping.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 from biocypher._mapping import OntologyMapping
 
 # TODO migrate as appropriate from test translate
@@ -78,6 +77,97 @@ def test_input_label_accepted_as_label_in_input():
     dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep_warnings) == 0
     assert extended["protein"]["input_label"] == "protein"
+
+
+def test_inherit_properties_merges_parent_exclude_properties():
+    """Children with inherit_properties inherit parent exclude_properties as a list.
+
+    Previously this raised ValueError/AttributeError because the code initialised
+    exclude_properties as a dict and called .update() on it with a string/list value.
+    """
+    m = OntologyMapping()
+    m.schema = {
+        "parent entity": {
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "parent",
+            "properties": {"name": "str", "sequence": "str"},
+            "exclude_properties": "sequence",
+        },
+        "child entity": {
+            "is_a": "parent entity",
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "child",
+            "inherit_properties": True,
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        extended = m._extend_schema(d=m.schema)
+
+    child = extended["child entity"]
+    assert "sequence" in child["exclude_properties"]
+    assert "name" in child["properties"]
+    assert "sequence" in child["properties"]
+
+
+def test_inherit_properties_merges_parent_exclude_properties_list():
+    """Parent exclude_properties defined as a list is correctly merged into child."""
+    m = OntologyMapping()
+    m.schema = {
+        "parent entity": {
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "parent",
+            "properties": {"name": "str", "seq": "str", "accession": "str"},
+            "exclude_properties": ["seq", "accession"],
+        },
+        "child entity": {
+            "is_a": "parent entity",
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "child",
+            "inherit_properties": True,
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        extended = m._extend_schema(d=m.schema)
+
+    child = extended["child entity"]
+    assert "seq" in child["exclude_properties"]
+    assert "accession" in child["exclude_properties"]
+
+
+def test_inherit_properties_child_exclude_not_overwritten():
+    """Child's own exclude_properties are preserved and parent's are appended."""
+    m = OntologyMapping()
+    m.schema = {
+        "parent entity": {
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "parent",
+            "properties": {"name": "str", "seq": "str", "local": "str"},
+            "exclude_properties": "seq",
+        },
+        "child entity": {
+            "is_a": "parent entity",
+            "represented_as": "node",
+            "namespace": "uniprot",
+            "input_label": "child",
+            "inherit_properties": True,
+            "exclude_properties": "local",
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        extended = m._extend_schema(d=m.schema)
+
+    child = extended["child entity"]
+    excl = child["exclude_properties"]
+    assert "local" in excl
+    assert "seq" in excl
 
 
 def test_label_in_input_emits_deprecation_warning():


### PR DESCRIPTION
## Summary

`_vertical_property_inheritance` in `_mapping.py` lets child schema entries inherit properties from their parent when `inherit_properties: True` is set. The logic that merges the parent's `exclude_properties` was broken:

```python
# Before (broken)
if "exclude_properties" not in v:
    v["exclude_properties"] = {}          # wrong type — should be a list
parent_excl_props = self.schema[parent].get("exclude_properties", {})
if parent_excl_props:
    v["exclude_properties"].update(parent_excl_props)  # dict .update() on a str/list
```

`exclude_properties` in a schema YAML is a **string or list** (as expected by `_filter_props`), never a dict. Calling `.update()` on a string `"sequence"` raises `ValueError`; calling it on a string-typed `v["exclude_properties"]` raises `AttributeError`. Neither form was reachable by any existing test, because no current schema combines a parent with `exclude_properties` and a child with `inherit_properties: True`.

## Fix

- Initialise `exclude_properties` as `[]` instead of `{}`
- Normalise both the child's and parent's values to lists before merging
- Deduplicate entries while preserving order

```python
# After (fixed)
if "exclude_properties" not in v:
    v["exclude_properties"] = []
parent_excl_props = self.schema[parent].get("exclude_properties")
if parent_excl_props:
    if isinstance(parent_excl_props, str):
        parent_excl_props = [parent_excl_props]
    child_excl = v["exclude_properties"]
    if isinstance(child_excl, str):
        child_excl = [child_excl]
    merged = list(child_excl)
    for p in parent_excl_props:
        if p not in merged:
            merged.append(p)
    v["exclude_properties"] = merged
```

## Test plan

Three new tests in `test/test_mapping.py`:

- [x] `test_inherit_properties_merges_parent_exclude_properties` — parent with string `exclude_properties`; previously raised `ValueError`
- [x] `test_inherit_properties_merges_parent_exclude_properties_list` — parent with list `exclude_properties`
- [x] `test_inherit_properties_child_exclude_not_overwritten` — child's own `exclude_properties` is preserved; parent's are appended without duplication
- [x] All 252 existing tests continue to pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfwG2J5Ej3t6xYf15vy4Aq)_