### PR TITLE
fix(postgresql): add missing f-string prefix in _get_data_type log message

### DIFF
--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -54,7 +54,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
         try:
             return self.DATA_TYPE_LOOKUP[string]
         except KeyError:
-            logger.info('Could not determine data type {string}. Using default "VARCHAR"')
+            logger.info(f'Could not determine data type {string}. Using default "VARCHAR"')
             return "VARCHAR"
 
     def _quote_string(self, value: str) -> str:

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -1,7 +1,18 @@
+import logging
 import os
 import subprocess
 
 import pytest
+
+from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
+
+
+def test_get_data_type_unknown_logs_actual_type_name(caplog):
+    writer = _PostgreSQLBatchWriter.__new__(_PostgreSQLBatchWriter)
+    with caplog.at_level(logging.INFO):
+        result = writer._get_data_type("some_unknown_type")
+    assert result == "VARCHAR"
+    assert "some_unknown_type" in caplog.text
 
 
 @pytest.mark.parametrize("length", [4], scope="module")


### PR DESCRIPTION
## Summary

Closes #558

`_PostgreSQLBatchWriter._get_data_type` logs a fallback message when an unknown data type is encountered, but the string literal was missing the `f` prefix — so `{string}` was printed verbatim instead of the actual type name.

```python
# Before (broken) — logs the literal text '{string}':
logger.info('Could not determine data type {string}. Using default "VARCHAR"')

# After (fixed):
logger.info(f'Could not determine data type {string}. Using default "VARCHAR"')
```

## Impact of the bug

Any schema property using a type not in `DATA_TYPE_LOOKUP` (e.g. `"uint8"`, `"text"`, custom types) triggered the fallback but logged:

```
Could not determine data type {string}. Using default "VARCHAR"
```

instead of the useful:

```
Could not determine data type uint8. Using default "VARCHAR"
```

This made it impossible to identify which property type triggered the VARCHAR fallback without adding extra debugging.

## Test plan

- [x] `test_get_data_type_unknown_logs_actual_type_name` (new) — calls `_get_data_type` with an unknown type, verifies the return value is `"VARCHAR"` and the log record contains the actual type name. This test **fails** on the old code and **passes** on the fix.
- [x] All existing `test_postgres.py` tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYeTmFjdgq6EujX5sU1gmW)_