### PR TITLE
fix(biopathnet): use full Ontology graph so synonym types are found (#489)

### DIFF
--- a/biocypher/output/write/graph/_biopathnet.py
+++ b/biocypher/output/write/graph/_biopathnet.py
@@ -69,7 +69,11 @@ class _BioPathNetWriter(_Writer):
         dict_entity_types = {}
         str_nodes_props_graph = []
 
-        graph_hierarchy = copy.copy(self.translator.ontology._head_ontology.get_nx_graph()).reverse()
+        # Use the full Ontology graph (with synonym relabeling applied) so that
+        # user-defined synonym labels (e.g. "complex" -> "macromolecular complex")
+        # are found in the hierarchy.  The raw _head_ontology graph only contains
+        # canonical labels and would crash on any synonym type.
+        graph_hierarchy = copy.copy(self.translator.ontology._nx_graph).reverse()
         logger.debug(f"type(graph_hierarchy) = {type(graph_hierarchy)}")
         logger.debug(f"graph_hierarchy = {graph_hierarchy.nodes()}")
         ancestors_set = set()
@@ -90,6 +94,13 @@ class _BioPathNetWriter(_Writer):
 
             # Add all ancestors of the entity type in the set, in order to reconstruct
             # the useful part of the ontology for passing it to BioPathNet
+            if semantic_type not in graph_hierarchy:
+                logger.warning(
+                    f"Semantic type '{semantic_type}' not found in ontology graph. "
+                    "Skipping ancestor lookup for this node type."
+                )
+                ancestors_set.add(semantic_type)
+                continue
             ancestors = nx.ancestors(graph_hierarchy, semantic_type) | {semantic_type}
             logger.debug(f"Adding the type : {semantic_type}")
             logger.debug(f"Ancestors : {ancestors}")

--- a/test/output/write/graph/test_biopathnet.py
+++ b/test/output/write/graph/test_biopathnet.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from biocypher._create import BioCypherNode
 from biocypher._logger import logger
 
 
@@ -36,6 +37,39 @@ def test_biopathnet_writer_nodes(bw_biopathnet, _get_nodes):
 #        lines = f.readlines()
 #        len_lines = len(lines)
 #    assert len(nodes) == len_lines
+
+
+def test_biopathnet_writer_nodes_synonym_type(bw_biopathnet, tmp_path_session):
+    """Regression test for issue #489.
+
+    Nodes whose type is a schema synonym (e.g. 'complex' -> 'macromolecular
+    complex') must be written without raising a NetworkXError because the
+    full Ontology graph (with synonyms relabeled) is used for ancestor lookup
+    rather than the raw head-ontology graph.
+    """
+    synonym_nodes = [
+        BioCypherNode(
+            node_id="cpx1",
+            node_label="complex",
+            preferred_id="complexportal",
+            properties={},
+        ),
+        BioCypherNode(
+            node_id="cpx2",
+            node_label="complex",
+            preferred_id="complexportal",
+            properties={},
+        ),
+    ]
+
+    passed = bw_biopathnet.write_nodes(iter(synonym_nodes), batch_size=1e6)
+    assert passed
+
+    entity_types_file = os.path.join(tmp_path_session, "entity_types.txt")
+    assert os.path.exists(entity_types_file)
+    content = open(entity_types_file).read()
+    assert "cpx1" in content
+    assert "complex" in content
 
 
 @pytest.mark.parametrize("length", [4], scope="module")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -20,6 +20,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/d4/6585f3b6fdb75648bca294664af4becc8aa2fb3fb08f4e4e9fd27e10d773/adjusttext-1.3.0.tar.gz", hash = "sha256:4ab75cd4453af4828876ac3e964f2c49be642ea834f0c1f7449558d5f12cbca1", size = 15724, upload-time = "2024-10-31T16:45:36.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/1c/8feedd607cc14c5df9aef74fe3af9a99bf660743b842a9b5b1865326b4aa/adjustText-1.3.0-py3-none-any.whl", hash = "sha256:da23d7b24b6db5ffa039bb136bfa556207365e32f48ac74b07ad26dd485bc691", size = 13154, upload-time = "2024-10-31T16:45:35.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/80/7ad35ee5321a86b842f9e8516c8ae4c86f58db7b40e82ce9759f94517a50/adjusttext-1.3.0-py3-none-any.whl", hash = "sha256:bc6c118cd9d7caf6ae37f9355e51d840a2d7f64b4fb2956b8401de27c5af803b", size = 13264, upload-time = "2026-06-08T16:40:05.041Z" },
 ]
 
 [[package]]
@@ -277,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Fixes #489

The BioPathNet writer was building its ontology hierarchy graph from `_head_ontology.get_nx_graph()`, which only contains canonical ontology labels. When a user defines a schema synonym (e.g. `complex: synonym_for: macromolecular complex`), `Ontology._add_properties()` relabels the node in `Ontology._nx_graph` from the canonical term to the user-facing synonym — but the raw head-ontology adapter is never updated. As a result:

- `entity.get_type()` returns `"complex"` (the synonym)
- The hierarchy graph only contains `"macromolecular complex"`
- `nx.ancestors(graph_hierarchy, "complex")` raises `NetworkXError: The node complex is not in the digraph.`

**Fix:** switch from `self.translator.ontology._head_ontology.get_nx_graph()` to `self.translator.ontology._nx_graph`, which is the fully processed ontology graph with all synonyms relabeled.

A defensive warning log is also added for any type that still isn't found (e.g. a completely unknown label), instead of crashing with an opaque NetworkX error.

## Changes

- `biocypher/output/write/graph/_biopathnet.py`: use `ontology._nx_graph` (synonym-aware) instead of `_head_ontology.get_nx_graph()` for the hierarchy; add guard for unknown types
- `test/output/write/graph/test_biopathnet.py`: add regression test that writes nodes with a synonym type (`"complex"`) and asserts no crash + correct output

## Test plan

- [x] New regression test `test_biopathnet_writer_nodes_synonym_type` passes — writes `"complex"` nodes through the BioPathNet writer without error
- [x] Existing `test_biopathnet_writer_nodes` and `test_biopathnet_writer_edges` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL673UPu54XQBRXrFEWFcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KL673UPu54XQBRXrFEWFcA)_