### PR TITLE
fix(workflow): clear _seen_nodes/_seen_edges on remove/clear/from_json

### DIFF
--- a/biocypher/_workflow.py
+++ b/biocypher/_workflow.py
@@ -205,7 +205,10 @@ class BioCypherWorkflow:
         Returns:
             bool: True if node was removed, False if not found
         """
-        return self.graph.remove_node(node_id)
+        result = self.graph.remove_node(node_id)
+        if result:
+            self._seen_nodes.discard(node_id)
+        return result
 
     # ==================== EDGE OPERATIONS ====================
 
@@ -311,7 +314,11 @@ class BioCypherWorkflow:
         Returns:
             bool: True if edge was removed, False if not found
         """
-        return self.graph.remove_edge(edge_id)
+        edge = self.graph.get_edge(edge_id)
+        result = self.graph.remove_edge(edge_id)
+        if result and edge is not None:
+            self._seen_edges.discard((edge_id, edge.type))
+        return result
 
     # ==================== HYPEREDGE OPERATIONS ====================
 
@@ -619,6 +626,8 @@ class BioCypherWorkflow:
         data = json.loads(json_data)
         self.graph = Graph.from_dict(data)
         self.name = self.graph.name
+        self._seen_nodes = set(self.graph._nodes.keys())
+        self._seen_edges = {(edge.id, edge.type) for edge in self.graph._edges.values()}
 
     def save(self, filepath: str) -> None:
         """Save the graph to a file.
@@ -646,6 +655,8 @@ class BioCypherWorkflow:
     def clear(self) -> None:
         """Clear all nodes and edges from the graph."""
         self.graph = Graph(name=self.name, directed=self.graph.directed)
+        self._seen_nodes.clear()
+        self._seen_edges.clear()
         logger.info("Graph cleared")
 
     def copy(self) -> "BioCypherWorkflow":

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -722,6 +722,22 @@ class TestUtilityOperations:
         assert len(self.workflow) == 0
         assert not self.workflow.has_edge("edge1")
 
+    def test_clear_resets_deduplication_tracking(self):
+        """Test that clear() resets _seen_nodes/_seen_edges so nodes can be re-added."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("node1", "protein")
+        workflow.add_node("node2", "protein")
+        workflow.add_edge("edge1", "interaction", "node1", "node2")
+
+        workflow.clear()
+
+        # After clear, the same IDs must be addable again
+        result = workflow.add_node("node1", "protein")
+        assert result is True
+        workflow.add_node("node2", "protein")
+        result = workflow.add_edge("edge1", "interaction", "node1", "node2")
+        assert result is True
+
     def test_copy(self):
         """Test copying the workflow."""
         self.workflow.add_node("node1", "protein", name="TP53")
@@ -936,6 +952,48 @@ class TestValidationModes:
         # Different edge should succeed
         result3 = workflow.add_edge("edge2", "interaction", "node1", "node2")
         assert result3 is True
+
+    def test_remove_node_clears_deduplication_tracking(self):
+        """Test that remove_node() removes the ID from _seen_nodes so it can be re-added."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("node1", "protein")
+
+        # Removing the node should allow re-adding it
+        workflow.remove_node("node1")
+        result = workflow.add_node("node1", "protein")
+        assert result is True
+        assert workflow.has_node("node1")
+
+    def test_remove_edge_clears_deduplication_tracking(self):
+        """Test that remove_edge() removes the key from _seen_edges so it can be re-added."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("node1", "protein")
+        workflow.add_node("node2", "protein")
+        workflow.add_edge("edge1", "interaction", "node1", "node2")
+
+        # Removing the edge should allow re-adding it
+        workflow.remove_edge("edge1")
+        result = workflow.add_edge("edge1", "interaction", "node1", "node2")
+        assert result is True
+        assert workflow.has_edge("edge1")
+
+    def test_from_json_populates_deduplication_tracking(self):
+        """Test that from_json() populates _seen_nodes/_seen_edges for deduplication."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("node1", "protein")
+        workflow.add_node("node2", "protein")
+        workflow.add_edge("edge1", "interaction", "node1", "node2")
+        json_str = workflow.to_json()
+
+        # Load into a new workflow with deduplication
+        workflow2 = create_workflow("test2", deduplication=True)
+        workflow2.from_json(json_str)
+
+        # Loaded node/edge IDs should be treated as already seen
+        result_node = workflow2.add_node("node1", "protein")
+        assert result_node is False  # Duplicate
+        result_edge = workflow2.add_edge("edge1", "interaction", "node1", "node2")
+        assert result_edge is False  # Duplicate
 
     def test_schema_validation_valid_data(self):
         """Test schema validation with valid data."""


### PR DESCRIPTION
## Summary

Closes #561

`BioCypherWorkflow` tracks seen entity IDs in `_seen_nodes` and `_seen_edges` to power the `deduplication=True` mode, but three mutation methods failed to keep those sets in sync with the underlying graph:

- `remove_node` / `remove_edge` left stale entries, so a removed entity could never be re-added.
- `clear()` replaced the graph but left both sets populated, making it impossible to re-add any previously-seen entity after a full reset.
- `from_json()` replaced the graph without repopulating the sets, so newly-loaded entities were invisible to future deduplication checks.

### Changes

| Method | Fix |
|--------|-----|
| `remove_node(id)` | Discards `id` from `_seen_nodes` on success |
| `remove_edge(id)` | Looks up the edge type before removal; discards `(id, type)` from `_seen_edges` on success |
| `clear()` | Calls `_seen_nodes.clear()` and `_seen_edges.clear()` after replacing the graph |
| `from_json(json)` | Repopulates `_seen_nodes` and `_seen_edges` from the loaded graph |

## Test plan

- [x] `test_clear_resets_deduplication_tracking` — adds nodes/edges, clears, then re-adds the same IDs and asserts they succeed.
- [x] `test_remove_node_clears_deduplication_tracking` — adds a node, removes it, re-adds and asserts success.
- [x] `test_remove_edge_clears_deduplication_tracking` — adds an edge, removes it, re-adds and asserts success.
- [x] `test_from_json_populates_deduplication_tracking` — serialises a workflow, loads into a new deduplication-enabled workflow, and asserts that loaded IDs are treated as duplicates.
- [x] All 84 existing `test_workflow.py` tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016UqGDQ5Zyss4FZ5Ypau1Xq)_