### PR TITLE
fix(core): fix tuple error message, dead code, and bitwise op in get_kg()

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -165,8 +165,6 @@ class BioCypher:
         self._writer = None
         self._driver = None
         self._in_memory_kg = None
-
-        self._in_memory_kg = None
         self._nodes = None
         self._edges = None
 
@@ -450,7 +448,7 @@ class BioCypher:
 
     def _is_online_and_in_memory(self) -> bool:
         """Return True if in online mode and in-memory dbms is used."""
-        return (not self._offline) & (self._dbms in IN_MEMORY_DBMS)
+        return (not self._offline) and (self._dbms in IN_MEMORY_DBMS)
 
     def write_nodes(
         self,
@@ -555,14 +553,11 @@ class BioCypher:
         dataframes or a NetworkX DiGraph.
         """
         if not self._is_online_and_in_memory():
-            msg = (f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}.",)
+            msg = f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}."
             raise ValueError(msg)
         if not self._in_memory_kg:
             msg = "No in-memory KG instance found. Please call `add()` first."
             raise ValueError(msg)
-
-        if not self._in_memory_kg:
-            self._initialize_in_memory_kg()
         return self._in_memory_kg.get_kg()
 
     # DOWNLOAD AND CACHE MANAGEMENT METHODS ###

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -96,6 +96,7 @@ def test_in_memory_kg_only_in_online_mode(core):
         with pytest.raises(ValueError) as e:
             core.get_kg()
         assert "Getting the in-memory KG is only available in online mode for " in str(e.value)
+        assert isinstance(e.value.args[0], str), "error message must be a str, not a tuple"
 
 
 def test_no_in_memory_kg_for_dbms(core):


### PR DESCRIPTION
## Summary

Four related defects in `BioCypher._core`, all in or near `get_kg()`:

### 1. Tuple error message (`get_kg`, line ~558)

`get_kg()` raised `ValueError` with a one-element tuple instead of a string because of a trailing comma:

```python
# Before (broken) — trailing comma makes msg a tuple:
msg = (f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}.",)
raise ValueError(msg)   # args[0] is a tuple, not a string
```

`str(e.value)` then returned `"('…',)"`, breaking any caller that inspects `e.args[0]` expecting a string (and identical in pattern to the bug fixed in #551 for `_translate.py`).

```python
# After (fixed):
msg = f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}."
raise ValueError(msg)
```

### 2. Dead / unreachable code (`get_kg`, lines ~564-565)

After the `raise ValueError` guard for `not self._in_memory_kg`, two lines immediately below checked the same condition again and called `_initialize_in_memory_kg()`. That branch could never be reached — if `_in_memory_kg` is falsy, the raise already fired.

```python
# Removed:
if not self._in_memory_kg:          # always False here
    self._initialize_in_memory_kg()
```

### 3. Bitwise `&` instead of logical `and` (`_is_online_and_in_memory`, line ~453)

```python
# Before:
return (not self._offline) & (self._dbms in IN_MEMORY_DBMS)

# After:
return (not self._offline) and (self._dbms in IN_MEMORY_DBMS)
```

For bool operands the result is identical, but `&` suppresses short-circuit evaluation and is semantically wrong.

### 4. Duplicate `self._in_memory_kg = None` in `__init__` (lines ~167/169)

The same attribute was unconditionally assigned `None` twice on consecutive lines. Duplicate removed.

## Test plan

- [x] `test_in_memory_kg_only_in_online_mode` — extended with `assert isinstance(e.value.args[0], str)` to catch the tuple regression. Would have **failed** on the old code, **passes** on the fix.
- [x] `test_no_in_memory_kg_for_dbms` — still passes.
- [x] `test_no_in_memory_instance_found` — still passes.
- [x] All 13 existing `test_core.py` tests continue to pass.

https://claude.ai/code/session_01LV36mSkEERL7RASe8DGJFP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LV36mSkEERL7RASe8DGJFP)_