### PR TITLE
fix: remove trailing commas that made error messages into tuples (_misc, _ontology, _batch_writer)

### DIFF
--- a/biocypher/_misc.py
+++ b/biocypher/_misc.py
@@ -102,7 +102,7 @@ def _get_inheritance_tree(inheritance_graph: dict | nx.Graph) -> dict | None:
                 "following hierarchy tree (the child node is only added once). "
                 "If you wish to browse all relationships of the parsed "
                 "ontologies, write a graphml file to disk using "
-                "`to_disk = <directory>` and view this file.",
+                "`to_disk = <directory>` and view this file."
             )
             logger.warning(msg)
         # unlist values

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -786,7 +786,7 @@ class Ontology:
                 "ontology, but have not provided a schema configuration. "
                 "To display a partial ontology graph, please provide a schema "
                 "configuration file; to visualise the full graph, please use "
-                "the parameter `full = True`.",
+                "the parameter `full = True`."
             )
             logger.error(msg)
             raise ValueError(msg)

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -331,7 +331,7 @@ class _BatchWriter(_Writer, ABC):
             if getattr(self, order) is None:
                 msg = (
                     f"A batch writer `{order}` parameter must be set, "
-                    f"it must be one of: {', '.join(self._labels_orders)}.",
+                    f"it must be one of: {', '.join(self._labels_orders)}."
                 )
                 logger.error(msg)
                 raise ValueError(msg)
@@ -339,7 +339,7 @@ class _BatchWriter(_Writer, ABC):
             if getattr(self, order) not in self._labels_orders:
                 msg = (
                     f"A batch writer `{order}` parameter cannot be `{getattr(self, order)}`, "
-                    f"it must be one of: {', '.join(self._labels_orders)}.",
+                    f"it must be one of: {', '.join(self._labels_orders)}."
                 )
                 logger.error(msg)
                 raise ValueError(msg)

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1526,3 +1526,24 @@ def test_quote_escaped_in_edge_string_property(bw):
 
     assert passed
     assert "'T''253'" in content, f"Escaped quote not found in: {content!r}"
+
+
+def test_check_labels_order_none_raises_string_error(bw):
+    """_check_labels_order must raise ValueError with a plain-string message when
+    a labels_order attribute is None, not a one-element tuple."""
+    bw.node_labels_order = None
+    with pytest.raises(ValueError) as exc_info:
+        bw._check_labels_order()
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "node_labels_order" in exc_info.value.args[0]
+
+
+def test_check_labels_order_invalid_raises_string_error(bw):
+    """_check_labels_order must raise ValueError with a plain-string message when
+    a labels_order attribute has an invalid value, not a one-element tuple."""
+    bw.node_labels_order = "Ascending"  # restore from previous test if needed
+    bw.edge_labels_order = "BadOrder"
+    with pytest.raises(ValueError) as exc_info:
+        bw._check_labels_order()
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "edge_labels_order" in exc_info.value.args[0]

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -86,6 +86,24 @@ def test_tree_vis_multiple_inheritance(caplog):
     assert tree_vis.to_json(with_data=True) == expected_tree_vis.to_json(with_data=True)
 
 
+def test_multiple_inheritance_warning_message_is_string(caplog):
+    """Warning message must be a plain string, not a one-element tuple repr."""
+    inheritance_tree_data = {
+        "root": [],
+        "level1A": ["root"],
+        "level1B": ["root"],
+        "level2A": ["level1A", "level1B"],
+    }
+    inheritance_tree = nx.DiGraph(inheritance_tree_data)
+    with caplog.at_level(logging.WARNING):
+        create_tree_visualisation(inheritance_tree)
+
+    warning_records = [r for r in caplog.records if "multiple inheritance" in r.message.lower()]
+    assert warning_records, "Expected a multiple-inheritance warning"
+    assert isinstance(warning_records[0].msg, str), "msg should be str, not a tuple"
+    assert not warning_records[0].message.startswith("("), "message should not be tuple repr"
+
+
 if __name__ == "__main__":
     # to look at it
     print(create_tree_visualisation(nx.DiGraph(_get_inheritance_tree)).show())

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -92,6 +92,21 @@ def test_show_ontology(hybrid_ontology):
     assert treevis is not None
 
 
+def test_show_ontology_without_schema_raises_string_error():
+    """show_ontology_structure(full=False) without a schema must raise ValueError
+    with a plain-string message, not a one-element tuple."""
+    from biocypher._mapping import OntologyMapping
+
+    ontology = Ontology(
+        head_ontology={"url": "test/ontologies/ontology1.ttl", "root_node": "Thing"},
+        ontology_mapping=OntologyMapping(),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        ontology.show_ontology_structure(full=False)
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "schema configuration" in exc_info.value.args[0]
+
+
 def test_show_full_ontology(hybrid_ontology):
     treevis = hybrid_ontology.show_ontology_structure(full=True)
     assert treevis is not None


### PR DESCRIPTION
## Summary

Four `msg = (...)` blocks in three files had a trailing comma after the last string literal, silently making `msg` a one-element tuple instead of a string. This is the same class of bug fixed in `_translate.py` (#552) and `_core.py` (#553), extended to the remaining affected files.

```python
# Before (broken) — trailing comma creates a tuple:
msg = (
    "Some long error "
    "message here.",   # ← trailing comma!
)
logger.error(msg)    # logs: ('Some long error message here.',)
raise ValueError(msg)  # args[0] is a tuple, not a string

# After (fixed):
msg = (
    "Some long error "
    "message here."    # no trailing comma
)
logger.error(msg)    # logs: Some long error message here.
raise ValueError(msg)  # args[0] is a string
```

## Affected locations

| File | Location | Condition |
|---|---|---|
| `biocypher/_misc.py` | `create_tree_visualisation` (~line 99) | multiple-inheritance warning |
| `biocypher/_ontology.py` | `Ontology.show_ontology_structure` (~line 783) | `full=False` with no schema configured |
| `biocypher/output/write/_batch_writer.py` | `_check_labels_order` (~line 326) | `labels_order` attribute is `None` |
| `biocypher/output/write/_batch_writer.py` | `_check_labels_order` (~line 334) | `labels_order` attribute has an invalid value |

## Impact of the bug (before fix)

1. `logger.error/warning(msg)` emitted the tuple repr `('…',)` instead of a clean message.
2. `except ValueError as e: e.args[0]` returned a tuple, breaking any caller that inspects the message programmatically.
3. `pytest.raises(ValueError, match="…")` could not reliably match the message.

## Test plan

- [x] `test_multiple_inheritance_warning_message_is_string` (new, `test_misc.py`) — verifies `record.msg` is `str` and the message does not start with `(`
- [x] `test_show_ontology_without_schema_raises_string_error` (new, `test_ontology.py`) — verifies `show_ontology_structure(full=False)` raises `ValueError` with a plain-string `args[0]`
- [x] `test_check_labels_order_none_raises_string_error` (new, `test_neo4j.py`) — verifies `_check_labels_order` raises `ValueError` with string message when parameter is `None`
- [x] `test_check_labels_order_invalid_raises_string_error` (new, `test_neo4j.py`) — verifies same for invalid value
- [x] All 29 existing `test_misc.py` + `test_ontology.py` tests pass
- [x] All 46 existing `test_neo4j.py` tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_0191KVPfeYqAys2PQNBJvDVa)_