### PR TITLE
fix(get_writer): forward postgresql `host` config key to writer as `db_host`

### DIFF
--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -129,6 +129,7 @@ def get_writer(
             import_call_additional_options=dbms_config.get("import_call_additional_options"),  # neo4j
             db_user=dbms_config.get("user"),  # psql
             db_password=dbms_config.get("password"),  # psql
+            db_host=dbms_config.get("host"),  # psql
             db_port=dbms_config.get("port"),  # psql
             file_format=dbms_config.get("file_format"),  # rdf, owl
             rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf, owl

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
+from biocypher.output.write._get_writer import get_writer
 from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
 
 
@@ -13,6 +15,34 @@ def test_get_data_type_unknown_logs_actual_type_name(caplog):
         result = writer._get_data_type("some_unknown_type")
     assert result == "VARCHAR"
     assert "some_unknown_type" in caplog.text
+
+
+def test_get_writer_passes_db_host_to_postgresql_writer(translator, deduplicator, tmp_path):
+    """get_writer must forward the 'host' config key to the writer as db_host."""
+    custom_host = "my-custom-pg-host.example.com"
+    mock_config = {
+        "user": "testuser",
+        "password": "testpass",
+        "host": custom_host,
+        "port": "5432",
+        "database_name": "testdb",
+        "delimiter": "\t",
+        "quote_character": '"',
+        "labels_order": "Ascending",
+        "node_labels_order": "None",
+        "edge_labels_order": "None",
+    }
+
+    with patch("biocypher.output.write._get_writer._config", return_value=mock_config):
+        writer = get_writer(
+            dbms="postgresql",
+            translator=translator,
+            deduplicator=deduplicator,
+            output_directory=str(tmp_path),
+            strict_mode=False,
+        )
+
+    assert writer.db_host == custom_host
 
 
 @pytest.mark.parametrize("length", [4], scope="module")


### PR DESCRIPTION
## Summary

Closes #568

`get_writer` in `biocypher/output/write/_get_writer.py` forwarded `db_user`, `db_password`, and `db_port` from the `postgresql` config section but silently omitted the `host` key. As a result `_BatchWriter.__init__` always fell back to `self.db_host = db_host or "localhost"`, and any user-configured remote host was ignored — the generated `psql` import script would unconditionally contain `--host localhost`.

### Root cause

```python
# Before (host key missing):
return writer(
    ...
    db_user=dbms_config.get("user"),
    db_password=dbms_config.get("password"),
    # db_host=dbms_config.get("host"),   ← was never passed
    db_port=dbms_config.get("port"),
    ...
)
```

### Fix

One line added to the writer constructor call:

```python
db_host=dbms_config.get("host"),  # psql
```

## Test plan

- [x] `test_get_writer_passes_db_host_to_postgresql_writer` — new regression test; patches `_config` to return a custom host, calls `get_writer`, and asserts `writer.db_host` equals the configured value. Would have **failed** on the old code, **passes** on the fix.
- [x] All 3 existing non-database PostgreSQL writer tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwVmbjj2bf8FrS3odECZYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwVmbjj2bf8FrS3odECZYq)_