### PR TITLE
fix(translate): _filter_props must not mutate the shared schema dict in strict mode

### DIFF
--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -171,7 +171,9 @@ class Translator:
             raise AttributeError(msg)
 
         # strict mode: add required properties (only if there is a whitelist)
+        # copy to avoid permanently mutating the shared schema dict
         if self.strict_mode and filter_props:
+            filter_props = dict(filter_props)
             filter_props.update(
                 {"source": "str", "licence": "str", "version": "str"},
             )

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -604,6 +604,28 @@ def test_strict_mode_property_filter(translator):
     assert "version" in translated_protein_node[0].get_properties().keys()
 
 
+def test_strict_mode_does_not_mutate_schema(translator):
+    """Strict-mode calls must not permanently inject keys into the shared schema dict.
+
+    _filter_props previously called dict.update() on the dict reference returned
+    directly by extended_schema[bl_type]['properties'], permanently adding
+    source/licence/version to the schema entry.  All subsequent non-strict calls
+    for the same type would then output those keys with value None.
+
+    This test must run after test_strict_mode_property_filter so that the
+    mutation, if still present, has already occurred.
+    """
+    translator.strict_mode = False
+
+    protein_plain = ("p_plain", "protein", {"taxon": 9606})
+    nodes = list(translator.translate_nodes([protein_plain]))
+    props = nodes[0].get_properties()
+
+    assert "source" not in props
+    assert "licence" not in props
+    assert "version" not in props
+
+
 def test_translate_entities_empty_iterable(translator):
     """translate_entities with an empty iterable should warn and return an empty iterator (issue #493)."""
     result = list(translator.translate_entities([]))


### PR DESCRIPTION
## Summary

`_filter_props` in `biocypher/_translate.py` called `dict.update()` directly on the dictionary reference returned by `extended_schema[bl_type]['properties']`. This mutated the actual schema dict, permanently injecting `source`, `licence`, and `version` into the schema entry for every type processed with `strict_mode=True`.

As a result, **all subsequent non-strict calls for the same type** would include those keys with `None` as the value — silently corrupting output properties without any warning.

## Root cause

```python
# Before (broken):
filter_props = self.ontology.mapping.extended_schema[bl_type].get("properties", {})
# filter_props is a direct reference to the schema dict, not a copy
if self.strict_mode and filter_props:
    filter_props.update(             # <-- mutates the shared schema dict in place
        {"source": "str", "licence": "str", "version": "str"},
    )
```

After the first strict-mode call for e.g. `protein`, its schema entry permanently contained `source`, `licence`, `version` in addition to the original `name`, `score`, `taxon`, `genes`. The `missing_props` loop then added all absent keys as `None` for every subsequent protein node:

```python
# missing_props now always includes source/licence/version
for k in missing_props:
    filtered_props[k] = None  # silently injected into non-strict output
```

## Fix

Copy `filter_props` before mutating it so the original schema dict is never modified:

```python
# After (fixed):
if self.strict_mode and filter_props:
    filter_props = dict(filter_props)  # copy to avoid mutating the shared schema dict
    filter_props.update(
        {"source": "str", "licence": "str", "version": "str"},
    )
```

## Regression test

`test_strict_mode_does_not_mutate_schema` runs immediately after `test_strict_mode_property_filter` (which triggers the strict-mode path). It verifies that:
- A subsequent non-strict `translate_nodes` call for the same type (`protein`) does **not** produce `source`, `licence`, or `version` in its output properties.

## Test plan

- [x] `test_strict_mode_property_filter` still passes (strict-mode output still contains required provenance keys)
- [x] `test_strict_mode_does_not_mutate_schema` passes (new regression test)
- [x] All 22 existing `test_translate.py` tests continue to pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH99gNPmQ4ikDD4PEBg5CU)_