### PR TITLE
fix(core): replace non-existent start_ontology() calls with _get_translator()

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -806,8 +806,8 @@ class BioCypher:
             str: The BioCypher equivalent of the term.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.translate_term(term)
 
@@ -832,8 +832,8 @@ class BioCypher:
             str: The original term.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.reverse_translate_term(term)
 
@@ -849,8 +849,8 @@ class BioCypher:
             str: The BioCypher equivalent of the query.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.translate(query)
 
@@ -866,7 +866,7 @@ class BioCypher:
             str: The original query.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.reverse_translate(query)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -170,3 +170,36 @@ def test_pandas_and_tabular_work_in_offline_mode(tmp_path):
         )
         assert bc._dbms == dbms
         assert bc._offline
+
+
+def test_translate_term_via_core(core):
+    """BioCypher.translate_term must lazily initialise the translator and return the mapped label."""
+    assert core._translator is None
+    result = core.translate_term("hgnc")
+    assert result == "Gene"
+    assert core._translator is not None
+
+
+def test_reverse_translate_term_via_core(core):
+    """BioCypher.reverse_translate_term must lazily initialise the translator and reverse-map the label."""
+    assert core._translator is None
+    result = core.reverse_translate_term("Gene")
+    assert result is not None
+    assert "hgnc" in result
+
+
+def test_translate_query_via_core(core):
+    """BioCypher.translate_query must lazily initialise the translator and translate Cypher labels."""
+    assert core._translator is None
+    query = "MATCH (n:hgnc) RETURN n"
+    result = core.translate_query(query)
+    assert "Gene" in result
+    assert "hgnc" not in result
+
+
+def test_reverse_translate_query_via_core(core):
+    """BioCypher.reverse_translate_query must lazily initialise the translator."""
+    assert core._translator is None
+    query = "MATCH (n:Protein)-[r:POST_TRANSLATIONAL_INTERACTION]->(m:Protein) RETURN n"
+    result = core.reverse_translate_query(query)
+    assert isinstance(result, str)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #353

`BioCypher.translate_term`, `reverse_translate_term`, `translate_query`, and `reverse_translate_query` all called `self.start_ontology()` to lazily initialise the translator, but `start_ontology()` was never defined on the class. Any call to these four public methods raised `AttributeError` at runtime.

## Root cause

```python
# Before (broken) — start_ontology() does not exist:
def translate_term(self, term: str) -> str:
    self.start_ontology()          # AttributeError: 'BioCypher' object has no attribute 'start_ontology'
    return self._translator.translate_term(term)
```

## Fix

Replace with the same lazy-init guard already used by `_add_nodes` and `_add_edges`:

```python
# After:
def translate_term(self, term: str) -> str:
    if not self._translator:
        self._get_translator()
    return self._translator.translate_term(term)
```

Applied identically to all four methods.

## Test plan

- [x] `test_translate_term_via_core` — calls `BioCypher.translate_term` with an uninitialised translator; verifies the translator is created lazily and the correct label is returned
- [x] `test_reverse_translate_term_via_core` — same for `reverse_translate_term`
- [x] `test_translate_query_via_core` — same for `translate_query`
- [x] `test_reverse_translate_query_via_core` — same for `reverse_translate_query`
- [x] All 17 existing `test_core.py` tests continue to pass

https://claude.ai/code/session_01VydRecYAwjGaB5FnAmGMq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01VydRecYAwjGaB5FnAmGMq7)_