### PR TITLE
fix(postgresql): remove set-literal typo so PGPASSWORD is only injected when a password is set

### DIFF
--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -300,7 +300,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
             *self.import_call_edges,
         ]:
             import_call += f'echo "Setup {import_file_path}..."\n'
-            if {self.db_password}:
+            if self.db_password:
                 # set password variable inline
                 import_call += f"PGPASSWORD={self.db_password} "
             import_call += f"{self.import_call_bin_prefix}psql -f {import_file_path}"
@@ -315,7 +315,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
         for command in self._copy_from_csv_commands:
             table_part = command.split(" ")[3]
             import_call += f'echo "Importing {table_part}..."\n'
-            if {self.db_password}:
+            if self.db_password:
                 # set password variable inline
                 import_call += f"PGPASSWORD={self.db_password} "
             import_call += f'{self.import_call_bin_prefix}psql -c "{command}"'

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -45,6 +45,35 @@ def test_get_writer_passes_db_host_to_postgresql_writer(translator, deduplicator
     assert writer.db_host == custom_host
 
 
+def _make_writer(db_password):
+    """Minimal _PostgreSQLBatchWriter with enough state to run _construct_import_call."""
+    writer = _PostgreSQLBatchWriter.__new__(_PostgreSQLBatchWriter)
+    writer.db_password = db_password
+    writer.db_name = "testdb"
+    writer.db_host = "localhost"
+    writer.db_port = "5432"
+    writer.db_user = "testuser"
+    writer.import_call_bin_prefix = ""
+    writer.import_call_nodes = {"/tmp/node-create_table.sql"}
+    writer.import_call_edges = set()
+    writer._copy_from_csv_commands = {r"\copy protein FROM '/tmp/Protein-part000.csv' DELIMITER E',' CSV;"}
+    return writer
+
+
+def test_import_call_no_pgpassword_when_password_is_none():
+    """PGPASSWORD must not appear when db_password is None (fixes set-literal bug)."""
+    writer = _make_writer(db_password=None)
+    import_call = writer._construct_import_call()
+    assert "PGPASSWORD" not in import_call
+
+
+def test_import_call_includes_pgpassword_when_password_is_set():
+    """PGPASSWORD=<value> must be prepended to psql calls when db_password is set."""
+    writer = _make_writer(db_password="s3cr3t")
+    import_call = writer._construct_import_call()
+    assert "PGPASSWORD=s3cr3t" in import_call
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_gen_comma_postgresql(bw_comma_postgresql, _get_nodes):
     nodes = _get_nodes


### PR DESCRIPTION
## Summary

Closes #566

`_PostgreSQLBatchWriter._construct_import_call` contained a set-literal typo on two lines:

```python
# Before (broken) — {self.db_password} is a Python set, always truthy:
if {self.db_password}:
    import_call += f"PGPASSWORD={self.db_password} "
```

Because `{None}` (a set containing `None`) is truthy, the condition was **always `True`**, so every generated `postgres-import-call.sh` unconditionally contained `PGPASSWORD=None` — even when no password was configured. This breaks passwordless authentication (peer auth, `.pgpass`, etc.) and leaks a nonsense credential into the script.

```python
# After (fixed) — plain truthiness check:
if self.db_password:
    import_call += f"PGPASSWORD={self.db_password} "
```

The same typo appeared twice — once in the `CREATE TABLE` loop and once in the `COPY FROM` loop; both are fixed.

## Test plan

- [x] `test_import_call_no_pgpassword_when_password_is_none` (new) — builds a minimal writer with `db_password=None`, calls `_construct_import_call`, asserts `PGPASSWORD` does **not** appear. This test **fails** on the old code and **passes** on the fix.
- [x] `test_import_call_includes_pgpassword_when_password_is_set` (new) — builds a writer with `db_password="s3cr3t"`, asserts `PGPASSWORD=s3cr3t` **does** appear. Passes on both old and new code (positive-case sanity check).
- [x] All 4 existing non-requires-postgresql tests in `test_postgres.py` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ARZcN9uYPvP4zkJ7wZ5d2

---
_Generated by [Claude Code](https://claude.ai/code/session_012ARZcN9uYPvP4zkJ7wZ5d2)_