### PR TITLE
fix(batch_writer): correct log message key in edge_labels_order fallback

### DIFF
--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -369,7 +369,7 @@ class _BatchWriter(_Writer, ABC):
                 logger.info(msg)
 
             if self.edge_labels_order == "None":
-                msg = f"`node_labels_order` set to `labels_order`=`{self.labels_order}`."
+                msg = f"`edge_labels_order` set to `labels_order`=`{self.labels_order}`."
                 self.edge_labels_order = self.labels_order
                 logger.info(msg)
 

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1412,3 +1412,23 @@ def test_powershell_template_structure():
         "{args_neo4j_v5}",
     }
     assert expected_placeholders.issubset(set(placeholders))
+
+
+def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator, tmp_path):
+    """When edge_labels_order='None' the fallback log must name 'edge_labels_order', not 'node_labels_order'."""
+    with caplog.at_level(logging.INFO):
+        _Neo4jBatchWriter(
+            translator=translator,
+            deduplicator=deduplicator,
+            output_directory=str(tmp_path),
+            delimiter=";",
+            labels_order="Descending",
+            edge_labels_order="None",
+        )
+    messages = [r.message for r in caplog.records]
+    assert any(
+        "`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"Expected edge_labels_order fallback log, got: {messages}"
+    assert not any(
+        "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"node_labels_order appeared in edge fallback log: {messages}"


### PR DESCRIPTION
## Summary

Copy-paste bug in `_BatchWriter._check_labels_order` (`biocypher/output/write/_batch_writer.py`, line 372): when `edge_labels_order` is `"None"` and falls back to `labels_order`, the log message incorrectly said `node_labels_order` instead of `edge_labels_order`.

```python
# Before (broken) — wrong key name in the message:
if self.edge_labels_order == "None":
    msg = f"`node_labels_order` set to `labels_order`=`{self.labels_order}`."
    self.edge_labels_order = self.labels_order

# After (fixed):
if self.edge_labels_order == "None":
    msg = f"`edge_labels_order` set to `labels_order`=`{self.labels_order}`."
    self.edge_labels_order = self.labels_order
```

The adjacent block for `node_labels_order` (lines 366–369) was correct; the error was purely in the copy-pasted `edge_labels_order` block below it.

## Impact

Any user who passes `labels_order=X` without an explicit `edge_labels_order`, or who sets `edge_labels_order="None"` to rely on the `labels_order` shortcut, would see a misleading log line claiming `node_labels_order` was set — making it harder to diagnose configuration issues.

## Test plan

- [x] `test_edge_labels_order_fallback_log_message` (new) — creates a writer with `labels_order="Descending"` and `edge_labels_order="None"`, captures logs, and asserts the message contains `edge_labels_order` (not `node_labels_order`). Fails on the old code, passes on the fix.
- [x] All 45 existing `test_neo4j.py` tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUvazXhLFw99gKrkfbds6v)_