### PR TITLE
fix(get): get_cached_version returns file paths for extracted archives

### DIFF
--- a/biocypher/_get.py
+++ b/biocypher/_get.py
@@ -283,8 +283,18 @@ class Downloader:
             paths.append(api_path)
         return paths
 
+    # Archive suffixes that pooch keeps in the cache dir after extraction.
+    # We skip these so that get_cached_version returns the same extracted
+    # file paths that the initial download returned, not the archives.
+    _ARCHIVE_SUFFIXES = (".zip", ".tar.gz", ".tgz", ".tar", ".gz", ".bz2")
+
     def get_cached_version(self, resource: Resource) -> list[str]:
         """Get the cached version of a resource.
+
+        Walks the resource's cache directory recursively and returns paths to
+        all non-archive files.  This mirrors what the initial download returns:
+        for plain files the file itself, and for archives the extracted
+        contents rather than the archive or an unzip sub-directory.
 
         Args:
         ----
@@ -298,8 +308,10 @@ class Downloader:
         cached_location = os.path.join(self.cache_dir, resource.name)
         logger.info(f"Use cached version from {cached_location}.")
         paths = []
-        for file in os.listdir(cached_location):
-            paths.append(os.path.join(cached_location, file))
+        for dirpath, _, filenames in os.walk(cached_location):
+            for filename in filenames:
+                if not any(filename.endswith(suffix) for suffix in self._ARCHIVE_SUFFIXES):
+                    paths.append(os.path.join(dirpath, filename))
         return paths
 
     def _retrieve(

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -299,6 +299,9 @@ def test_download_zip_and_expiration(mock_retrieve):
     paths = downloader.download(resource)
     # should not download again
     assert "tmp" in paths[0]
+    # cached paths must be actual files, not directories or archive containers
+    assert all(os.path.isfile(p) for p in paths), "get_cached_version must return file paths, not directories"
+    assert len(paths) == 2
 
     # minus 8 days from date_downloaded
     downloader.cache_dict["test_resource"]["date_downloaded"] = str(datetime.now() - timedelta(days=8))


### PR DESCRIPTION
## Summary

`Downloader.get_cached_version` called `os.listdir` on the resource's cache directory and returned every entry as a path verbatim. For resources backed by zip / tar.gz archives, `pooch` leaves **two** entries in that directory after extraction: the archive file itself and a `<name>.unzip` sub-directory. The function therefore returned **a directory path** instead of the individual extracted file paths, causing `IsADirectoryError` when any caller tried to open the result.

## Root cause

```python
# Before (broken for archive resources)
for file in os.listdir(cached_location):
    paths.append(os.path.join(cached_location, file))
```

For a zip resource the directory contains e.g. `["archive.zip", "archive.zip.unzip/"]`. The old code returned both — a file path and a **directory** path — instead of the extracted files inside `archive.zip.unzip/`.

## Fix

Use `os.walk` to recurse into any sub-directories created by extraction, and skip entries whose name ends with a known archive suffix (`.zip`, `.tar.gz`, `.tgz`, `.tar`, `.gz`, `.bz2`). This matches what the initial download returns — `pooch.Unzip()` / `pooch.Decompress()` already filters out the archive container and returns only the extracted file paths.

```python
# After
for dirpath, _, filenames in os.walk(cached_location):
    for filename in filenames:
        if not any(filename.endswith(suffix) for suffix in self._ARCHIVE_SUFFIXES):
            paths.append(os.path.join(dirpath, filename))
```

## Test plan

- [x] `test_download_zip_and_expiration` extended with `assert all(os.path.isfile(p) for p in paths)` and `assert len(paths) == 2` — these assertions **fail** on the old code and **pass** on the fix.
- [x] All 335 existing tests continue to pass (`20 skipped` are unrelated to this change — they require a live Neo4j/SQLite instance or an FTP server).

https://claude.ai/code/session_01H9K1DwnmpYmPKyQ73ErUcT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9K1DwnmpYmPKyQ73ErUcT)_