### PR TITLE
fix(config): replace deprecated `preferred_id` with `namespace` in test and tutorial schema configs

### DIFF
--- a/biocypher/_config/test_schema_config.yaml
+++ b/biocypher/_config/test_schema_config.yaml
@@ -6,7 +6,7 @@ Title: BioCypher graph schema configuration file
 
 protein:
   represented_as: node
-  preferred_id: uniprot
+  namespace: uniprot
   input_label: protein
   db_collection_name: proteins
   properties:
@@ -17,40 +17,40 @@ protein:
 
 microRNA:
   represented_as: node
-  preferred_id: mirbase.mature
+  namespace: mirbase.mature
   input_label: mirna
 
 complex:
   synonym_for: macromolecular complex
   represented_as: node
-  preferred_id: complexportal
+  namespace: complexportal
   input_label: complex
 
 pathway:
   represented_as: node
-  preferred_id: [reactome, wikipathways]
+  namespace: [reactome, wikipathways]
   input_label: [reactome, wikipathways]
 
 gene:
   represented_as: node
-  preferred_id: hgnc
+  namespace: hgnc
   input_label: [hgnc, ensg]
   exclude_properties: accession
 
 disease:
   represented_as: node
-  preferred_id: doid
+  namespace: doid
   input_label: Disease
 
 side effect:
   is_a: phenotypic feature
   represented_as: node
-  preferred_id: sider.effect
+  namespace: sider.effect
   input_label: sider
 
 sequence variant:
   represented_as: node
-  preferred_id: [clinically relevant, known, somatic]
+  namespace: [clinically relevant, known, somatic]
   input_label: [Clinically_relevant_variant, Known_variant, Somatic_mutation]
   properties:
     source: str
@@ -61,7 +61,7 @@ sequence variant:
 snRNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: [intact, rnacentral]
+  namespace: [intact, rnacentral]
   input_label: [intact_snrna, rnacentral_snrna]
   properties:
     ac: str
@@ -73,7 +73,7 @@ snRNA sequence:
 DNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: ensembl
+  namespace: ensembl
   input_label: dna
   properties:
     ac: str
@@ -86,7 +86,7 @@ dsDNA sequence:
   is_a: [DNA sequence, nucleic acid entity]
   inherit_properties: True
   represented_as: node
-  preferred_id: [intact, uniparc]
+  namespace: [intact, uniparc]
   input_label: [intact_dsdna, uniprot_archive_dsdna]
 
 # ---

--- a/biocypher/_config/test_schema_config_extended.yaml
+++ b/biocypher/_config/test_schema_config_extended.yaml
@@ -6,7 +6,7 @@ Title: BioCypher graph schema configuration file
 
 protein:
   represented_as: node
-  preferred_id: uniprot
+  namespace: uniprot
   input_label: protein
   db_collection_name: proteins
   properties:
@@ -17,40 +17,40 @@ protein:
 
 microRNA:
   represented_as: node
-  preferred_id: mirbase.mature
+  namespace: mirbase.mature
   input_label: mirna
 
 complex:
   synonym_for: macromolecular complex
   represented_as: node
-  preferred_id: complexportal
+  namespace: complexportal
   input_label: complex
 
 pathway:
   represented_as: node
-  preferred_id: [reactome, wikipathways]
+  namespace: [reactome, wikipathways]
   input_label: [reactome, wikipathways]
 
 gene:
   represented_as: node
-  preferred_id: hgnc
+  namespace: hgnc
   input_label: [hgnc, ensg]
   exclude_properties: accession
 
 disease:
   represented_as: node
-  preferred_id: doid
+  namespace: doid
   input_label: Disease
 
 side effect:
   is_a: phenotypic feature
   represented_as: node
-  preferred_id: sider.effect
+  namespace: sider.effect
   input_label: sider
 
 sequence variant:
   represented_as: node
-  preferred_id: [clinically relevant, known, somatic]
+  namespace: [clinically relevant, known, somatic]
   input_label: [Clinically_relevant_variant, Known_variant, Somatic_mutation]
   properties:
     source: str
@@ -73,7 +73,7 @@ lethal variant:
 snRNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: [intact, rnacentral]
+  namespace: [intact, rnacentral]
   input_label: [intact_snrna, rnacentral_snrna]
   properties:
     ac: str
@@ -85,7 +85,7 @@ snRNA sequence:
 DNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: ensembl
+  namespace: ensembl
   input_label: dna
   properties:
     ac: str
@@ -98,7 +98,7 @@ dsDNA sequence:
   is_a: [DNA sequence, nucleic acid entity]
   inherit_properties: True
   represented_as: node
-  preferred_id: [intact, uniparc]
+  namespace: [intact, uniparc]
   input_label: [intact_dsdna, uniprot_archive_dsdna]
 
 # ---

--- a/tutorial/01_schema_config.yaml
+++ b/tutorial/01_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_protein

--- a/tutorial/02_schema_config.yaml
+++ b/tutorial/02_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: [uniprot_protein, entrez_protein]

--- a/tutorial/03_schema_config.yaml
+++ b/tutorial/03_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]

--- a/tutorial/04_schema_config.yaml
+++ b/tutorial/04_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str

--- a/tutorial/05_schema_config.yaml
+++ b/tutorial/05_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,5 +12,5 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform

--- a/tutorial/06_schema_config.yaml
+++ b/tutorial/06_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: node
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str

--- a/tutorial/06_schema_config_pandas.yaml
+++ b/tutorial/06_schema_config_pandas.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: edge
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str

--- a/tutorial/07_schema_config.yaml
+++ b/tutorial/07_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: node
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str
@@ -27,5 +27,5 @@ protein protein interaction:
 complex:
     synonym_for: macromolecular complex
     represented_as: node
-    preferred_id: complexportal
+    namespace: complexportal
     input_label: complex


### PR DESCRIPTION
## Summary

- The `namespace` field was introduced in #519 as the preferred replacement for `preferred_id` in schema config YAML files, but the internal test configs and all tutorial configs were never updated.
- Every test that loaded these files emitted a `DeprecationWarning` for each schema entry, flooding the test output with noise and masking real warnings.
- This PR renames `preferred_id:` → `namespace:` in 10 YAML files (2 internal test configs + 8 tutorial configs).

## Root cause

`_mapping._extend_schema()` added a `DeprecationWarning` when it sees `preferred_id` in a schema entry (#519), but the files shipped with the repository were not updated at the same time.

```python
# _mapping.py — triggers warning for every entry in the old configs
elif v.get("preferred_id") is not None:
    warnings.warn(
        f"The 'preferred_id' field in schema config entry '{k}' is deprecated. "
        "Please use 'namespace' instead.",
        DeprecationWarning,
    )
```

## Changes

| File | Occurrences updated |
|---|---|
| `biocypher/_config/test_schema_config.yaml` | 11 |
| `biocypher/_config/test_schema_config_extended.yaml` | 11 |
| `tutorial/01_schema_config.yaml` | 1 |
| `tutorial/02_schema_config.yaml` | 1 |
| `tutorial/03_schema_config.yaml` | 1 |
| `tutorial/04_schema_config.yaml` | 1 |
| `tutorial/05_schema_config.yaml` | 2 |
| `tutorial/06_schema_config.yaml` | 3 |
| `tutorial/06_schema_config_pandas.yaml` | 3 |
| `tutorial/07_schema_config.yaml` | 4 |

## No functional change

`_extend_schema()` immediately normalises `namespace` → `preferred_id` internally, so all downstream code that reads `v["preferred_id"]` is unaffected.

## Test plan

- [x] All 287 previously passing tests continue to pass
- [x] Zero `DeprecationWarning: ... preferred_id ... deprecated` emitted during the test run (verified with `-W error::DeprecationWarning`)
- [x] `test_preferred_id_in_schema_emits_deprecation_warning` still passes (it uses an inline dict, not the YAML files)
- [x] `test_namespace_accepted_as_preferred_id` still passes

> **Note:** Two pre-existing `test_networkx_writer_*` failures exist on `main` due to a test-ordering/shared-temp-directory issue unrelated to this change; they are present before and after this PR.

https://claude.ai/code/session_01MdAHcHJiUf3i3YNJvXK7WF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdAHcHJiUf3i3YNJvXK7WF)_