### PR TITLE
fix: correct garbled error messages in _ontology, _translate, _batch_writer

### DIFF
--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -781,7 +781,7 @@ class Ontology:
         """
         if not full and not self.mapping.extended_schema:
             msg = (
-                "You are attempting to visualise a subset of the loaded"
+                "You are attempting to visualise a subset of the loaded "
                 "ontology, but have not provided a schema configuration. "
                 "To display a partial ontology graph, please provide a schema "
                 "configuration file; to visualise the full graph, please use "

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -164,7 +164,7 @@ class Translator:
 
         if not isinstance(filter_props, dict):
             msg = (
-                f"Properties for type {bl_type} should be a dictonary. Verify your schema (did you declared "
+                f"Properties for type {bl_type} should be a dictionary. Verify your schema (did you declare "
                 "properties as a list?)"
             )
             logger.error(msg)

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -344,7 +344,7 @@ class _BatchWriter(_Writer, ABC):
         if self.labels_order == "None" and (self.node_labels_order == "None" or self.edge_labels_order == "None"):
             msg = (
                 "You have to set either `labels_order` or "
-                "both `node_labels_order` and `edge_labels_order`."
+                "both `node_labels_order` and `edge_labels_order`. "
                 "Current setting:\n"
                 f"- labels_order = `{self.labels_order}`\n"
                 f"- node_labels_order = `{self.node_labels_order}`\n"


### PR DESCRIPTION
## Summary

Three error message strings were silently broken due to missing spaces at implicit string-concatenation boundaries, or contained a typo and a grammatical error.

- **`_ontology.py`** (`show_ontology_structure`): `"loaded"` + `"ontology"` concatenated without a space, producing the unreadable `"…subset of the loadedontology, but…"`. Added the missing trailing space.
- **`_batch_writer.py`** (`_check_labels_order`): `"edge_labels_order`."` + `"Current"` concatenated without a space, producing `"…edge_labels_order`.Current setting:…"`. Added the missing trailing space.
- **`_translate.py`** (`_filter_props`): two independent issues in the same message:
  - typo `"dictonary"` → `"dictionary"`
  - grammatical error `"did you declared"` → `"did you declare"`

None of these affect runtime logic — only the text of error messages.

## Test plan

- [x] `python -c "import biocypher"` succeeds after the change
- [x] All three modified modules import without error
- [ ] Verify each error message is readable in a dev run that actually triggers the error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018asrc4MdQzTgcgGycQjjVe

---
_Generated by [Claude Code](https://claude.ai/code/session_018asrc4MdQzTgcgGycQjjVe)_