### PR TITLE
fix: add missing arangodb section to default config

### DIFF
--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -183,6 +183,22 @@ sqlite:
   # import_call_bin_prefix: '' # path to "sqlite3"
   # import_call_file_prefix: '/path/to/files'
 
+arangodb:
+  ### ArangoDB configuration ###
+  database_name: biocypher # DB name
+
+  # ArangoDB import batch writer settings
+
+  delimiter: ","
+  array_delimiter: "|"
+  quote_character: '"'
+  # import_call_bin_prefix: '' # path to "arangoimp"
+  # import_call_file_prefix: '/path/to/files'
+
+  labels_order: "Ascending" # Default: From more specific to more generic.
+  node_labels_order: "None" # Default: use labels_order.
+  edge_labels_order: "None"
+
 csv:
   ### CSV/Pandas configuration ###
   delimiter: ","

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import biocypher._config as cfg_module
 
-from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, reset
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, config as _config, reset
 
 
 def test_read_yaml():
@@ -87,3 +87,21 @@ def test_update_from_file_with_unknown_key(tmp_path):
         assert config("arangodb") == {"database_name": "mydb"}
     finally:
         reset()
+
+
+def test_arangodb_config_present_in_defaults():
+    """ArangoDB section must exist in defaults so get_writer("arangodb") doesn't crash.
+
+    Previously, the `arangodb` key was absent from biocypher_config.yaml, so
+    _config("arangodb") returned None, get_writer passed labels_order=None to the
+    writer, and _check_labels_order() raised a ValueError on first use.
+    """
+    from biocypher._config import reset
+
+    reset()  # ensure we're reading from the real defaults file
+
+    arango_cfg = _config("arangodb")
+
+    assert arango_cfg is not None, "arangodb section missing from defaults config"
+    assert "labels_order" in arango_cfg, "labels_order must be set so get_writer doesn't pass None"
+    assert "delimiter" in arango_cfg, "delimiter must be set for ArangoDB CSV output"


### PR DESCRIPTION
## Summary

- `arangodb` was registered in `DBMS_TO_CLASS` but had no corresponding section in `biocypher/_config/biocypher_config.yaml`
- This caused `get_writer("arangodb")` to receive `labels_order=None` (since `_config("arangodb")` returned `None`)
- `_ArangoDBBatchWriter._check_labels_order()` then raised a `ValueError` on first use, making the ArangoDB writer completely unusable via the standard `BioCypher(dbms="arangodb")` path

## Fix

Added the `arangodb` config block to `biocypher_config.yaml` with the same structure as the other batch writers (`delimiter`, `array_delimiter`, `quote_character`, `labels_order`, `node_labels_order`, `edge_labels_order`). Also added a regression test in `test/test_config.py` to prevent this from regressing silently.

## Test plan

- [x] `python -m pytest test/test_config.py -v --noconftest` — all 4 tests pass including the new `test_arangodb_config_present_in_defaults`
- [x] Manual verification: `from biocypher._config import config, reset; reset(); config("arangodb")` now returns the full config dict instead of `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vC5mYsXaejV6aBWkGdS6d

---
_Generated by [Claude Code](https://claude.ai/code/session_017vC5mYsXaejV6aBWkGdS6d)_