### PR TITLE
fix(neo4j): replace dots with underscores in label names

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -1241,7 +1241,8 @@ def parse_label(label: str) -> str:
     """Check if the label is compliant with Neo4j naming conventions.
 
     Check against https://neo4j.com/docs/cypher-manual/current/syntax/naming/,
-    and if not compliant, remove non-compliant characters.
+    and if not compliant, remove non-compliant characters. Dots are replaced
+    with underscores to avoid the need for backtick escaping in Cypher queries.
 
     Args:
     ----
@@ -1250,9 +1251,11 @@ def parse_label(label: str) -> str:
         str: The compliant label
 
     """
-    # Check if the name contains only alphanumeric characters, underscore, or dollar sign
-    # and dot (for class hierarchy of BioCypher)
-    allowed_chars = r"a-zA-Z0-9_$ ."
+    # Replace dots with underscores to avoid backtick-escaping requirements in Neo4j
+    label = label.replace(".", "_")
+
+    # Check if the name contains only alphanumeric characters, underscore, dollar sign, or space
+    allowed_chars = r"a-zA-Z0-9_$ "
     matches = re.findall(f"[{allowed_chars}]", label)
     non_matches = re.findall(f"[^{allowed_chars}]", label)
     if non_matches:

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -385,7 +385,7 @@ def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, 
 
     expected_file_names = [
         "PatientPerson-part000.csv",
-        "$He524lloWor.Ld-part000.csv",
+        "$He524lloWor_ld-part000.csv",
     ]
     for file_name in os.listdir(tmp_path):
         assert file_name in expected_file_names
@@ -1278,11 +1278,11 @@ def test_check_label_name():
     # Test case 4: label starts with a non-alphanumeric character
     assert parse_label("@Invalid_Label") == "Invalid_Label"
 
-    # Additional test case: label with dot (for class hierarchy of BioCypher)
-    assert parse_label("valid.label") == "valid.label"
+    # Dots are replaced with underscores to avoid backtick-escaping in Cypher queries
+    assert parse_label("valid.label") == "valid_label"
 
-    # Additional test case: label with dot and non-compliant characters
-    assert parse_label("In.valid.Label@1") == "In.valid.Label1"
+    # Dots replaced before other characters are stripped
+    assert parse_label("In.valid.Label@1") == "In_valid_Label1"
 
     # Test case: label contains only non-compliant characters (would previously crash with IndexError)
     assert parse_label("@#^&") == ""


### PR DESCRIPTION
## Summary

Closes #312

Labels containing dots — e.g. `KEGG.pathway` or `ncbi.genome` from Bioregistry identifiers — are valid in ontologies and schema configs, but Neo4j requires backtick-escaping to use them in Cypher queries:

```cypher
MATCH (n:`KEGG.Pathway`) ...  -- must be backtick-escaped
```

This makes ad-hoc queries against the graph less ergonomic. The fix is to replace `.` with `_` in `parse_label()`, producing clean labels that need no escaping:

```cypher
MATCH (n:KEGG_Pathway) ...    -- no escaping needed
```

## Root cause

`parse_label()` in `_batch_writer.py` explicitly allowed dots in the character set (`allowed_chars = r"a-zA-Z0-9_$ ."`), preserving them in Neo4j node and relationship labels. The comment even called this out as intentional ("for class hierarchy of BioCypher"), but the resulting labels require backtick-escaping in every Cypher query.

## Fix

One line added before the existing character-filter regex:

```python
# Before
allowed_chars = r"a-zA-Z0-9_$ ."

# After
label = label.replace(".", "_")   # ← convert dot to underscore first
allowed_chars = r"a-zA-Z0-9_$ "   # ← dot no longer in allowed set
```

This only affects the Neo4j output path (`_batch_writer.py` and `_neo4j.py`). Other writers (RDF, ArangoDB, PostgreSQL, OWL) do not call `parse_label()` and are unaffected.

`name_sentence_to_pascal()` in `_translate.py` retains its dot-splitting logic for non-Neo4j backends where dotted labels may still appear.

## Test plan

- [x] `test_check_label_name` — `parse_label("valid.label")` now returns `"valid_label"` (was `"valid.label"`)
- [x] `test_write_node_data_from_list_not_compliant_names` — expected output file updated from `$He524lloWor.Ld-part000.csv` to `$He524lloWor_ld-part000.csv`
- [x] All 44 existing `test_neo4j.py` tests pass
- [x] Full suite: 331 passed, 35 skipped (external services), 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmpWRvkCe95Taz3MnfMnsG)_