### PR TITLE
fix(core): add_nodes/add_edges crash on first call when _nodes/_edges is None

### DIFF
--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -191,9 +191,9 @@ class BioCypher:
 
         """
         if isinstance(nodes, list):
-            self._nodes = list(itertools.chain(self._nodes, nodes))
+            self._nodes = list(itertools.chain(self._nodes or [], nodes))
         else:
-            self._nodes = itertools.chain(self._nodes, nodes)
+            self._nodes = itertools.chain(self._nodes or iter([]), nodes)
 
     def add_edges(self, edges) -> None:
         """Add new edges to the internal representation.
@@ -207,9 +207,9 @@ class BioCypher:
 
         """
         if isinstance(edges, list):
-            self._edges = list(itertools.chain(self._edges, edges))
+            self._edges = list(itertools.chain(self._edges or [], edges))
         else:
-            self._edges = itertools.chain(self._edges, edges)
+            self._edges = itertools.chain(self._edges or iter([]), edges)
 
     def to_df(self):
         """Create DataFrame using internal representation.
@@ -246,8 +246,7 @@ class BioCypher:
         if not self._translator:
             self._get_translator()
 
-        # These attributes might not exist when using in-memory KG directly
-        if hasattr(self, "_nodes") and hasattr(self, "_edges"):
+        if self._nodes is not None and self._edges is not None:
             tnodes = self._translator.translate_entities(self._nodes)
             tedges = self._translator.translate_entities(self._edges)
             self._in_memory_kg.add_nodes(tnodes)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -204,3 +204,29 @@ def test_reverse_translate_query_via_core(core):
     query = "MATCH (n:Protein)-[r:POST_TRANSLATIONAL_INTERACTION]->(m:Protein) RETURN n"
     result = core.reverse_translate_query(query)
     assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_nodes_first_call_does_not_crash(core, _get_nodes):
+    """add_nodes must not crash when self._nodes is still None (first call)."""
+    # self._nodes starts as None; passing a list used to raise
+    # TypeError: 'NoneType' object is not iterable via itertools.chain
+    core.add_nodes(_get_nodes)
+    assert core._nodes == _get_nodes
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_nodes_accumulates_across_calls(core, _get_nodes):
+    """Successive add_nodes calls must append, not crash on the second call."""
+    first_half = _get_nodes[:4]
+    second_half = _get_nodes[4:]
+    core.add_nodes(first_half)
+    core.add_nodes(second_half)
+    assert len(core._nodes) == len(first_half) + len(second_half)
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_edges_first_call_does_not_crash(core, _get_edges):
+    """add_edges must not crash when self._edges is still None (first call)."""
+    core.add_edges(_get_edges)
+    assert core._edges == _get_edges


### PR DESCRIPTION
## Summary

`BioCypher.add_nodes()` and `add_edges()` crashed with `TypeError: 'NoneType' object is not iterable` on every first call because `self._nodes` and `self._edges` are initialised to `None` in `__init__`, and `itertools.chain(None, iterable)` raises when consumed.

### Root cause

```python
# __init__
self._nodes = None   # ← starts as None
self._edges = None

# add_nodes (broken)
if isinstance(nodes, list):
    self._nodes = list(itertools.chain(self._nodes, nodes))
    #                              ^^^^^^^^^^^^ None is not iterable → TypeError
```

`itertools.chain` is lazy so the chain object itself is created without error, but `list()` immediately consumes it, hitting `None` as the first iterable and raising `TypeError`.

The same crash applies to the generator branch (non-list input): the chain is created silently but raises when eventually consumed by `_to_KG`.

### Fix

Use `self._nodes or []` / `self._edges or iter([])` so the initial `None` is replaced with an empty iterable before chaining:

```python
# add_nodes (fixed)
if isinstance(nodes, list):
    self._nodes = list(itertools.chain(self._nodes or [], nodes))
else:
    self._nodes = itertools.chain(self._nodes or iter([]), nodes)
```

Also replace the stale `hasattr(self, "_nodes")` guard in `_to_KG()` with an explicit `is not None` check. The attributes are always set by `__init__`, so `hasattr` is always `True`; the intent of the guard is to skip translation when no data has been accumulated via `add_nodes`/`add_edges`.

```python
# Before (always True, misleading comment)
if hasattr(self, "_nodes") and hasattr(self, "_edges"):

# After (reflects actual intent)
if self._nodes is not None and self._edges is not None:
```

## Test plan

- [x] `test_add_nodes_first_call_does_not_crash` — calls `add_nodes([...])` on a fresh `BioCypher` instance; would have raised `TypeError` on the old code, passes on the fix
- [x] `test_add_nodes_accumulates_across_calls` — calls `add_nodes` twice and checks total length; exercises the second-call path
- [x] `test_add_edges_first_call_does_not_crash` — same as above for edges
- [x] All 13 existing `test_core.py` tests continue to pass (16 total)

https://claude.ai/code/session_01NRdocXp3dHgubn7AKrHqU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRdocXp3dHgubn7AKrHqU2)_