### PR TITLE
feat(neo4j): add import_call_additional_options config key

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -119,6 +119,8 @@ neo4j:
   skip_duplicate_nodes: false
   skip_bad_relationships: false
 
+  # import_call_additional_options: '--report-file="/import.report" --bad-tolerance=-1'
+
   ## Import call prefixes
 
   # import_call_bin_prefix: bin/

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -144,6 +144,7 @@ class _BatchWriter(_Writer, ABC):
         strict_mode: bool = False,
         skip_bad_relationships: bool = False,
         skip_duplicate_nodes: bool = False,
+        import_call_additional_options: str | None = None,
         db_user: str = None,
         db_password: str = None,
         db_host: str = None,
@@ -224,6 +225,10 @@ class _BatchWriter(_Writer, ABC):
             skip_duplicate_nodes:
                 Whether to skip duplicate nodes. (Specific to Neo4j.)
 
+            import_call_additional_options:
+                Optional string of extra flags to append verbatim to the
+                generated neo4j-admin import command. (Specific to Neo4j.)
+
             db_user:
                 The database user.
 
@@ -288,6 +293,7 @@ class _BatchWriter(_Writer, ABC):
         self.quote = quote
         self.skip_bad_relationships = skip_bad_relationships
         self.skip_duplicate_nodes = skip_duplicate_nodes
+        self.import_call_additional_options = import_call_additional_options
 
         if import_call_bin_prefix is None:
             self.import_call_bin_prefix = self._get_default_import_call_bin_prefix()

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -126,6 +126,7 @@ def get_writer(
             edge_labels_order=dbms_config.get("edge_labels_order"),  # batch writer
             skip_bad_relationships=dbms_config.get("skip_bad_relationships"),  # neo4j
             skip_duplicate_nodes=dbms_config.get("skip_duplicate_nodes"),  # neo4j
+            import_call_additional_options=dbms_config.get("import_call_additional_options"),  # neo4j
             db_user=dbms_config.get("user"),  # psql
             db_password=dbms_config.get("password"),  # psql
             db_port=dbms_config.get("port"),  # psql

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -438,6 +438,8 @@ class _Neo4jBatchWriter(_BatchWriter):
             import_call += "--skip-bad-relationships=true "
         if self.skip_duplicate_nodes:
             import_call += "--skip-duplicate-nodes=true "
+        if self.import_call_additional_options:
+            import_call += f"{self.import_call_additional_options} "
 
         # append node import calls
         for header_path, parts_path in self.import_call_nodes:
@@ -472,6 +474,7 @@ class _Neo4jBatchWriter(_BatchWriter):
         import_call.append(f"{wipe_cmd}true " if self.wipe else "")
         import_call.append("--skip-bad-relationships=true " if self.skip_bad_relationships else "")
         import_call.append("--skip-duplicate-nodes=true " if self.skip_duplicate_nodes else "")
+        import_call.append(f"{self.import_call_additional_options} " if self.import_call_additional_options else "")
         import_call.extend(
             f'--nodes="{header_path},{parts_path}" ' for header_path, parts_path in self.import_call_nodes
         )

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -209,6 +209,25 @@ def test_construct_import_call_powershell(bw):
     assert "import --database=neo4j" in import_script
 
 
+def test_import_call_additional_options(translator, deduplicator, tmp_path_session):
+    bw_extra = _Neo4jBatchWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        delimiter=";",
+        array_delimiter="|",
+        quote="'",
+        import_call_additional_options='--report-file="/import.report" --bad-tolerance=-1',
+    )
+
+    call = bw_extra._get_import_call("import", "--database=", "--force=")
+
+    assert '--report-file="/import.report" --bad-tolerance=-1' in call
+
+    for f in os.listdir(tmp_path_session):
+        os.remove(os.path.join(tmp_path_session, f))
+
+
 def test_write_hybrid_ontology_nodes(bw):
     nodes = []
     for i in range(4):


### PR DESCRIPTION
## Summary

Closes #564

- Adds an `import_call_additional_options` string key to the `neo4j` section of `biocypher_config.yaml`. Its value is appended verbatim to the generated `neo4j-admin import` command line, covering both the bash and PowerShell variants.
- Threads the new parameter through `_BatchWriter.__init__` → `_get_writer.py` → `_Neo4jBatchWriter._get_import_call` / `_get_import_call_windows`.
- Adds a test (`test_import_call_additional_options`) that verifies the extra flags appear in the generated call.

**Example config:**
```yaml
neo4j:
  import_call_additional_options: '--report-file="/data/import.report" --bad-tolerance=-1'
```

## Test plan

- [x] `test_import_call_additional_options` — new test verifying the option is present in the generated import call
- [x] All 45 existing Neo4j writer tests still pass (`pytest test/output/write/graph/test_neo4j.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaGaT4rZDg7o6bhkAorp8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaGaT4rZDg7o6bhkAorp8M)_