### PR TITLE
fix(workflow): keep _seen_nodes/_seen_edges in sync with graph mutations

### DIFF
--- a/biocypher/_workflow.py
+++ b/biocypher/_workflow.py
@@ -205,7 +205,10 @@ class BioCypherWorkflow:
         Returns:
             bool: True if node was removed, False if not found
         """
-        return self.graph.remove_node(node_id)
+        result = self.graph.remove_node(node_id)
+        if result:
+            self._seen_nodes.discard(node_id)
+        return result
 
     # ==================== EDGE OPERATIONS ====================
 
@@ -311,6 +314,10 @@ class BioCypherWorkflow:
         Returns:
             bool: True if edge was removed, False if not found
         """
+        if self.deduplication:
+            edge = self.graph.get_edge(edge_id)
+            if edge is not None:
+                self._seen_edges.discard((edge_id, edge.type))
         return self.graph.remove_edge(edge_id)
 
     # ==================== HYPEREDGE OPERATIONS ====================
@@ -619,6 +626,9 @@ class BioCypherWorkflow:
         data = json.loads(json_data)
         self.graph = Graph.from_dict(data)
         self.name = self.graph.name
+        if self.deduplication:
+            self._seen_nodes = {node.id for node in self.graph.get_nodes()}
+            self._seen_edges = {(edge.id, edge.type) for edge in self.graph.get_edges()}
 
     def save(self, filepath: str) -> None:
         """Save the graph to a file.
@@ -646,6 +656,8 @@ class BioCypherWorkflow:
     def clear(self) -> None:
         """Clear all nodes and edges from the graph."""
         self.graph = Graph(name=self.name, directed=self.graph.directed)
+        self._seen_nodes.clear()
+        self._seen_edges.clear()
         logger.info("Graph cleared")
 
     def copy(self) -> "BioCypherWorkflow":

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -1060,3 +1060,55 @@ class TestValidationModes:
         workflow.add_node("node1", "protein")
         with pytest.raises(ValueError):
             workflow.add_node("node1", "protein")  # Should fail due to deduplication
+
+
+class TestDeduplicationTrackingSync:
+    """Regression tests for _seen_nodes/_seen_edges staying in sync with the graph."""
+
+    def test_remove_node_allows_readd(self):
+        """After remove_node, the same ID must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("p1", "protein")
+        workflow.remove_node("p1")
+        result = workflow.add_node("p1", "protein")
+        assert result is True
+
+    def test_remove_edge_allows_readd(self):
+        """After remove_edge, the same ID must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+        workflow.remove_edge("e1")
+        result = workflow.add_edge("e1", "interaction", "n1", "n2")
+        assert result is True
+
+    def test_clear_allows_readd(self):
+        """After clear(), previously-seen IDs must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+        workflow.clear()
+        result_node = workflow.add_node("n1", "protein")
+        assert result_node is True
+        workflow.add_node("n2", "protein")
+        result_edge = workflow.add_edge("e1", "interaction", "n1", "n2")
+        assert result_edge is True
+
+    def test_from_json_populates_seen_sets(self):
+        """from_json() must populate _seen_nodes/_seen_edges so loaded entities are tracked."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+
+        json_str = workflow.to_json()
+
+        # Load into a fresh deduplication-enabled workflow
+        new_workflow = create_workflow("test2", deduplication=True)
+        new_workflow.from_json(json_str)
+
+        # Loaded entities should be tracked — re-adding must return False
+        assert new_workflow.add_node("n1", "protein") is False
+        assert new_workflow.add_edge("e1", "interaction", "n1", "n2") is False


### PR DESCRIPTION
## Summary

Closes #561

`BioCypherWorkflow` maintains `_seen_nodes` and `_seen_edges` sets for deduplication, but four mutation methods failed to keep them in sync with the underlying graph:

| Method | Bug | Fix |
|--------|-----|-----|
| `remove_node` | node stays in `_seen_nodes` after removal; can never be re-added | `discard` from `_seen_nodes` on successful removal |
| `remove_edge` | edge key stays in `_seen_edges` after removal; can never be re-added | look up edge type, `discard` `(id, type)` tuple before removal |
| `clear` | `_seen_nodes`/`_seen_edges` survive graph reset; all previously-seen IDs permanently blocked | call `.clear()` on both sets alongside graph reset |
| `from_json` | loaded entities invisible to deduplication; re-adding them returns `True` when it should return `False` | rebuild sets from loaded graph when `deduplication=True` |

## Test plan

- [x] `test_remove_node_allows_readd` — adds node, removes it, re-adds it; asserts `True`. **Failed** before fix, **passes** after.
- [x] `test_remove_edge_allows_readd` — adds edge, removes it, re-adds it; asserts `True`. **Failed** before fix, **passes** after.
- [x] `test_clear_allows_readd` — adds node + edge, calls `clear()`, re-adds both; asserts `True`. **Failed** before fix, **passes** after.
- [x] `test_from_json_populates_seen_sets` — serialises a workflow, loads it into a fresh deduplication-enabled workflow, attempts to re-add the loaded entities; asserts `False` (already seen). **Failed** before fix, **passes** after.
- [x] All 80 pre-existing `test_workflow.py` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rhuoPRyARyh6cANuxP8zK

---
_Generated by [Claude Code](https://claude.ai/code/session_015rhuoPRyARyh6cANuxP8zK)_