### PR TITLE
feat(write): split nodes with varying property sets into separate header groups

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -310,6 +310,14 @@ class _BatchWriter(_Writer, ABC):
 
         self.parts = {}  # dict to store the paths of part files for each label
 
+        # map of node label -> {property signature: group key}. Nodes of a
+        # label that present different property sets (e.g. schemaless input
+        # with optional properties) are split into separate output groups so
+        # that each part file conforms to its own header. The first signature
+        # encountered keeps the plain label as its group key (i.e. legacy file
+        # names and import call); further signatures get a suffixed key.
+        self._node_property_groups = defaultdict(dict)
+
         self._labels_orders = ["Alphabetical", "Ascending", "Descending", "Leaves", "None"]
         self.labels_order = labels_order
         self.node_labels_order = node_labels_order
@@ -554,6 +562,93 @@ class _BatchWriter(_Writer, ABC):
 
         return all_labels
 
+    def _get_node_property_types(self, node, label: str) -> dict:
+        """Determine the property names and types of a single node.
+
+        Properties are taken from the schema configuration if the label is
+        configured, otherwise they are inferred from the node itself
+        (schemaless input). The returned dict maps property name to a type
+        string and is used both to build the CSV header and to assign the node
+        to a property-signature group.
+
+        Args:
+        ----
+            node: the BioCypherNode to inspect
+
+            label (str): the primary (ontology) label of the node
+
+        Returns:
+        -------
+            dict: property name -> type string
+
+        """
+        # get properties from config if present
+        if label in self.translator.ontology.mapping.extended_schema:
+            cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
+                "properties",
+            )
+        else:
+            cprops = None
+
+        if cprops:
+            d = dict(cprops)
+
+            # add id and preferred id to properties; these are
+            # created in node creation (`_create.BioCypherNode`)
+            d["id"] = "str"
+            d["preferred_id"] = "str"
+
+            # add strict mode properties
+            if self.strict_mode:
+                d["source"] = "str"
+                d["version"] = "str"
+                d["licence"] = "str"
+
+        else:
+            d = dict(node.get_properties())
+            # encode property type
+            for k, v in d.items():
+                if v is not None:
+                    if isinstance(v, list):
+                        elem_type = type(v[0]).__name__ if v else "str"
+                        d[k] = f"{elem_type}[]"
+                    else:
+                        d[k] = type(v).__name__
+
+        return d
+
+    def _get_node_group_key(self, label: str, prop_dict: dict) -> str:
+        """Assign a node to an output group based on its property signature.
+
+        Nodes that share the same set of properties and types are written to
+        the same group (header + part files + import call entry). The first
+        signature seen for a label keeps the plain label as its key, so the
+        common case (schema-configured or homogeneous data) is unchanged and
+        produces the same single header as before. Additional signatures get a
+        distinct, file-name-safe suffix.
+
+        Args:
+        ----
+            label (str): the primary (ontology) label of the node
+
+            prop_dict (dict): property name -> type string for the node
+
+        Returns:
+        -------
+            str: the group key to use for buffering, file naming and headers
+
+        """
+        # order-invariant, type-aware signature
+        signature = tuple(sorted(prop_dict.items()))
+        groups = self._node_property_groups[label]
+
+        if signature not in groups:
+            # first signature keeps the legacy label (and thus legacy file
+            # names); subsequent signatures are suffixed
+            groups[signature] = label if not groups else f"{label} group{len(groups)}"
+
+        return groups[signature]
+
     def _write_node_data(self, nodes, batch_size, force: bool = False):
         """Write biocypher nodes to CSV.
 
@@ -642,71 +737,41 @@ class _BatchWriter(_Writer, ABC):
                 logger.warning(f"Node {label} has no id; skipping.")
                 return True
 
-            if label not in bins:
-                # start new list
-                bins[label].append(node)
-                bin_l[label] = 1
+            # determine the node's property types and route it to the output
+            # group for its property signature. Schema-configured or otherwise
+            # homogeneous data yields a single group per label (identical to
+            # the previous behaviour); schemaless data with varying property
+            # sets is split into one group per distinct set, so each part file
+            # conforms to its own header instead of raising a mismatch error.
+            d = self._get_node_property_types(node, label)
+            gkey = self._get_node_group_key(label, d)
 
-                # get properties from config if present
-                if label in self.translator.ontology.mapping.extended_schema:
-                    cprops = self.translator.ontology.mapping.extended_schema.get(label).get(
-                        "properties",
-                    )
-                else:
-                    cprops = None
-                if cprops:
-                    d = dict(cprops)
+            if gkey not in bins:
+                # start new list for this group
+                bins[gkey].append(node)
+                bin_l[gkey] = 1
 
-                    # add id and preferred id to properties; these are
-                    # created in node creation (`_create.BioCypherNode`)
-                    d["id"] = "str"
-                    d["preferred_id"] = "str"
-
-                    # add strict mode properties
-                    if self.strict_mode:
-                        d["source"] = "str"
-                        d["version"] = "str"
-                        d["licence"] = "str"
-
-                else:
-                    d = dict(node.get_properties())
-                    # encode property type
-                    for k, v in d.items():
-                        if v is not None:
-                            if isinstance(v, list):
-                                elem_type = type(v[0]).__name__ if v else "str"
-                                d[k] = f"{elem_type}[]"
-                            else:
-                                d[k] = type(v).__name__
-                # else use first encountered node to define properties for
-                # checking; could later be by checking all nodes but much
-                # more complicated, particularly involving batch writing
-                # (would require "do-overs"). for now, we output a warning
-                # if node properties diverge from reference properties (in
-                # write_single_node_list_to_file) TODO if it occurs, ask
-                # user to select desired properties and restart the process
-
-                reference_props[label] = d
-                labels[label] = self._get_all_labels(label, self.node_labels_order, force)
+                reference_props[gkey] = d
+                labels[gkey] = self._get_all_labels(label, self.node_labels_order, force)
 
             else:
                 # add to list
-                bins[label].append(node)
-                bin_l[label] += 1
-                if not bin_l[label] < batch_size:
+                bins[gkey].append(node)
+                bin_l[gkey] += 1
+                if not bin_l[gkey] < batch_size:
                     # batch size controlled here
                     passed = self._write_single_node_list_to_file(
-                        bins[label],
-                        label,
-                        reference_props[label],
-                        labels[label],
+                        bins[gkey],
+                        gkey,
+                        reference_props[gkey],
+                        labels[gkey],
                     )
 
                     if not passed:
                         return False
 
-                    bins[label] = []
-                    bin_l[label] = 0
+                    bins[gkey] = []
+                    bin_l[gkey] = 0
 
             return True
 
@@ -715,26 +780,23 @@ class _BatchWriter(_Writer, ABC):
             if empty:
                 return True
 
-            # after generator depleted, write remainder of bins
-            for label, nl in bins.items():
+            # after generator depleted, write remainder of bins (keyed by
+            # property-signature group, see consume())
+            for gkey, nl in bins.items():
                 passed = self._write_single_node_list_to_file(
                     nl,
-                    label,
-                    reference_props[label],
-                    labels[label],
+                    gkey,
+                    reference_props[gkey],
+                    labels[gkey],
                 )
 
                 if not passed:
                     return False
 
-            # use complete bin list to write header files
-            # TODO if a node type has varying properties
-            # (ie missingness), we'd need to collect all possible
-            # properties in the generator pass
-
-            # save config or first-node properties to instance attribute
-            for label in reference_props:
-                self.node_property_dict[label] = reference_props[label]
+            # one header per group; groups with varying property sets were
+            # already separated in consume(), so each header matches its parts
+            for gkey in reference_props:
+                self.node_property_dict[gkey] = reference_props[gkey]
 
             return True
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -617,6 +617,40 @@ class _BatchWriter(_Writer, ABC):
 
         return d
 
+    def _existing_header_property_names(self, group_key: str) -> set | None:
+        """Read the property names of a group's header file already on disk.
+
+        Used to reconcile against output written by a previous writer instance
+        pointing at the same directory (e.g. a schema change applied by
+        re-instantiating BioCypher for the next batch, which produces a fresh
+        writer with empty in-memory group state). Returns the set of property
+        column names, or ``None`` if no header file exists for the group.
+
+        Args:
+        ----
+            group_key (str): the group key whose header file to inspect
+
+        Returns:
+        -------
+            set | None: property column names, or None if no header exists
+
+        """
+        pascal = self.translator.name_sentence_to_pascal(parse_label(group_key))
+        header_path = os.path.join(self.outdir, f"{pascal}-header.csv")
+
+        if not os.path.exists(header_path):
+            return None
+
+        with open(header_path, encoding="utf-8") as f:
+            first_line = f.readline().strip()
+
+        # tokens look like ":ID", "name", "score:double", ":LABEL"; the
+        # property name is the part before the (optional) ":type" suffix, and
+        # the ":ID"/":LABEL" sentinels have an empty name and are dropped
+        names = {token.split(":")[0] for token in first_line.split(self.delim)}
+        names.discard("")
+        return names
+
     def _get_node_group_key(self, label: str, prop_dict: dict) -> str:
         """Assign a node to an output group based on its property signature.
 
@@ -626,6 +660,14 @@ class _BatchWriter(_Writer, ABC):
         common case (schema-configured or homogeneous data) is unchanged and
         produces the same single header as before. Additional signatures get a
         distinct, file-name-safe suffix.
+
+        Candidate group keys are also checked against header files already on
+        disk: if the plain label (or a suffixed key) is already occupied by a
+        different property set written by a previous writer instance, the next
+        free key is used instead. This prevents a schema change applied between
+        batches -- which builds a new writer with empty in-memory state -- from
+        overwriting a prior batch's header and leaving it inconsistent with its
+        part files.
 
         Args:
         ----
@@ -642,12 +684,26 @@ class _BatchWriter(_Writer, ABC):
         signature = tuple(sorted(prop_dict.items()))
         groups = self._node_property_groups[label]
 
-        if signature not in groups:
-            # first signature keeps the legacy label (and thus legacy file
-            # names); subsequent signatures are suffixed
-            groups[signature] = label if not groups else f"{label} group{len(groups)}"
+        if signature in groups:
+            return groups[signature]
 
-        return groups[signature]
+        # find the first candidate key that is neither claimed in-memory for a
+        # different signature nor occupied on disk by a different property set.
+        # Cross-instance reconciliation is by property-name set only (types are
+        # not fully recoverable from a header file); a same-columns/different-
+        # types change reuses the group and overwrites its header.
+        prop_names = set(prop_dict.keys())
+        index = 0
+        while True:
+            candidate = label if index == 0 else f"{label} group{index}"
+            if candidate not in groups.values():
+                existing = self._existing_header_property_names(candidate)
+                if existing is None or existing == prop_names:
+                    break
+            index += 1
+
+        groups[signature] = candidate
+        return candidate
 
     def _write_node_data(self, nodes, batch_size, force: bool = False):
         """Write biocypher nodes to CSV.

--- a/docs/learn/tutorials/tutorial001_basics.md
+++ b/docs/learn/tutorials/tutorial001_basics.md
@@ -368,11 +368,15 @@ Thus, it is often desirable to filter out properties that are not needed to
 save time, disk space, and memory.
 
 !!! note "Note"
-	Maintaining consistent properties per entity type is particularly important
-	when using the admin import feature of Neo4j, which requires consistency
-	between the header and data files. Properties that are introduced into only
-	some of the rows will lead to column misalignment and import failure. In
-	"online mode", this is not an issue.
+	Maintaining consistent properties per entity type is important for a clean,
+	single-file-per-type import. When you designate properties in the schema
+	configuration, BioCypher enforces them: every node of that type gets the same
+	columns (missing values are filled with `None`), producing one header and one
+	set of part files. For labels that are **not** configured in the schema,
+	properties are inferred per node; if different nodes carry different property
+	sets, BioCypher routes each distinct set to its own header/part group (see
+	[Varying property sets](#varying-property-sets)) rather than misaligning one
+	shared header. In "online mode", this is not a concern.
 
 We will take a look at how to handle property selection in BioCypher in a
 way that is flexible and easy to maintain.
@@ -477,6 +481,37 @@ parent class) or replaced by the parent class properties (if they are present).
 	We now create three separate data files, all of which are children of the
 	`protein` class; two implicit children (`uniprot.protein` and `entrez.protein`)
 	and one explicit child (`protein isoform`).
+
+### Varying property sets
+
+Designating properties in the schema is the recommended way to keep an entity
+type consistent. When a label is **not** configured in the schema, BioCypher
+cannot enforce a fixed column set, so it infers the properties (names and types)
+from each node. If all nodes of that label carry the same properties, the result
+is a single header and part file, exactly as before.
+
+If different nodes of the same label carry different property sets, BioCypher no
+longer misaligns a single shared header. Instead it groups nodes by their
+property signature and writes one header/part group per signature. The first
+signature encountered keeps the plain label file names (e.g.
+`Protein-header.csv`, `Protein-part000.csv`); each further signature gets a
+suffixed group (`ProteinGroup1-header.csv`, `ProteinGroup1-part000.csv`, and so
+on). All groups for the label are referenced in the import call, so the import
+still succeeds and each part file matches its own header. Property order does not
+matter (the signature is order-invariant), but a difference in property *types*
+(e.g. an integer `age` in one node and a string `age` in another) does open a
+separate group, because the resulting CSV headers differ.
+
+This also holds across batches. Because a schema change is applied by
+re-instantiating BioCypher (the schema is bound at construction), a second batch
+runs with a fresh writer. When that writer's output directory already contains
+headers from an earlier batch, it reconciles against them: a batch whose property
+set matches an existing header appends to that group, while a batch with a
+changed property set opens a new group instead of overwriting the earlier
+header. Cross-batch reconciliation compares property *names* only, so a batch
+that keeps the same columns but changes a property's type will reuse the existing
+group and overwrite its header; if you need that distinction preserved, write the
+batches to separate output directories.
 
 ## Section 4: Handling relationships
 

--- a/docs/reference/outputs/neo4j-output.md
+++ b/docs/reference/outputs/neo4j-output.md
@@ -120,7 +120,11 @@ Data input from the source database is exactly as in the case of interacting
 with a running database, with the data representation being converted to a
 series of CSV files in a designated output folder (standard being
 `biocypher-out/` and the current datetime).  BioCypher creates separate header
-and data files for all node and edge types to be represented in the graph.
+and data files for all node and edge types to be represented in the graph. A
+single type whose nodes carry varying property sets (for labels not fixed by the
+schema configuration) may be split into more than one header/part group, each
+named after the type with a numeric suffix (e.g. `ProteinGroup1`); see
+[Varying property sets](../../learn/tutorials/tutorial001_basics.md#varying-property-sets).
 Additionally, it creates a file called `neo4j-admin-import-call.sh`
 containing the console command for creating a new database, which only has to be
 executed from the directory of the currently running Neo4j database.

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -370,6 +370,271 @@ def test_write_node_data_non_string_list_properties(bw):
     )
 
 
+def test_write_node_data_varying_properties_splits_groups(bw):
+    """Patients of one label with different property sets are split into
+    separate header/part groups, so each part file conforms to its own header
+    instead of raising a mismatch error (schemaless / optional-property input).
+
+    The first property signature keeps the legacy (label-named) files; further
+    signatures get a distinct, file-name-safe suffix. Both groups are referenced
+    in the import call for the same label.
+    """
+    patients = [
+        # signature A: {name} -- Alice and Bob have no diagnosis recorded
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob"}),
+        # signature B: {name, diagnosis} -- Carol does
+        BioCypherNode("p3", "patient", properties={"name": "Carol", "diagnosis": "diabetes"}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+    call = bw.get_import_call()
+
+    # group 0 keeps the legacy names; group 1 gets a suffixed name
+    g0_header = os.path.join(bw.outdir, "Patient-header.csv")
+    g0_part = os.path.join(bw.outdir, "Patient-part000.csv")
+    g1_header = os.path.join(bw.outdir, "PatientGroup1-header.csv")
+    g1_part = os.path.join(bw.outdir, "PatientGroup1-part000.csv")
+
+    for p in (g0_header, g0_part, g1_header, g1_part):
+        assert os.path.isfile(p), f"missing expected output file {p}"
+
+    g0_header_txt = open(g0_header).read()
+    g1_header_txt = open(g1_header).read()
+
+    # only the second signature carries 'diagnosis'
+    assert "diagnosis" not in g0_header_txt
+    assert "diagnosis" in g1_header_txt
+
+    # each part file has the same number of columns as its header
+    def n_cols(path):
+        return len(open(path).readline().rstrip("\n").split(";"))
+
+    assert n_cols(g0_part) == n_cols(g0_header)
+    assert n_cols(g1_part) == n_cols(g1_header)
+
+    # patients are routed to the group matching their property set
+    assert "Carol" in open(g1_part).read()
+    g0_part_txt = open(g0_part).read()
+    assert "Alice" in g0_part_txt
+    assert "Bob" in g0_part_txt
+
+    # the import call references both groups for the same label
+    assert "Patient-header.csv" in call
+    assert "PatientGroup1-header.csv" in call
+
+
+def test_write_node_data_homogeneous_properties_single_group(bw):
+    """Homogeneous input (the common case) must still produce exactly one group
+    with the legacy file names — no behavioural change without divergence."""
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob"}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert os.path.isfile(os.path.join(bw.outdir, "Patient-header.csv"))
+    # no suffixed group files were created
+    suffixed = [f for f in os.listdir(bw.outdir) if f.startswith("PatientGroup")]
+    assert suffixed == []
+
+
+def _headers(outdir):
+    return sorted(f for f in os.listdir(outdir) if f.endswith("-header.csv"))
+
+
+def _parts(outdir, prefix):
+    return sorted(f for f in os.listdir(outdir) if f.startswith(f"{prefix}-part"))
+
+
+def test_write_node_data_reappearing_signature_single_call(bw):
+    """Within one write call: schema 1, schema 2, then schema 1 again.
+
+    The reappearing first signature must be routed back to its existing group,
+    not opened as a third one. Two groups total; both schema-1 patients share
+    the legacy group's single part file.
+    """
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),  # schema 1
+        BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"}),  # schema 2
+        BioCypherNode("p3", "patient", properties={"name": "Carol"}),  # schema 1 again
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    # exactly two groups, not three
+    assert _headers(bw.outdir) == ["Patient-header.csv", "PatientGroup1-header.csv"]
+    assert _parts(bw.outdir, "Patient") == ["Patient-part000.csv"]
+    assert _parts(bw.outdir, "PatientGroup1") == ["PatientGroup1-part000.csv"]
+
+    g0 = open(os.path.join(bw.outdir, "Patient-part000.csv")).read()
+    # Alice and Carol (both schema 1) share the legacy group; Bob does not
+    assert "Alice" in g0 and "Carol" in g0
+    assert "Bob" not in g0
+    assert "Bob" in open(os.path.join(bw.outdir, "PatientGroup1-part000.csv")).read()
+
+
+def test_write_node_data_reappearing_signature_across_calls(bw):
+    """Across separate write calls: schema 1, schema 2, then schema 1 again.
+
+    The signature -> group mapping persists on the writer, so the third call
+    reuses the first group and appends a new part file (part001) rather than
+    overwriting part000 or creating a new group. The import-call glob
+    (``Patient-part.*``) therefore picks up both parts.
+    """
+    assert bw._write_node_data(
+        [BioCypherNode("p1", "patient", properties={"name": "Alice"})],
+        batch_size=int(1e4),
+        force=True,
+    )
+    assert bw._write_node_data(
+        [BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"})],
+        batch_size=int(1e4),
+        force=True,
+    )
+    assert bw._write_node_data(
+        [BioCypherNode("p3", "patient", properties={"name": "Carol"})],
+        batch_size=int(1e4),
+        force=True,
+    )
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == ["Patient-header.csv", "PatientGroup1-header.csv"]
+    # schema-1 group gained a second part file for the reappearing signature
+    assert _parts(bw.outdir, "Patient") == ["Patient-part000.csv", "Patient-part001.csv"]
+    assert _parts(bw.outdir, "PatientGroup1") == ["PatientGroup1-part000.csv"]
+
+    assert "Alice" in open(os.path.join(bw.outdir, "Patient-part000.csv")).read()
+    assert "Carol" in open(os.path.join(bw.outdir, "Patient-part001.csv")).read()
+
+
+def test_write_node_data_property_order_invariant_grouping(bw):
+    """Two patients with the same properties in different insertion order must
+    share a single group (the signature is order-invariant)."""
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice", "diagnosis": "flu"}),
+        BioCypherNode("p2", "patient", properties={"diagnosis": "cold", "name": "Bob"}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == ["Patient-header.csv"]
+
+
+def test_write_node_data_property_type_differences_split_groups(bw):
+    """Patients with the same property *names* but different value *types* are
+    split into separate groups, because their CSV headers differ (e.g.
+    ``age:long`` vs an untyped string ``age``)."""
+    patients = [
+        BioCypherNode("p1", "patient", properties={"age": 42}),  # int -> age:long
+        BioCypherNode("p2", "patient", properties={"age": "forty"}),  # str -> age
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == ["Patient-header.csv", "PatientGroup1-header.csv"]
+    g0 = open(os.path.join(bw.outdir, "Patient-header.csv")).read()
+    g1 = open(os.path.join(bw.outdir, "PatientGroup1-header.csv")).read()
+    assert "age:long" in g0
+    assert "age:long" not in g1
+
+
+def test_write_node_data_multiple_signatures_get_incrementing_groups(bw):
+    """Three distinct signatures produce the legacy group plus two suffixed
+    groups with incrementing indices."""
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"}),
+        BioCypherNode("p3", "patient", properties={"name": "Carol", "age": 30}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == [
+        "Patient-header.csv",
+        "PatientGroup1-header.csv",
+        "PatientGroup2-header.csv",
+    ]
+
+
+def test_write_node_data_grouping_independent_across_labels(bw):
+    """Signature grouping is per label; divergence in one label does not affect
+    another, and the suffixed file names do not collide."""
+    nodes = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"}),
+        BioCypherNode("s1", "sample", properties={"tissue": "liver"}),
+        BioCypherNode("s2", "sample", properties={"tissue": "blood", "quality": 0.9}),
+    ]
+
+    assert bw._write_node_data(nodes, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == [
+        "Patient-header.csv",
+        "PatientGroup1-header.csv",
+        "Sample-header.csv",
+        "SampleGroup1-header.csv",
+    ]
+
+
+def test_write_node_data_group_uses_real_label_not_group_key(bw):
+    """The internal group key must never leak into the data: every node keeps
+    the real ``:LABEL`` (``Patient``) regardless of which group it was written
+    to. Otherwise the suffixed group's nodes would get the wrong graph label.
+    """
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice"}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+
+    for part in ("Patient-part000.csv", "PatientGroup1-part000.csv"):
+        content = open(os.path.join(bw.outdir, part)).read()
+        assert "PatientGroup1" not in content  # group key never appears in data
+        for line in content.splitlines():
+            if line.strip():
+                # last column is the Neo4j :LABEL value
+                assert line.split(";")[-1] == "Patient"
+
+
+def test_write_node_data_small_batch_size_flushes_per_group(bw):
+    """Batch size is an IO guard applied per group: three same-signature
+    patients with batch_size=2 flush a full part at the threshold and the
+    remainder at the end, yielding two part files in one group."""
+    patients = [BioCypherNode(f"p{i}", "patient", properties={"name": f"n{i}"}) for i in range(3)]
+
+    assert bw._write_node_data(patients, batch_size=2, force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == ["Patient-header.csv"]
+    assert _parts(bw.outdir, "Patient") == ["Patient-part000.csv", "Patient-part001.csv"]
+
+
+def test_write_node_data_none_valued_properties_group_consistently(bw):
+    """Edge case: a property that is consistently ``None`` does not raise (the
+    signature sort never compares ``None`` against a type string, since keys are
+    unique) and yields a single group with the property present as a column."""
+    patients = [
+        BioCypherNode("p1", "patient", properties={"name": "Alice", "diagnosis": None}),
+        BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": None}),
+    ]
+
+    assert bw._write_node_data(patients, batch_size=int(1e4), force=True)
+    assert bw._write_node_headers()
+
+    assert _headers(bw.outdir) == ["Patient-header.csv"]
+    assert "diagnosis" in open(os.path.join(bw.outdir, "Patient-header.csv")).read()
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, _get_nodes_non_compliant_names):
     nodes = _get_nodes_non_compliant_names

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -635,6 +635,54 @@ def test_write_node_data_none_valued_properties_group_consistently(bw):
     assert "diagnosis" in open(os.path.join(bw.outdir, "Patient-header.csv")).read()
 
 
+def test_write_node_data_schema_change_between_writer_instances(bw, translator, deduplicator, tmp_path_session):
+    """A schema change applied between batches builds a fresh writer instance
+    (schema is bound at construction), whose in-memory group state is empty.
+
+    The second writer must not overwrite the first batch's header when its
+    property set differs: it reconciles against the header already on disk and
+    routes the changed signature to a new group instead. This keeps the first
+    batch's header and part files mutually consistent.
+    """
+    # batch 1: {name}
+    assert bw._write_node_data(
+        [BioCypherNode("p1", "patient", properties={"name": "Alice"})],
+        batch_size=int(1e4),
+        force=True,
+    )
+    assert bw._write_node_headers()
+    g0_header = os.path.join(bw.outdir, "Patient-header.csv")
+    n_cols_batch_1 = len(open(g0_header).readline().rstrip("\n").split(";"))
+
+    # batch 2: fresh writer, same output dir, {name, diagnosis}
+    writer_2 = _Neo4jBatchWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        delimiter=";",
+        array_delimiter="|",
+        quote="'",
+    )
+    assert writer_2._write_node_data(
+        [BioCypherNode("p2", "patient", properties={"name": "Bob", "diagnosis": "diabetes"})],
+        batch_size=int(1e4),
+        force=True,
+    )
+    assert writer_2._write_node_headers()
+
+    # batch 2's changed signature opened a new group instead of reusing Patient
+    assert os.path.isfile(os.path.join(bw.outdir, "PatientGroup1-header.csv"))
+    assert "diagnosis" in open(os.path.join(bw.outdir, "PatientGroup1-header.csv")).read()
+
+    # batch 1's header was left untouched and still matches its part file
+    n_cols_header_now = len(open(g0_header).readline().rstrip("\n").split(";"))
+    part_0 = os.path.join(bw.outdir, "Patient-part000.csv")
+    n_cols_part_0 = len(open(part_0).readline().rstrip("\n").split(";"))
+    assert n_cols_header_now == n_cols_batch_1
+    assert n_cols_part_0 == n_cols_header_now
+    assert "diagnosis" not in open(g0_header).read()
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, _get_nodes_non_compliant_names):
     nodes = _get_nodes_non_compliant_names


### PR DESCRIPTION
## Summary

The CSV / Neo4j admin-import batch writer derives **one header per node label**, fixed from the first node it sees (or from the schema). When a later node of the same label carries a different property set, `_write_single_node_list_to_file` raises a *"has more or fewer properties than another"* error.

That is fine for schema-defined data, but it breaks **schemaless / optional-property input** — e.g. FHIR resources where only some patients carry a given attribute. Today the only ways around it are to pre-scan the entire input to learn the full property union, or to rewrite previously written part files whenever a new property appears. Both are expensive (a second pass over the source, or unbounded I/O re-writes).

This PR groups nodes by their **property signature** instead:

- Nodes that share the same property set *and types* go to the same group (header + part files + import-call entry); a new signature opens a new group.
- Neo4j admin import already accepts **multiple file groups for the same label**, so each group is emitted as its own `--nodes=` entry and properties stay naturally sparse across the graph.
- It's a single streaming pass — no pre-scan of the input, no rewriting of prior parts.

## Behaviour

- **Fully backward compatible, no user action.** Schema-configured or otherwise homogeneous data produces exactly one signature, so the group keeps the plain label and you get the *same* single header, part files and import call as before. All 44 pre-existing `test_neo4j.py` tests pass unchanged.
- Only previously-**erroring** (divergent) input changes: it now succeeds, producing additional suffixed groups, e.g. `Patient-header.csv` + `PatientGroup1-header.csv`.
- The first signature per label keeps the legacy file names; subsequent signatures get a file-name-safe suffix.
- A reappearing signature is routed back to its existing group (it does not spawn a new one, and appends a new part file across calls).
- The real ontology `:LABEL` is preserved for every node regardless of group — the internal group key never leaks into the data.

## How it works

In `_BatchWriter` (writer-agnostic), the node-write path now:
1. determines each node's property/type dict (`_get_node_property_types`, extracted from the existing inline logic), and
2. maps its order-invariant, type-aware signature to a group key (`_get_node_group_key`).

All existing per-label bookkeeping (`bins`, `parts`, `node_property_dict`, `import_call_nodes`) is keyed by this group key. The Neo4j header/import-call code needed **no change** — it already iterates per entry and supports multiple `--nodes=` groups for one label.

## Scope & known follow-ups (intentionally out of this PR)

- **Nodes only.** Edges retain their current behaviour (their header writer does schema lookups by the dict key, so grouping them is a separate, larger change).
- **Memory** stays bounded per group by `batch_size`, as before — now per *signature* rather than per *label*. For input with a very large number of distinct property sets, a global cap on total buffered lines would be a sensible follow-up.
- A property that is consistently `None` forms its own signature (header column present, values empty). Harmless, but could be normalised later to reduce over-splitting.

## Tests

`test/output/write/graph/test_neo4j.py`, 11 new tests (full suite green, 69 passed / 4 DB-skipped):
- varying property sets split into groups, with matching headers/parts and both in the import call;
- homogeneous input still produces one legacy-named group;
- schema-1 / schema-2 / schema-1 reappearance, both within one call and across calls (part-index continuity);
- order-invariant grouping; type-difference splitting; multiple incrementing groups; independent grouping across labels;
- `:LABEL` preserved / group key never leaks; per-group batch flushing; `None`-valued property edge case.

## Review request

The MeDaX team — could you review this and, importantly, **try it on your actual FHIR data before we merge**? The motivating case is the patient-property divergence you hit; I'd like to confirm the generated headers, part files and `neo4j-admin` import call behave as expected on a real, large run (memory profile included). Not for merge until that's validated.