### PR TITLE
fix(config): config() setter crashes with KeyError for keys absent from defaults

### DIFF
--- a/biocypher/_config/__init__.py
+++ b/biocypher/_config/__init__.py
@@ -124,7 +124,12 @@ def config(*args, **kwargs) -> Optional[Any]:
         return result[0] if len(result) == 1 else result
 
     for key, value in kwargs.items():
-        globals()["_config"][key].update(value)
+        if value is None:
+            globals()["_config"][key] = None
+        elif key in globals()["_config"] and isinstance(globals()["_config"][key], dict) and isinstance(value, dict):
+            globals()["_config"][key].update(value)
+        else:
+            globals()["_config"][key] = value
 
 
 def reset():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import biocypher._config as cfg_module
 
-from biocypher._config import _read_yaml, _USER_CONFIG_FILE
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, reset
 
 
 def test_read_yaml():
@@ -44,3 +44,46 @@ def test_read_config_merges_user_and_local(monkeypatch):
     assert result["neo4j"]["uri"] == "neo4j://myserver:7687"  # from user
     assert result["neo4j"]["database_name"] == "my_project_db"  # from local
     assert result["neo4j"]["password"] == "neo4j"  # from defaults
+
+
+def test_config_setter_merges_dict_for_known_key():
+    """config(key=dict) merges into the existing dict for a known key."""
+    try:
+        config(neo4j={"database_name": "customdb"})
+        result = config("neo4j")
+        assert result["database_name"] == "customdb"
+        assert "uri" in result  # other defaults preserved
+    finally:
+        reset()
+
+
+def test_config_setter_creates_new_key():
+    """config(key=value) must not raise KeyError for a key absent from defaults."""
+    try:
+        config(arangodb={"database_name": "mydb"})
+        result = config("arangodb")
+        assert result == {"database_name": "mydb"}
+    finally:
+        reset()
+
+
+def test_config_setter_accepts_none_value():
+    """config(key=None) sets the value to None without raising AttributeError."""
+    try:
+        config(neo4j=None)
+        assert config("neo4j") is None
+    finally:
+        reset()
+
+
+def test_update_from_file_with_unknown_key(tmp_path):
+    """update_from_file must not crash when the YAML contains a key not in the defaults."""
+    from biocypher._config import update_from_file
+
+    cfg_file = tmp_path / "biocypher_config.yaml"
+    cfg_file.write_text("arangodb:\n  database_name: mydb\n")
+    try:
+        update_from_file(str(cfg_file))
+        assert config("arangodb") == {"database_name": "mydb"}
+    finally:
+        reset()


### PR DESCRIPTION
## Summary

`config()` called `.update()` on `globals()["_config"][key]` without checking whether the key existed. This caused crashes in three distinct scenarios:

| Scenario | Error |
|---|---|
| Key is absent from defaults (e.g. `arangodb:`) | `KeyError: 'arangodb'` |
| Existing config value is `None` (e.g. after `head_ontology: null`) | `AttributeError: 'NoneType' object has no attribute 'update'` |
| Caller passes `None` as the value | `TypeError: 'NoneType' object is not iterable` |

### Real-world crash path

`update_from_file()` forwards every key in a YAML file directly to `config()`:

```python
def update_from_file(path: str):
    config(**_read_yaml(path))   # all YAML keys forwarded as kwargs
```

`BioCypher(biocypher_config_path=...)` calls `update_from_file`, so any user whose config file contained a top-level section not present in the bundled defaults (e.g. `arangodb:`, `airr:`, or any future DBMS) would hit `KeyError` at startup.

### Reproducer (before fix)

```python
from biocypher._config import config, update_from_file

config(arangodb={"database_name": "mydb"})
# KeyError: 'arangodb'

# Or via BioCypher:
# BioCypher(biocypher_config_path="config_with_arangodb.yaml")
# → KeyError: 'arangodb'
```

## Fix

Aligned the setter logic in `config()` with the defensive merge already used in `read_config()`:

```python
# Before (broken):
for key, value in kwargs.items():
    globals()["_config"][key].update(value)   # KeyError / AttributeError / TypeError

# After:
for key, value in kwargs.items():
    if value is None:
        globals()["_config"][key] = None
    elif key in globals()["_config"] and isinstance(globals()["_config"][key], dict) and isinstance(value, dict):
        globals()["_config"][key].update(value)   # merge dicts
    else:
        globals()["_config"][key] = value         # create or replace
```

## Test plan

- [x] `test_config_setter_merges_dict_for_known_key` — existing dict key is deep-merged, other keys preserved
- [x] `test_config_setter_creates_new_key` — unknown key is created instead of raising `KeyError`
- [x] `test_config_setter_accepts_none_value` — `None` value is stored without raising `AttributeError`
- [x] `test_update_from_file_with_unknown_key` — YAML with an unknown section flows through `update_from_file` without error
- [x] All 3 pre-existing `test_config.py` tests continue to pass

https://claude.ai/code/session_01Az7c52HmSPj85xDWbaEHer

---
_Generated by [Claude Code](https://claude.ai/code/session_01Az7c52HmSPj85xDWbaEHer)_