### PR TITLE
fix(batch_writer): route scalar string quoting through _quote_string()

### DIFF
--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1476,3 +1476,53 @@ def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator
     assert not any(
         "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
     ), f"node_labels_order appeared in edge fallback log: {messages}"
+
+
+def test_quote_escaped_in_node_string_property(bw):
+    """String properties containing the quote character must be escaped by doubling it."""
+    nodes = [
+        BioCypherNode(
+            node_id="n1",
+            node_label="protein",
+            properties={
+                "score": 1.0,
+                "name": "O'Brien",
+                "taxon": 9606,
+                "genes": ["gene1"],
+            },
+        ),
+    ]
+
+    passed = bw._write_node_data(nodes, batch_size=int(1e4))
+
+    csv_path = os.path.join(bw.outdir, "Protein-part000.csv")
+    with open(csv_path) as f:
+        content = f.read()
+
+    assert passed
+    assert "'O''Brien'" in content, f"Escaped quote not found in: {content!r}"
+    assert "'O'Brien'" not in content.replace("'O''Brien'", ""), (
+        "Unescaped quote found in output — _quote_string not called for node properties"
+    )
+
+
+def test_quote_escaped_in_edge_string_property(bw):
+    """String properties containing the quote character must be escaped in edge output."""
+    edges = [
+        BioCypherEdge(
+            relationship_id="e1",
+            source_id="p1",
+            target_id="p2",
+            relationship_label="PERTURBED_IN_DISEASE",
+            properties={"residue": "T'253"},
+        ),
+    ]
+
+    passed = bw._write_edge_data(edges, batch_size=int(1e4))
+
+    csv_path = os.path.join(bw.outdir, "PERTURBED_IN_DISEASE-part000.csv")
+    with open(csv_path) as f:
+        content = f.read()
+
+    assert passed
+    assert "'T''253'" in content, f"Escaped quote not found in: {content!r}"


### PR DESCRIPTION
## Summary

Scalar string properties in node and edge CSV output were written with bare quote interpolation, bypassing the subclass `_quote_string()` method. This meant a property value containing the quote character (e.g. `O'Brien`) was emitted unescaped (`'O'Brien'`) instead of the doubled-quote form required by Neo4j admin-import (`'O''Brien'`).

Relates to #343.

## Root cause

```python
# _write_node_data (before) — bypasses _quote_string():
plist.append(f"{self.quote}{p!s}{self.quote}")

# _write_edge_data (before) — bypasses _quote_string():
plist.append(self.quote + str(p) + self.quote)
```

Array values were already correctly routed through `_write_array_string()` → `_quote_string()`, so scalar strings were inconsistently handled: an array `["O'Brien"]` was escaped correctly, while a scalar `"O'Brien"` was not.

## Fix

```python
# _write_node_data and _write_edge_data (after):
plist.append(self._quote_string(str(p)))
```

`_quote_string()` is already an abstract method on `_BatchWriter` and overridden by each database-specific writer:
- `_Neo4jBatchWriter`: doubles the quote char (`O'Brien` → `'O''Brien'`)
- `_PostgreSQLBatchWriter`: wraps in quotes (behaviour unchanged)
- `_RDFWriter`: returns the value unchanged (behaviour unchanged)

## Test plan

- [x] `test_quote_escaped_in_node_string_property` — a node with `name="O'Brien"` produces `'O''Brien'` in the CSV (was `'O'Brien'` before the fix)
- [x] `test_quote_escaped_in_edge_string_property` — an edge with `residue="T'253"` produces `'T''253'` in the CSV
- [x] All 46 existing `test_neo4j.py` tests continue to pass

https://claude.ai/code/session_01Fj5vBpA54rHzXYDApWCX6t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj5vBpA54rHzXYDApWCX6t)_