### PR TITLE
Aggregate batched fix PRs (staging → main)

### DIFF
--- a/biocypher/_config/__init__.py
+++ b/biocypher/_config/__init__.py
@@ -124,7 +124,12 @@ def config(*args, **kwargs) -> Optional[Any]:
         return result[0] if len(result) == 1 else result
 
     for key, value in kwargs.items():
-        globals()["_config"][key].update(value)
+        if value is None:
+            globals()["_config"][key] = None
+        elif key in globals()["_config"] and isinstance(globals()["_config"][key], dict) and isinstance(value, dict):
+            globals()["_config"][key].update(value)
+        else:
+            globals()["_config"][key] = value
 
 
 def reset():

--- a/biocypher/_config/__init__.py
+++ b/biocypher/_config/__init__.py
@@ -81,6 +81,9 @@ def read_config() -> dict:
     # TODO account for .yml?
     local = _read_yaml("biocypher_config.yaml") or _read_yaml("config/biocypher_config.yaml") or {}
 
+    _warn_unknown_keys(local, defaults, "biocypher_config.yaml")
+    _warn_unknown_keys(user, defaults, "user config")
+
     for key in defaults:
         # Apply user-level settings on top of defaults first.
         # An explicit `null` in user config clears the default (e.g.
@@ -106,6 +109,20 @@ def read_config() -> dict:
                 defaults[key] = value
 
     return defaults
+
+
+def _warn_unknown_keys(config_dict: dict, valid_keys: dict, source: str) -> None:
+    """Warn about keys in config_dict that are not recognised in valid_keys."""
+    for key in config_dict:
+        if key not in valid_keys:
+            valid = sorted(k for k in valid_keys if k != "Title")
+            warnings.warn(
+                f"Unknown configuration key '{key}' found in {source}. "
+                f"This may be a misspelling. Valid top-level keys are: "
+                f"{', '.join(valid)}.",
+                category=UserWarning,
+                stacklevel=4,
+            )
 
 
 def config(*args, **kwargs) -> Optional[Any]:

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -183,6 +183,22 @@ sqlite:
   # import_call_bin_prefix: '' # path to "sqlite3"
   # import_call_file_prefix: '/path/to/files'
 
+arangodb:
+  ### ArangoDB configuration ###
+  database_name: biocypher # DB name
+
+  # ArangoDB import batch writer settings
+
+  delimiter: ","
+  array_delimiter: "|"
+  quote_character: '"'
+  # import_call_bin_prefix: '' # path to "arangoimp"
+  # import_call_file_prefix: '/path/to/files'
+
+  labels_order: "Ascending" # Default: From more specific to more generic.
+  node_labels_order: "None" # Default: use labels_order.
+  edge_labels_order: "None"
+
 csv:
   ### CSV/Pandas configuration ###
   delimiter: ","

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -183,6 +183,10 @@ sqlite:
   # import_call_bin_prefix: '' # path to "sqlite3"
   # import_call_file_prefix: '/path/to/files'
 
+  labels_order: "Ascending" # Default: From more specific to more generic.
+  node_labels_order: "None" # Default: use labels_order.
+  edge_labels_order: "None"
+
 arangodb:
   ### ArangoDB configuration ###
   database_name: biocypher # DB name

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -119,6 +119,8 @@ neo4j:
   skip_duplicate_nodes: false
   skip_bad_relationships: false
 
+  # import_call_additional_options: '--report-file="/import.report" --bad-tolerance=-1'
+
   ## Import call prefixes
 
   # import_call_bin_prefix: bin/

--- a/biocypher/_config/biocypher_config.yaml
+++ b/biocypher/_config/biocypher_config.yaml
@@ -211,6 +211,10 @@ networkx:
   ### NetworkX configuration ###
   some_config: some_value # placeholder for technical reasons TODO
 
+airr:
+  ### AIRR configuration ###
+  some_config: some_value # placeholder for technical reasons TODO
+
 biopathnet:
   file_format: txt
   entity_types_file_stem: entity_types

--- a/biocypher/_config/test_schema_config.yaml
+++ b/biocypher/_config/test_schema_config.yaml
@@ -6,7 +6,7 @@ Title: BioCypher graph schema configuration file
 
 protein:
   represented_as: node
-  preferred_id: uniprot
+  namespace: uniprot
   input_label: protein
   db_collection_name: proteins
   properties:
@@ -17,40 +17,40 @@ protein:
 
 microRNA:
   represented_as: node
-  preferred_id: mirbase.mature
+  namespace: mirbase.mature
   input_label: mirna
 
 complex:
   synonym_for: macromolecular complex
   represented_as: node
-  preferred_id: complexportal
+  namespace: complexportal
   input_label: complex
 
 pathway:
   represented_as: node
-  preferred_id: [reactome, wikipathways]
+  namespace: [reactome, wikipathways]
   input_label: [reactome, wikipathways]
 
 gene:
   represented_as: node
-  preferred_id: hgnc
+  namespace: hgnc
   input_label: [hgnc, ensg]
   exclude_properties: accession
 
 disease:
   represented_as: node
-  preferred_id: doid
+  namespace: doid
   input_label: Disease
 
 side effect:
   is_a: phenotypic feature
   represented_as: node
-  preferred_id: sider.effect
+  namespace: sider.effect
   input_label: sider
 
 sequence variant:
   represented_as: node
-  preferred_id: [clinically relevant, known, somatic]
+  namespace: [clinically relevant, known, somatic]
   input_label: [Clinically_relevant_variant, Known_variant, Somatic_mutation]
   properties:
     source: str
@@ -61,7 +61,7 @@ sequence variant:
 snRNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: [intact, rnacentral]
+  namespace: [intact, rnacentral]
   input_label: [intact_snrna, rnacentral_snrna]
   properties:
     ac: str
@@ -73,7 +73,7 @@ snRNA sequence:
 DNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: ensembl
+  namespace: ensembl
   input_label: dna
   properties:
     ac: str
@@ -86,7 +86,7 @@ dsDNA sequence:
   is_a: [DNA sequence, nucleic acid entity]
   inherit_properties: True
   represented_as: node
-  preferred_id: [intact, uniparc]
+  namespace: [intact, uniparc]
   input_label: [intact_dsdna, uniprot_archive_dsdna]
 
 # ---

--- a/biocypher/_config/test_schema_config_extended.yaml
+++ b/biocypher/_config/test_schema_config_extended.yaml
@@ -6,7 +6,7 @@ Title: BioCypher graph schema configuration file
 
 protein:
   represented_as: node
-  preferred_id: uniprot
+  namespace: uniprot
   input_label: protein
   db_collection_name: proteins
   properties:
@@ -17,40 +17,40 @@ protein:
 
 microRNA:
   represented_as: node
-  preferred_id: mirbase.mature
+  namespace: mirbase.mature
   input_label: mirna
 
 complex:
   synonym_for: macromolecular complex
   represented_as: node
-  preferred_id: complexportal
+  namespace: complexportal
   input_label: complex
 
 pathway:
   represented_as: node
-  preferred_id: [reactome, wikipathways]
+  namespace: [reactome, wikipathways]
   input_label: [reactome, wikipathways]
 
 gene:
   represented_as: node
-  preferred_id: hgnc
+  namespace: hgnc
   input_label: [hgnc, ensg]
   exclude_properties: accession
 
 disease:
   represented_as: node
-  preferred_id: doid
+  namespace: doid
   input_label: Disease
 
 side effect:
   is_a: phenotypic feature
   represented_as: node
-  preferred_id: sider.effect
+  namespace: sider.effect
   input_label: sider
 
 sequence variant:
   represented_as: node
-  preferred_id: [clinically relevant, known, somatic]
+  namespace: [clinically relevant, known, somatic]
   input_label: [Clinically_relevant_variant, Known_variant, Somatic_mutation]
   properties:
     source: str
@@ -73,7 +73,7 @@ lethal variant:
 snRNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: [intact, rnacentral]
+  namespace: [intact, rnacentral]
   input_label: [intact_snrna, rnacentral_snrna]
   properties:
     ac: str
@@ -85,7 +85,7 @@ snRNA sequence:
 DNA sequence:
   is_a: nucleic acid entity
   represented_as: node
-  preferred_id: ensembl
+  namespace: ensembl
   input_label: dna
   properties:
     ac: str
@@ -98,7 +98,7 @@ dsDNA sequence:
   is_a: [DNA sequence, nucleic acid entity]
   inherit_properties: True
   represented_as: node
-  preferred_id: [intact, uniparc]
+  namespace: [intact, uniparc]
   input_label: [intact_dsdna, uniprot_archive_dsdna]
 
 # ---

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -191,9 +191,9 @@ class BioCypher:
 
         """
         if isinstance(nodes, list):
-            self._nodes = list(itertools.chain(self._nodes, nodes))
+            self._nodes = list(itertools.chain(self._nodes or [], nodes))
         else:
-            self._nodes = itertools.chain(self._nodes, nodes)
+            self._nodes = itertools.chain(self._nodes or iter([]), nodes)
 
     def add_edges(self, edges) -> None:
         """Add new edges to the internal representation.
@@ -207,9 +207,9 @@ class BioCypher:
 
         """
         if isinstance(edges, list):
-            self._edges = list(itertools.chain(self._edges, edges))
+            self._edges = list(itertools.chain(self._edges or [], edges))
         else:
-            self._edges = itertools.chain(self._edges, edges)
+            self._edges = itertools.chain(self._edges or iter([]), edges)
 
     def to_df(self):
         """Create DataFrame using internal representation.
@@ -246,8 +246,7 @@ class BioCypher:
         if not self._translator:
             self._get_translator()
 
-        # These attributes might not exist when using in-memory KG directly
-        if hasattr(self, "_nodes") and hasattr(self, "_edges"):
+        if self._nodes is not None and self._edges is not None:
             tnodes = self._translator.translate_entities(self._nodes)
             tedges = self._translator.translate_entities(self._edges)
             self._in_memory_kg.add_nodes(tnodes)

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -806,8 +806,8 @@ class BioCypher:
             str: The BioCypher equivalent of the term.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.translate_term(term)
 
@@ -832,8 +832,8 @@ class BioCypher:
             str: The original term.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.reverse_translate_term(term)
 
@@ -849,8 +849,8 @@ class BioCypher:
             str: The BioCypher equivalent of the query.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.translate(query)
 
@@ -866,7 +866,7 @@ class BioCypher:
             str: The original query.
 
         """
-        # instantiate adapter if not exists
-        self.start_ontology()
+        if not self._translator:
+            self._get_translator()
 
         return self._translator.reverse_translate(query)

--- a/biocypher/_core.py
+++ b/biocypher/_core.py
@@ -165,8 +165,6 @@ class BioCypher:
         self._writer = None
         self._driver = None
         self._in_memory_kg = None
-
-        self._in_memory_kg = None
         self._nodes = None
         self._edges = None
 
@@ -450,7 +448,7 @@ class BioCypher:
 
     def _is_online_and_in_memory(self) -> bool:
         """Return True if in online mode and in-memory dbms is used."""
-        return (not self._offline) & (self._dbms in IN_MEMORY_DBMS)
+        return (not self._offline) and (self._dbms in IN_MEMORY_DBMS)
 
     def write_nodes(
         self,
@@ -555,14 +553,11 @@ class BioCypher:
         dataframes or a NetworkX DiGraph.
         """
         if not self._is_online_and_in_memory():
-            msg = (f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}.",)
+            msg = f"Getting the in-memory KG is only available in online mode for {IN_MEMORY_DBMS}."
             raise ValueError(msg)
         if not self._in_memory_kg:
             msg = "No in-memory KG instance found. Please call `add()` first."
             raise ValueError(msg)
-
-        if not self._in_memory_kg:
-            self._initialize_in_memory_kg()
         return self._in_memory_kg.get_kg()
 
     # DOWNLOAD AND CACHE MANAGEMENT METHODS ###

--- a/biocypher/_get.py
+++ b/biocypher/_get.py
@@ -283,8 +283,18 @@ class Downloader:
             paths.append(api_path)
         return paths
 
+    # Archive suffixes that pooch keeps in the cache dir after extraction.
+    # We skip these so that get_cached_version returns the same extracted
+    # file paths that the initial download returned, not the archives.
+    _ARCHIVE_SUFFIXES = (".zip", ".tar.gz", ".tgz", ".tar", ".gz", ".bz2")
+
     def get_cached_version(self, resource: Resource) -> list[str]:
         """Get the cached version of a resource.
+
+        Walks the resource's cache directory recursively and returns paths to
+        all non-archive files.  This mirrors what the initial download returns:
+        for plain files the file itself, and for archives the extracted
+        contents rather than the archive or an unzip sub-directory.
 
         Args:
         ----
@@ -298,8 +308,10 @@ class Downloader:
         cached_location = os.path.join(self.cache_dir, resource.name)
         logger.info(f"Use cached version from {cached_location}.")
         paths = []
-        for file in os.listdir(cached_location):
-            paths.append(os.path.join(cached_location, file))
+        for dirpath, _, filenames in os.walk(cached_location):
+            for filename in filenames:
+                if not any(filename.endswith(suffix) for suffix in self._ARCHIVE_SUFFIXES):
+                    paths.append(os.path.join(dirpath, filename))
         return paths
 
     def _retrieve(

--- a/biocypher/_misc.py
+++ b/biocypher/_misc.py
@@ -102,7 +102,7 @@ def _get_inheritance_tree(inheritance_graph: dict | nx.Graph) -> dict | None:
                 "following hierarchy tree (the child node is only added once). "
                 "If you wish to browse all relationships of the parsed "
                 "ontologies, write a graphml file to disk using "
-                "`to_disk = <directory>` and view this file.",
+                "`to_disk = <directory>` and view this file."
             )
             logger.warning(msg)
         # unlist values

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -786,7 +786,7 @@ class Ontology:
                 "ontology, but have not provided a schema configuration. "
                 "To display a partial ontology graph, please provide a schema "
                 "configuration file; to visualise the full graph, please use "
-                "the parameter `full = True`.",
+                "the parameter `full = True`."
             )
             logger.error(msg)
             raise ValueError(msg)

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -249,12 +249,12 @@ class OntologyAdapter:
 
         """
         for node in list(nx_graph.nodes):
-            nx_id, nx_label = self._get_nx_id_and_label(node, switch_label_and_id)
-            if nx_id == "none":
-                # remove node if it has no id
+            if not self.has_label(node, self._rdf_graph):
+                logger.debug(f"Node '{node}' has no rdfs:label in the ontology and will be removed.")
                 nx_graph.remove_node(node)
                 continue
 
+            _, nx_label = self._get_nx_id_and_label(node, switch_label_and_id)
             nx_graph.nodes[node]["label"] = nx_label
         return nx_graph
 
@@ -333,8 +333,9 @@ class OntologyAdapter:
 
         """
         node_id_str = self._remove_prefix(str(node))
-        node_label_str = str(self._rdf_graph.value(node, rdflib.RDFS.label))
-        if rename_nodes:
+        rdf_label = self._rdf_graph.value(node, rdflib.RDFS.label)
+        node_label_str = str(rdf_label) if rdf_label is not None else ""
+        if rename_nodes and node_label_str:
             node_label_str = node_label_str.replace("_", " ")
             node_label_str = to_lower_sentence_case(node_label_str)
         nx_id = node_label_str if switch_id_and_label else node_id_str

--- a/biocypher/_ontology.py
+++ b/biocypher/_ontology.py
@@ -781,7 +781,7 @@ class Ontology:
         """
         if not full and not self.mapping.extended_schema:
             msg = (
-                "You are attempting to visualise a subset of the loaded"
+                "You are attempting to visualise a subset of the loaded "
                 "ontology, but have not provided a schema configuration. "
                 "To display a partial ontology graph, please provide a schema "
                 "configuration file; to visualise the full graph, please use "

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -164,7 +164,7 @@ class Translator:
 
         if not isinstance(filter_props, dict):
             msg = (
-                f"Properties for type {bl_type} should be a dictonary. Verify your schema (did you declared "
+                f"Properties for type {bl_type} should be a dictionary. Verify your schema (did you declare "
                 "properties as a list?)"
             )
             logger.error(msg)

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -105,7 +105,7 @@ class Translator:
                     if prop not in _props:
                         msg = (
                             f"Property `{prop}` missing from node {_id}. "
-                            "Strict mode is enabled, so this is not allowed.",
+                            "Strict mode is enabled, so this is not allowed."
                         )
                         logger.error(msg)
                         raise ValueError(msg)
@@ -241,21 +241,21 @@ class Translator:
                 if "source" not in _props:
                     msg = (
                         f"Edge {_id if _id else (_src, _tar)} does not have a `source` property."
-                        " This is required in strict mode.",
+                        " This is required in strict mode."
                     )
                     logger.error(msg)
                     raise ValueError(msg)
                 if "licence" not in _props:
                     msg = (
                         f"Edge {_id if _id else (_src, _tar)} does not have a `licence` property."
-                        " This is required in strict mode.",
+                        " This is required in strict mode."
                     )
                     logger.error(msg)
                     raise ValueError(msg)
                 if "version" not in _props:
                     msg = (
                         f"Edge {_id if _id else (_src, _tar)} does not have a `version` property."
-                        " This is required in strict mode.",
+                        " This is required in strict mode."
                     )
                     logger.error(msg)
                     raise ValueError(msg)
@@ -439,7 +439,7 @@ class Translator:
                         "Reverse translation of multiple inputs not "
                         "implemented yet. Many-to-one mappings are "
                         "not reversible. "
-                        f"({key} -> {self.reverse_mappings[key]})",
+                        f"({key} -> {self.reverse_mappings[key]})"
                     )
                     logger.error(msg)
                     raise NotImplementedError(msg)

--- a/biocypher/_translate.py
+++ b/biocypher/_translate.py
@@ -171,7 +171,9 @@ class Translator:
             raise AttributeError(msg)
 
         # strict mode: add required properties (only if there is a whitelist)
+        # copy to avoid permanently mutating the shared schema dict
         if self.strict_mode and filter_props:
+            filter_props = dict(filter_props)
             filter_props.update(
                 {"source": "str", "licence": "str", "version": "str"},
             )

--- a/biocypher/_workflow.py
+++ b/biocypher/_workflow.py
@@ -205,7 +205,10 @@ class BioCypherWorkflow:
         Returns:
             bool: True if node was removed, False if not found
         """
-        return self.graph.remove_node(node_id)
+        result = self.graph.remove_node(node_id)
+        if result:
+            self._seen_nodes.discard(node_id)
+        return result
 
     # ==================== EDGE OPERATIONS ====================
 
@@ -311,6 +314,10 @@ class BioCypherWorkflow:
         Returns:
             bool: True if edge was removed, False if not found
         """
+        if self.deduplication:
+            edge = self.graph.get_edge(edge_id)
+            if edge is not None:
+                self._seen_edges.discard((edge_id, edge.type))
         return self.graph.remove_edge(edge_id)
 
     # ==================== HYPEREDGE OPERATIONS ====================
@@ -619,6 +626,9 @@ class BioCypherWorkflow:
         data = json.loads(json_data)
         self.graph = Graph.from_dict(data)
         self.name = self.graph.name
+        if self.deduplication:
+            self._seen_nodes = {node.id for node in self.graph.get_nodes()}
+            self._seen_edges = {(edge.id, edge.type) for edge in self.graph.get_edges()}
 
     def save(self, filepath: str) -> None:
         """Save the graph to a file.
@@ -646,6 +656,8 @@ class BioCypherWorkflow:
     def clear(self) -> None:
         """Clear all nodes and edges from the graph."""
         self.graph = Graph(name=self.name, directed=self.graph.directed)
+        self._seen_nodes.clear()
+        self._seen_edges.clear()
         logger.info("Graph cleared")
 
     def copy(self) -> "BioCypherWorkflow":

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -144,6 +144,7 @@ class _BatchWriter(_Writer, ABC):
         strict_mode: bool = False,
         skip_bad_relationships: bool = False,
         skip_duplicate_nodes: bool = False,
+        import_call_additional_options: str | None = None,
         db_user: str = None,
         db_password: str = None,
         db_host: str = None,
@@ -224,6 +225,10 @@ class _BatchWriter(_Writer, ABC):
             skip_duplicate_nodes:
                 Whether to skip duplicate nodes. (Specific to Neo4j.)
 
+            import_call_additional_options:
+                Optional string of extra flags to append verbatim to the
+                generated neo4j-admin import command. (Specific to Neo4j.)
+
             db_user:
                 The database user.
 
@@ -288,6 +293,7 @@ class _BatchWriter(_Writer, ABC):
         self.quote = quote
         self.skip_bad_relationships = skip_bad_relationships
         self.skip_duplicate_nodes = skip_duplicate_nodes
+        self.import_call_additional_options = import_call_additional_options
 
         if import_call_bin_prefix is None:
             self.import_call_bin_prefix = self._get_default_import_call_bin_prefix()

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -369,7 +369,7 @@ class _BatchWriter(_Writer, ABC):
                 logger.info(msg)
 
             if self.edge_labels_order == "None":
-                msg = f"`node_labels_order` set to `labels_order`=`{self.labels_order}`."
+                msg = f"`edge_labels_order` set to `labels_order`=`{self.labels_order}`."
                 self.edge_labels_order = self.labels_order
                 logger.info(msg)
 

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -331,7 +331,7 @@ class _BatchWriter(_Writer, ABC):
             if getattr(self, order) is None:
                 msg = (
                     f"A batch writer `{order}` parameter must be set, "
-                    f"it must be one of: {', '.join(self._labels_orders)}.",
+                    f"it must be one of: {', '.join(self._labels_orders)}."
                 )
                 logger.error(msg)
                 raise ValueError(msg)
@@ -339,7 +339,7 @@ class _BatchWriter(_Writer, ABC):
             if getattr(self, order) not in self._labels_orders:
                 msg = (
                     f"A batch writer `{order}` parameter cannot be `{getattr(self, order)}`, "
-                    f"it must be one of: {', '.join(self._labels_orders)}.",
+                    f"it must be one of: {', '.join(self._labels_orders)}."
                 )
                 logger.error(msg)
                 raise ValueError(msg)

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -344,7 +344,7 @@ class _BatchWriter(_Writer, ABC):
         if self.labels_order == "None" and (self.node_labels_order == "None" or self.edge_labels_order == "None"):
             msg = (
                 "You have to set either `labels_order` or "
-                "both `node_labels_order` and `edge_labels_order`."
+                "both `node_labels_order` and `edge_labels_order`. "
                 "Current setting:\n"
                 f"- labels_order = `{self.labels_order}`\n"
                 f"- node_labels_order = `{self.node_labels_order}`\n"

--- a/biocypher/output/write/_batch_writer.py
+++ b/biocypher/output/write/_batch_writer.py
@@ -1241,7 +1241,8 @@ def parse_label(label: str) -> str:
     """Check if the label is compliant with Neo4j naming conventions.
 
     Check against https://neo4j.com/docs/cypher-manual/current/syntax/naming/,
-    and if not compliant, remove non-compliant characters.
+    and if not compliant, remove non-compliant characters. Dots are replaced
+    with underscores to avoid the need for backtick escaping in Cypher queries.
 
     Args:
     ----
@@ -1250,9 +1251,11 @@ def parse_label(label: str) -> str:
         str: The compliant label
 
     """
-    # Check if the name contains only alphanumeric characters, underscore, or dollar sign
-    # and dot (for class hierarchy of BioCypher)
-    allowed_chars = r"a-zA-Z0-9_$ ."
+    # Replace dots with underscores to avoid backtick-escaping requirements in Neo4j
+    label = label.replace(".", "_")
+
+    # Check if the name contains only alphanumeric characters, underscore, dollar sign, or space
+    allowed_chars = r"a-zA-Z0-9_$ "
     matches = re.findall(f"[{allowed_chars}]", label)
     non_matches = re.findall(f"[^{allowed_chars}]", label)
     if non_matches:

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -129,6 +129,7 @@ def get_writer(
             import_call_additional_options=dbms_config.get("import_call_additional_options"),  # neo4j
             db_user=dbms_config.get("user"),  # psql
             db_password=dbms_config.get("password"),  # psql
+            db_host=dbms_config.get("host"),  # psql
             db_port=dbms_config.get("port"),  # psql
             file_format=dbms_config.get("file_format"),  # rdf, owl
             rdf_namespaces=dbms_config.get("rdf_namespaces"),  # rdf, owl

--- a/biocypher/output/write/_get_writer.py
+++ b/biocypher/output/write/_get_writer.py
@@ -126,6 +126,7 @@ def get_writer(
             edge_labels_order=dbms_config.get("edge_labels_order"),  # batch writer
             skip_bad_relationships=dbms_config.get("skip_bad_relationships"),  # neo4j
             skip_duplicate_nodes=dbms_config.get("skip_duplicate_nodes"),  # neo4j
+            import_call_additional_options=dbms_config.get("import_call_additional_options"),  # neo4j
             db_user=dbms_config.get("user"),  # psql
             db_password=dbms_config.get("password"),  # psql
             db_port=dbms_config.get("port"),  # psql

--- a/biocypher/output/write/graph/_biopathnet.py
+++ b/biocypher/output/write/graph/_biopathnet.py
@@ -69,7 +69,11 @@ class _BioPathNetWriter(_Writer):
         dict_entity_types = {}
         str_nodes_props_graph = []
 
-        graph_hierarchy = copy.copy(self.translator.ontology._head_ontology.get_nx_graph()).reverse()
+        # Use the full Ontology graph (with synonym relabeling applied) so that
+        # user-defined synonym labels (e.g. "complex" -> "macromolecular complex")
+        # are found in the hierarchy.  The raw _head_ontology graph only contains
+        # canonical labels and would crash on any synonym type.
+        graph_hierarchy = copy.copy(self.translator.ontology._nx_graph).reverse()
         logger.debug(f"type(graph_hierarchy) = {type(graph_hierarchy)}")
         logger.debug(f"graph_hierarchy = {graph_hierarchy.nodes()}")
         ancestors_set = set()
@@ -90,6 +94,13 @@ class _BioPathNetWriter(_Writer):
 
             # Add all ancestors of the entity type in the set, in order to reconstruct
             # the useful part of the ontology for passing it to BioPathNet
+            if semantic_type not in graph_hierarchy:
+                logger.warning(
+                    f"Semantic type '{semantic_type}' not found in ontology graph. "
+                    "Skipping ancestor lookup for this node type."
+                )
+                ancestors_set.add(semantic_type)
+                continue
             ancestors = nx.ancestors(graph_hierarchy, semantic_type) | {semantic_type}
             logger.debug(f"Adding the type : {semantic_type}")
             logger.debug(f"Ancestors : {ancestors}")

--- a/biocypher/output/write/graph/_neo4j.py
+++ b/biocypher/output/write/graph/_neo4j.py
@@ -438,6 +438,8 @@ class _Neo4jBatchWriter(_BatchWriter):
             import_call += "--skip-bad-relationships=true "
         if self.skip_duplicate_nodes:
             import_call += "--skip-duplicate-nodes=true "
+        if self.import_call_additional_options:
+            import_call += f"{self.import_call_additional_options} "
 
         # append node import calls
         for header_path, parts_path in self.import_call_nodes:
@@ -472,6 +474,7 @@ class _Neo4jBatchWriter(_BatchWriter):
         import_call.append(f"{wipe_cmd}true " if self.wipe else "")
         import_call.append("--skip-bad-relationships=true " if self.skip_bad_relationships else "")
         import_call.append("--skip-duplicate-nodes=true " if self.skip_duplicate_nodes else "")
+        import_call.append(f"{self.import_call_additional_options} " if self.import_call_additional_options else "")
         import_call.extend(
             f'--nodes="{header_path},{parts_path}" ' for header_path, parts_path in self.import_call_nodes
         )

--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -54,7 +54,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
         try:
             return self.DATA_TYPE_LOOKUP[string]
         except KeyError:
-            logger.info('Could not determine data type {string}. Using default "VARCHAR"')
+            logger.info(f'Could not determine data type {string}. Using default "VARCHAR"')
             return "VARCHAR"
 
     def _quote_string(self, value: str) -> str:

--- a/biocypher/output/write/relational/_postgresql.py
+++ b/biocypher/output/write/relational/_postgresql.py
@@ -300,7 +300,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
             *self.import_call_edges,
         ]:
             import_call += f'echo "Setup {import_file_path}..."\n'
-            if {self.db_password}:
+            if self.db_password:
                 # set password variable inline
                 import_call += f"PGPASSWORD={self.db_password} "
             import_call += f"{self.import_call_bin_prefix}psql -f {import_file_path}"
@@ -315,7 +315,7 @@ class _PostgreSQLBatchWriter(_BatchWriter):
         for command in self._copy_from_csv_commands:
             table_part = command.split(" ")[3]
             import_call += f'echo "Importing {table_part}..."\n'
-            if {self.db_password}:
+            if self.db_password:
                 # set password variable inline
                 import_call += f"PGPASSWORD={self.db_password} "
             import_call += f'{self.import_call_bin_prefix}psql -c "{command}"'

--- a/test/ontologies/missing_label_parent.ttl
+++ b/test/ontologies/missing_label_parent.ttl
@@ -1,0 +1,20 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+owl:ID_root a owl:Class ;
+     rdfs:label "Test_Missing_Parent_Label_Root" ;
+     rdfs:comment "The root class." .
+
+owl:ID_level1 a owl:Class ;
+     rdfs:label "Test_Missing_Parent_Label_Level1" ;
+     rdfs:subClassOf owl:ID_root ;
+     rdfs:comment "Level1 - has a label and valid parent." .
+
+owl:ID_level2 a owl:Class ;
+     rdfs:label "Test_Missing_Parent_Label_Level2" ;
+     rdfs:subClassOf owl:ID_parent_no_label ;
+     rdfs:comment "Level2 - its parent has no label." .
+
+owl:ID_parent_no_label a owl:Class ;
+     rdfs:comment "No label on this parent node." ;
+     rdfs:subClassOf owl:ID_root .

--- a/test/output/write/graph/test_biopathnet.py
+++ b/test/output/write/graph/test_biopathnet.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from biocypher._create import BioCypherNode
 from biocypher._logger import logger
 
 
@@ -36,6 +37,39 @@ def test_biopathnet_writer_nodes(bw_biopathnet, _get_nodes):
 #        lines = f.readlines()
 #        len_lines = len(lines)
 #    assert len(nodes) == len_lines
+
+
+def test_biopathnet_writer_nodes_synonym_type(bw_biopathnet, tmp_path_session):
+    """Regression test for issue #489.
+
+    Nodes whose type is a schema synonym (e.g. 'complex' -> 'macromolecular
+    complex') must be written without raising a NetworkXError because the
+    full Ontology graph (with synonyms relabeled) is used for ancestor lookup
+    rather than the raw head-ontology graph.
+    """
+    synonym_nodes = [
+        BioCypherNode(
+            node_id="cpx1",
+            node_label="complex",
+            preferred_id="complexportal",
+            properties={},
+        ),
+        BioCypherNode(
+            node_id="cpx2",
+            node_label="complex",
+            preferred_id="complexportal",
+            properties={},
+        ),
+    ]
+
+    passed = bw_biopathnet.write_nodes(iter(synonym_nodes), batch_size=1e6)
+    assert passed
+
+    entity_types_file = os.path.join(tmp_path_session, "entity_types.txt")
+    assert os.path.exists(entity_types_file)
+    content = open(entity_types_file).read()
+    assert "cpx1" in content
+    assert "complex" in content
 
 
 @pytest.mark.parametrize("length", [4], scope="module")

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -410,7 +410,7 @@ def test_write_node_data_from_list_not_compliant_names(monkeypatch, caplog, bw, 
 
     expected_file_names = [
         "PatientPerson-part000.csv",
-        "$He524lloWor.Ld-part000.csv",
+        "$He524lloWor_ld-part000.csv",
     ]
     for file_name in os.listdir(tmp_path):
         assert file_name in expected_file_names
@@ -1303,11 +1303,11 @@ def test_check_label_name():
     # Test case 4: label starts with a non-alphanumeric character
     assert parse_label("@Invalid_Label") == "Invalid_Label"
 
-    # Additional test case: label with dot (for class hierarchy of BioCypher)
-    assert parse_label("valid.label") == "valid.label"
+    # Dots are replaced with underscores to avoid backtick-escaping in Cypher queries
+    assert parse_label("valid.label") == "valid_label"
 
-    # Additional test case: label with dot and non-compliant characters
-    assert parse_label("In.valid.Label@1") == "In.valid.Label1"
+    # Dots replaced before other characters are stripped
+    assert parse_label("In.valid.Label@1") == "In_valid_Label1"
 
     # Test case: label contains only non-compliant characters (would previously crash with IndexError)
     assert parse_label("@#^&") == ""

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1526,3 +1526,24 @@ def test_quote_escaped_in_edge_string_property(bw):
 
     assert passed
     assert "'T''253'" in content, f"Escaped quote not found in: {content!r}"
+
+
+def test_check_labels_order_none_raises_string_error(bw):
+    """_check_labels_order must raise ValueError with a plain-string message when
+    a labels_order attribute is None, not a one-element tuple."""
+    bw.node_labels_order = None
+    with pytest.raises(ValueError) as exc_info:
+        bw._check_labels_order()
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "node_labels_order" in exc_info.value.args[0]
+
+
+def test_check_labels_order_invalid_raises_string_error(bw):
+    """_check_labels_order must raise ValueError with a plain-string message when
+    a labels_order attribute has an invalid value, not a one-element tuple."""
+    bw.node_labels_order = "Ascending"  # restore from previous test if needed
+    bw.edge_labels_order = "BadOrder"
+    with pytest.raises(ValueError) as exc_info:
+        bw._check_labels_order()
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "edge_labels_order" in exc_info.value.args[0]

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -406,12 +406,12 @@ def test_write_node_data_non_string_list_properties(bw):
     # Verify that the inferred types in node_property_dict use "int[]" / "float[]"
     # rather than the bare "list" that type(v).__name__ would previously return.
     prop_types = bw.node_property_dict.get("post translational interaction", {})
-    assert prop_types.get("scores") == "int[]", (
-        f"Expected 'int[]' but got {prop_types.get('scores')!r}; list type inference is broken"
-    )
-    assert prop_types.get("weights") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('weights')!r}; list type inference is broken"
-    )
+    assert (
+        prop_types.get("scores") == "int[]"
+    ), f"Expected 'int[]' but got {prop_types.get('scores')!r}; list type inference is broken"
+    assert (
+        prop_types.get("weights") == "float[]"
+    ), f"Expected 'float[]' but got {prop_types.get('weights')!r}; list type inference is broken"
 
 
 @pytest.mark.parametrize("length", [4], scope="module")
@@ -973,12 +973,12 @@ def test_write_edge_data_non_string_list_properties(bw):
 
     assert passed
     prop_types = bw.edge_property_dict.get("phosphorylation", {})
-    assert prop_types.get("sites") == "str[]", (
-        f"Expected 'str[]' but got {prop_types.get('sites')!r}; list type inference is broken for edges"
-    )
-    assert prop_types.get("scores") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('scores')!r}; list type inference is broken for edges"
-    )
+    assert (
+        prop_types.get("sites") == "str[]"
+    ), f"Expected 'str[]' but got {prop_types.get('sites')!r}; list type inference is broken for edges"
+    assert (
+        prop_types.get("scores") == "float[]"
+    ), f"Expected 'float[]' but got {prop_types.get('scores')!r}; list type inference is broken for edges"
 
 
 @pytest.mark.parametrize("length", [8], scope="module")
@@ -1470,12 +1470,12 @@ def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator
             edge_labels_order="None",
         )
     messages = [r.message for r in caplog.records]
-    assert any("`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages), (
-        f"Expected edge_labels_order fallback log, got: {messages}"
-    )
-    assert not any("`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages), (
-        f"node_labels_order appeared in edge fallback log: {messages}"
-    )
+    assert any(
+        "`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"Expected edge_labels_order fallback log, got: {messages}"
+    assert not any(
+        "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"node_labels_order appeared in edge fallback log: {messages}"
 
 
 def test_quote_escaped_in_node_string_property(bw):
@@ -1501,9 +1501,9 @@ def test_quote_escaped_in_node_string_property(bw):
 
     assert passed
     assert "'O''Brien'" in content, f"Escaped quote not found in: {content!r}"
-    assert "'O'Brien'" not in content.replace("'O''Brien'", ""), (
-        "Unescaped quote found in output — _quote_string not called for node properties"
-    )
+    assert "'O'Brien'" not in content.replace(
+        "'O''Brien'", ""
+    ), "Unescaped quote found in output — _quote_string not called for node properties"
 
 
 def test_quote_escaped_in_edge_string_property(bw):

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1437,3 +1437,23 @@ def test_powershell_template_structure():
         "{args_neo4j_v5}",
     }
     assert expected_placeholders.issubset(set(placeholders))
+
+
+def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator, tmp_path):
+    """When edge_labels_order='None' the fallback log must name 'edge_labels_order', not 'node_labels_order'."""
+    with caplog.at_level(logging.INFO):
+        _Neo4jBatchWriter(
+            translator=translator,
+            deduplicator=deduplicator,
+            output_directory=str(tmp_path),
+            delimiter=";",
+            labels_order="Descending",
+            edge_labels_order="None",
+        )
+    messages = [r.message for r in caplog.records]
+    assert any(
+        "`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"Expected edge_labels_order fallback log, got: {messages}"
+    assert not any(
+        "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
+    ), f"node_labels_order appeared in edge fallback log: {messages}"

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -407,10 +407,10 @@ def test_write_node_data_non_string_list_properties(bw):
     # rather than the bare "list" that type(v).__name__ would previously return.
     prop_types = bw.node_property_dict.get("post translational interaction", {})
     assert prop_types.get("scores") == "int[]", (
-        f"Expected 'int[]' but got {prop_types.get('scores')!r}; " "list type inference is broken"
+        f"Expected 'int[]' but got {prop_types.get('scores')!r}; list type inference is broken"
     )
     assert prop_types.get("weights") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('weights')!r}; " "list type inference is broken"
+        f"Expected 'float[]' but got {prop_types.get('weights')!r}; list type inference is broken"
     )
 
 
@@ -974,10 +974,10 @@ def test_write_edge_data_non_string_list_properties(bw):
     assert passed
     prop_types = bw.edge_property_dict.get("phosphorylation", {})
     assert prop_types.get("sites") == "str[]", (
-        f"Expected 'str[]' but got {prop_types.get('sites')!r}; " "list type inference is broken for edges"
+        f"Expected 'str[]' but got {prop_types.get('sites')!r}; list type inference is broken for edges"
     )
     assert prop_types.get("scores") == "float[]", (
-        f"Expected 'float[]' but got {prop_types.get('scores')!r}; " "list type inference is broken for edges"
+        f"Expected 'float[]' but got {prop_types.get('scores')!r}; list type inference is broken for edges"
     )
 
 
@@ -1470,12 +1470,12 @@ def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator
             edge_labels_order="None",
         )
     messages = [r.message for r in caplog.records]
-    assert any(
-        "`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
-    ), f"Expected edge_labels_order fallback log, got: {messages}"
-    assert not any(
-        "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
-    ), f"node_labels_order appeared in edge fallback log: {messages}"
+    assert any("`edge_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages), (
+        f"Expected edge_labels_order fallback log, got: {messages}"
+    )
+    assert not any("`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages), (
+        f"node_labels_order appeared in edge fallback log: {messages}"
+    )
 
 
 def test_quote_escaped_in_node_string_property(bw):

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -209,6 +209,25 @@ def test_construct_import_call_powershell(bw):
     assert "import --database=neo4j" in import_script
 
 
+def test_import_call_additional_options(translator, deduplicator, tmp_path_session):
+    bw_extra = _Neo4jBatchWriter(
+        translator=translator,
+        deduplicator=deduplicator,
+        output_directory=tmp_path_session,
+        delimiter=";",
+        array_delimiter="|",
+        quote="'",
+        import_call_additional_options='--report-file="/import.report" --bad-tolerance=-1',
+    )
+
+    call = bw_extra._get_import_call("import", "--database=", "--force=")
+
+    assert '--report-file="/import.report" --bad-tolerance=-1' in call
+
+    for f in os.listdir(tmp_path_session):
+        os.remove(os.path.join(tmp_path_session, f))
+
+
 def test_write_hybrid_ontology_nodes(bw):
     nodes = []
     for i in range(4):

--- a/test/output/write/graph/test_neo4j.py
+++ b/test/output/write/graph/test_neo4j.py
@@ -1476,3 +1476,53 @@ def test_edge_labels_order_fallback_log_message(caplog, translator, deduplicator
     assert not any(
         "`node_labels_order` set to `labels_order`=`Descending`" in msg for msg in messages
     ), f"node_labels_order appeared in edge fallback log: {messages}"
+
+
+def test_quote_escaped_in_node_string_property(bw):
+    """String properties containing the quote character must be escaped by doubling it."""
+    nodes = [
+        BioCypherNode(
+            node_id="n1",
+            node_label="protein",
+            properties={
+                "score": 1.0,
+                "name": "O'Brien",
+                "taxon": 9606,
+                "genes": ["gene1"],
+            },
+        ),
+    ]
+
+    passed = bw._write_node_data(nodes, batch_size=int(1e4))
+
+    csv_path = os.path.join(bw.outdir, "Protein-part000.csv")
+    with open(csv_path) as f:
+        content = f.read()
+
+    assert passed
+    assert "'O''Brien'" in content, f"Escaped quote not found in: {content!r}"
+    assert "'O'Brien'" not in content.replace("'O''Brien'", ""), (
+        "Unescaped quote found in output — _quote_string not called for node properties"
+    )
+
+
+def test_quote_escaped_in_edge_string_property(bw):
+    """String properties containing the quote character must be escaped in edge output."""
+    edges = [
+        BioCypherEdge(
+            relationship_id="e1",
+            source_id="p1",
+            target_id="p2",
+            relationship_label="PERTURBED_IN_DISEASE",
+            properties={"residue": "T'253"},
+        ),
+    ]
+
+    passed = bw._write_edge_data(edges, batch_size=int(1e4))
+
+    csv_path = os.path.join(bw.outdir, "PERTURBED_IN_DISEASE-part000.csv")
+    with open(csv_path) as f:
+        content = f.read()
+
+    assert passed
+    assert "'T''253'" in content, f"Escaped quote not found in: {content!r}"

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -1,7 +1,18 @@
+import logging
 import os
 import subprocess
 
 import pytest
+
+from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
+
+
+def test_get_data_type_unknown_logs_actual_type_name(caplog):
+    writer = _PostgreSQLBatchWriter.__new__(_PostgreSQLBatchWriter)
+    with caplog.at_level(logging.INFO):
+        result = writer._get_data_type("some_unknown_type")
+    assert result == "VARCHAR"
+    assert "some_unknown_type" in caplog.text
 
 
 @pytest.mark.parametrize("length", [4], scope="module")

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -45,6 +45,35 @@ def test_get_writer_passes_db_host_to_postgresql_writer(translator, deduplicator
     assert writer.db_host == custom_host
 
 
+def _make_writer(db_password):
+    """Minimal _PostgreSQLBatchWriter with enough state to run _construct_import_call."""
+    writer = _PostgreSQLBatchWriter.__new__(_PostgreSQLBatchWriter)
+    writer.db_password = db_password
+    writer.db_name = "testdb"
+    writer.db_host = "localhost"
+    writer.db_port = "5432"
+    writer.db_user = "testuser"
+    writer.import_call_bin_prefix = ""
+    writer.import_call_nodes = {"/tmp/node-create_table.sql"}
+    writer.import_call_edges = set()
+    writer._copy_from_csv_commands = {r"\copy protein FROM '/tmp/Protein-part000.csv' DELIMITER E',' CSV;"}
+    return writer
+
+
+def test_import_call_no_pgpassword_when_password_is_none():
+    """PGPASSWORD must not appear when db_password is None (fixes set-literal bug)."""
+    writer = _make_writer(db_password=None)
+    import_call = writer._construct_import_call()
+    assert "PGPASSWORD" not in import_call
+
+
+def test_import_call_includes_pgpassword_when_password_is_set():
+    """PGPASSWORD=<value> must be prepended to psql calls when db_password is set."""
+    writer = _make_writer(db_password="s3cr3t")
+    import_call = writer._construct_import_call()
+    assert "PGPASSWORD=s3cr3t" in import_call
+
+
 @pytest.mark.parametrize("length", [4], scope="module")
 def test_write_node_data_from_gen_comma_postgresql(bw_comma_postgresql, _get_nodes):
     nodes = _get_nodes

--- a/test/output/write/relational/test_postgres.py
+++ b/test/output/write/relational/test_postgres.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
+from biocypher.output.write._get_writer import get_writer
 from biocypher.output.write.relational._postgresql import _PostgreSQLBatchWriter
 
 
@@ -13,6 +15,34 @@ def test_get_data_type_unknown_logs_actual_type_name(caplog):
         result = writer._get_data_type("some_unknown_type")
     assert result == "VARCHAR"
     assert "some_unknown_type" in caplog.text
+
+
+def test_get_writer_passes_db_host_to_postgresql_writer(translator, deduplicator, tmp_path):
+    """get_writer must forward the 'host' config key to the writer as db_host."""
+    custom_host = "my-custom-pg-host.example.com"
+    mock_config = {
+        "user": "testuser",
+        "password": "testpass",
+        "host": custom_host,
+        "port": "5432",
+        "database_name": "testdb",
+        "delimiter": "\t",
+        "quote_character": '"',
+        "labels_order": "Ascending",
+        "node_labels_order": "None",
+        "edge_labels_order": "None",
+    }
+
+    with patch("biocypher.output.write._get_writer._config", return_value=mock_config):
+        writer = get_writer(
+            dbms="postgresql",
+            translator=translator,
+            deduplicator=deduplicator,
+            output_directory=str(tmp_path),
+            strict_mode=False,
+        )
+
+    assert writer.db_host == custom_host
 
 
 @pytest.mark.parametrize("length", [4], scope="module")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -60,8 +60,8 @@ def test_config_setter_merges_dict_for_known_key():
 def test_config_setter_creates_new_key():
     """config(key=value) must not raise KeyError for a key absent from defaults."""
     try:
-        config(arangodb={"database_name": "mydb"})
-        result = config("arangodb")
+        config(custom_unknown_dbms={"database_name": "mydb"})
+        result = config("custom_unknown_dbms")
         assert result == {"database_name": "mydb"}
     finally:
         reset()
@@ -81,10 +81,10 @@ def test_update_from_file_with_unknown_key(tmp_path):
     from biocypher._config import update_from_file
 
     cfg_file = tmp_path / "biocypher_config.yaml"
-    cfg_file.write_text("arangodb:\n  database_name: mydb\n")
+    cfg_file.write_text("custom_unknown_dbms:\n  database_name: mydb\n")
     try:
         update_from_file(str(cfg_file))
-        assert config("arangodb") == {"database_name": "mydb"}
+        assert config("custom_unknown_dbms") == {"database_name": "mydb"}
     finally:
         reset()
 
@@ -105,3 +105,26 @@ def test_arangodb_config_present_in_defaults():
     assert arango_cfg is not None, "arangodb section missing from defaults config"
     assert "labels_order" in arango_cfg, "labels_order must be set so get_writer doesn't pass None"
     assert "delimiter" in arango_cfg, "delimiter must be set for ArangoDB CSV output"
+
+
+def test_sqlite_config_has_labels_order():
+    """SQLite section must have labels_order keys so get_writer("sqlite") doesn't crash.
+
+    Previously, the `sqlite` section in biocypher_config.yaml was missing
+    `labels_order`, `node_labels_order`, and `edge_labels_order`. Because
+    get_writer passes these keys from config to _BatchWriter.__init__, the
+    missing keys caused None to be forwarded, overriding the parameter defaults.
+    _check_labels_order() then raised a ValueError on first use, making the
+    SQLite writer completely unusable via BioCypher(dbms="sqlite").
+    """
+    from biocypher._config import reset
+
+    reset()  # ensure we're reading from the real defaults file
+
+    sqlite_cfg = _config("sqlite")
+
+    assert sqlite_cfg is not None, "sqlite section missing from defaults config"
+    assert "labels_order" in sqlite_cfg, "labels_order must be set so get_writer doesn't pass None"
+    assert "node_labels_order" in sqlite_cfg, "node_labels_order must be set so get_writer doesn't pass None"
+    assert "edge_labels_order" in sqlite_cfg, "edge_labels_order must be set so get_writer doesn't pass None"
+    assert "delimiter" in sqlite_cfg, "delimiter must be set for SQLite CSV output"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import biocypher._config as cfg_module
 
-from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, config as _config, reset
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE, _warn_unknown_keys, config, config as _config, reset
 
 
 def test_read_yaml():
@@ -128,3 +128,22 @@ def test_sqlite_config_has_labels_order():
     assert "node_labels_order" in sqlite_cfg, "node_labels_order must be set so get_writer doesn't pass None"
     assert "edge_labels_order" in sqlite_cfg, "edge_labels_order must be set so get_writer doesn't pass None"
     assert "delimiter" in sqlite_cfg, "delimiter must be set for SQLite CSV output"
+
+
+def test_warn_unknown_keys_emits_warning():
+    valid = {"biocypher": {}, "neo4j": {}}
+    config_with_typo = {"biocypher": {}, "postgreql": {}}
+
+    with pytest.warns(UserWarning, match="postgreql"):
+        _warn_unknown_keys(config_with_typo, valid, "test config")
+
+
+def test_warn_unknown_keys_no_warning_for_valid_keys():
+    import warnings
+
+    valid = {"biocypher": {}, "neo4j": {}, "postgresql": {}}
+    config_valid = {"biocypher": {}, "neo4j": {}}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        _warn_unknown_keys(config_valid, valid, "test config")  # must not raise

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import biocypher._config as cfg_module
 
-from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, reset
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, config as _config, reset
 
 
 def test_read_yaml():
@@ -87,3 +87,21 @@ def test_update_from_file_with_unknown_key(tmp_path):
         assert config("arangodb") == {"database_name": "mydb"}
     finally:
         reset()
+
+
+def test_arangodb_config_present_in_defaults():
+    """ArangoDB section must exist in defaults so get_writer("arangodb") doesn't crash.
+
+    Previously, the `arangodb` key was absent from biocypher_config.yaml, so
+    _config("arangodb") returned None, get_writer passed labels_order=None to the
+    writer, and _check_labels_order() raised a ValueError on first use.
+    """
+    from biocypher._config import reset
+
+    reset()  # ensure we're reading from the real defaults file
+
+    arango_cfg = _config("arangodb")
+
+    assert arango_cfg is not None, "arangodb section missing from defaults config"
+    assert "labels_order" in arango_cfg, "labels_order must be set so get_writer doesn't pass None"
+    assert "delimiter" in arango_cfg, "delimiter must be set for ArangoDB CSV output"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 import biocypher._config as cfg_module
 
-from biocypher._config import _read_yaml, _USER_CONFIG_FILE
+from biocypher._config import _read_yaml, _USER_CONFIG_FILE, config, reset
 
 
 def test_read_yaml():
@@ -44,3 +44,46 @@ def test_read_config_merges_user_and_local(monkeypatch):
     assert result["neo4j"]["uri"] == "neo4j://myserver:7687"  # from user
     assert result["neo4j"]["database_name"] == "my_project_db"  # from local
     assert result["neo4j"]["password"] == "neo4j"  # from defaults
+
+
+def test_config_setter_merges_dict_for_known_key():
+    """config(key=dict) merges into the existing dict for a known key."""
+    try:
+        config(neo4j={"database_name": "customdb"})
+        result = config("neo4j")
+        assert result["database_name"] == "customdb"
+        assert "uri" in result  # other defaults preserved
+    finally:
+        reset()
+
+
+def test_config_setter_creates_new_key():
+    """config(key=value) must not raise KeyError for a key absent from defaults."""
+    try:
+        config(arangodb={"database_name": "mydb"})
+        result = config("arangodb")
+        assert result == {"database_name": "mydb"}
+    finally:
+        reset()
+
+
+def test_config_setter_accepts_none_value():
+    """config(key=None) sets the value to None without raising AttributeError."""
+    try:
+        config(neo4j=None)
+        assert config("neo4j") is None
+    finally:
+        reset()
+
+
+def test_update_from_file_with_unknown_key(tmp_path):
+    """update_from_file must not crash when the YAML contains a key not in the defaults."""
+    from biocypher._config import update_from_file
+
+    cfg_file = tmp_path / "biocypher_config.yaml"
+    cfg_file.write_text("arangodb:\n  database_name: mydb\n")
+    try:
+        update_from_file(str(cfg_file))
+        assert config("arangodb") == {"database_name": "mydb"}
+    finally:
+        reset()

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -96,6 +96,7 @@ def test_in_memory_kg_only_in_online_mode(core):
         with pytest.raises(ValueError) as e:
             core.get_kg()
         assert "Getting the in-memory KG is only available in online mode for " in str(e.value)
+        assert isinstance(e.value.args[0], str), "error message must be a str, not a tuple"
 
 
 def test_no_in_memory_kg_for_dbms(core):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -170,3 +170,36 @@ def test_pandas_and_tabular_work_in_offline_mode(tmp_path):
         )
         assert bc._dbms == dbms
         assert bc._offline
+
+
+def test_translate_term_via_core(core):
+    """BioCypher.translate_term must lazily initialise the translator and return the mapped label."""
+    assert core._translator is None
+    result = core.translate_term("hgnc")
+    assert result == "Gene"
+    assert core._translator is not None
+
+
+def test_reverse_translate_term_via_core(core):
+    """BioCypher.reverse_translate_term must lazily initialise the translator and reverse-map the label."""
+    assert core._translator is None
+    result = core.reverse_translate_term("Gene")
+    assert result is not None
+    assert "hgnc" in result
+
+
+def test_translate_query_via_core(core):
+    """BioCypher.translate_query must lazily initialise the translator and translate Cypher labels."""
+    assert core._translator is None
+    query = "MATCH (n:hgnc) RETURN n"
+    result = core.translate_query(query)
+    assert "Gene" in result
+    assert "hgnc" not in result
+
+
+def test_reverse_translate_query_via_core(core):
+    """BioCypher.reverse_translate_query must lazily initialise the translator."""
+    assert core._translator is None
+    query = "MATCH (n:Protein)-[r:POST_TRANSLATIONAL_INTERACTION]->(m:Protein) RETURN n"
+    result = core.reverse_translate_query(query)
+    assert isinstance(result, str)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -204,3 +204,29 @@ def test_reverse_translate_query_via_core(core):
     query = "MATCH (n:Protein)-[r:POST_TRANSLATIONAL_INTERACTION]->(m:Protein) RETURN n"
     result = core.reverse_translate_query(query)
     assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_nodes_first_call_does_not_crash(core, _get_nodes):
+    """add_nodes must not crash when self._nodes is still None (first call)."""
+    # self._nodes starts as None; passing a list used to raise
+    # TypeError: 'NoneType' object is not iterable via itertools.chain
+    core.add_nodes(_get_nodes)
+    assert core._nodes == _get_nodes
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_nodes_accumulates_across_calls(core, _get_nodes):
+    """Successive add_nodes calls must append, not crash on the second call."""
+    first_half = _get_nodes[:4]
+    second_half = _get_nodes[4:]
+    core.add_nodes(first_half)
+    core.add_nodes(second_half)
+    assert len(core._nodes) == len(first_half) + len(second_half)
+
+
+@pytest.mark.parametrize("length", [4], scope="function")
+def test_add_edges_first_call_does_not_crash(core, _get_edges):
+    """add_edges must not crash when self._edges is still None (first call)."""
+    core.add_edges(_get_edges)
+    assert core._edges == _get_edges

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -299,6 +299,9 @@ def test_download_zip_and_expiration(mock_retrieve):
     paths = downloader.download(resource)
     # should not download again
     assert "tmp" in paths[0]
+    # cached paths must be actual files, not directories or archive containers
+    assert all(os.path.isfile(p) for p in paths), "get_cached_version must return file paths, not directories"
+    assert len(paths) == 2
 
     # minus 8 days from date_downloaded
     downloader.cache_dict["test_resource"]["date_downloaded"] = str(datetime.now() - timedelta(days=8))

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -86,6 +86,24 @@ def test_tree_vis_multiple_inheritance(caplog):
     assert tree_vis.to_json(with_data=True) == expected_tree_vis.to_json(with_data=True)
 
 
+def test_multiple_inheritance_warning_message_is_string(caplog):
+    """Warning message must be a plain string, not a one-element tuple repr."""
+    inheritance_tree_data = {
+        "root": [],
+        "level1A": ["root"],
+        "level1B": ["root"],
+        "level2A": ["level1A", "level1B"],
+    }
+    inheritance_tree = nx.DiGraph(inheritance_tree_data)
+    with caplog.at_level(logging.WARNING):
+        create_tree_visualisation(inheritance_tree)
+
+    warning_records = [r for r in caplog.records if "multiple inheritance" in r.message.lower()]
+    assert warning_records, "Expected a multiple-inheritance warning"
+    assert isinstance(warning_records[0].msg, str), "msg should be str, not a tuple"
+    assert not warning_records[0].message.startswith("("), "message should not be tuple repr"
+
+
 if __name__ == "__main__":
     # to look at it
     print(create_tree_visualisation(nx.DiGraph(_get_inheritance_tree)).show())

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -92,6 +92,21 @@ def test_show_ontology(hybrid_ontology):
     assert treevis is not None
 
 
+def test_show_ontology_without_schema_raises_string_error():
+    """show_ontology_structure(full=False) without a schema must raise ValueError
+    with a plain-string message, not a one-element tuple."""
+    from biocypher._mapping import OntologyMapping
+
+    ontology = Ontology(
+        head_ontology={"url": "test/ontologies/ontology1.ttl", "root_node": "Thing"},
+        ontology_mapping=OntologyMapping(),
+    )
+    with pytest.raises(ValueError) as exc_info:
+        ontology.show_ontology_structure(full=False)
+    assert isinstance(exc_info.value.args[0], str), "error message must be str, not tuple"
+    assert "schema configuration" in exc_info.value.args[0]
+
+
 def test_show_full_ontology(hybrid_ontology):
     treevis = hybrid_ontology.show_ontology_structure(full=True)
     assert treevis is not None

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -182,6 +182,28 @@ def test_missing_label_on_node():
     assert len(result.edges) == len(expected_edges)
 
 
+def test_missing_label_on_parent_node(caplog):
+    # A parent node without an rdfs:label should be removed from the graph,
+    # its descendants disconnected, and a debug message logged identifying it.
+    with caplog.at_level(logging.DEBUG, logger="biocypher._ontology"):
+        ontology_adapter = OntologyAdapter(
+            ontology_file="test/ontologies/missing_label_parent.ttl",
+            root_label="Test_Missing_Parent_Label_Root",
+        )
+    result = ontology_adapter.get_nx_graph()
+    # Expected hierarchy after removing the unlabeled parent:
+    #  test missing parent label root
+    #  ├── test missing parent label level1   (valid parent)
+    # (└── test missing parent label level2)  <- disconnected, excluded
+    expected_edges = [("test missing parent label level1", "test missing parent label root")]
+    for edge in expected_edges:
+        assert edge in result.edges
+    assert len(result.edges) == len(expected_edges)
+    # The removal should be visible in the debug log
+    removed_msgs = [r.message for r in caplog.records if "no rdfs:label" in r.message]
+    assert removed_msgs, "Expected a debug log entry for the unlabeled parent node"
+
+
 def test_switch_id_and_label():
     ontology_adapter_reversed = OntologyAdapter(
         ontology_file="test/ontologies/reverse_labels.ttl",

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -604,6 +604,28 @@ def test_strict_mode_property_filter(translator):
     assert "version" in translated_protein_node[0].get_properties().keys()
 
 
+def test_strict_mode_does_not_mutate_schema(translator):
+    """Strict-mode calls must not permanently inject keys into the shared schema dict.
+
+    _filter_props previously called dict.update() on the dict reference returned
+    directly by extended_schema[bl_type]['properties'], permanently adding
+    source/licence/version to the schema entry.  All subsequent non-strict calls
+    for the same type would then output those keys with value None.
+
+    This test must run after test_strict_mode_property_filter so that the
+    mutation, if still present, has already occurred.
+    """
+    translator.strict_mode = False
+
+    protein_plain = ("p_plain", "protein", {"taxon": 9606})
+    nodes = list(translator.translate_nodes([protein_plain]))
+    props = nodes[0].get_properties()
+
+    assert "source" not in props
+    assert "licence" not in props
+    assert "version" not in props
+
+
 def test_translate_entities_empty_iterable(translator):
     """translate_entities with an empty iterable should warn and return an empty iterator (issue #493)."""
     result = list(translator.translate_entities([]))

--- a/test/test_translate.py
+++ b/test/test_translate.py
@@ -626,6 +626,27 @@ def test_strict_mode_does_not_mutate_schema(translator):
     assert "version" not in props
 
 
+def test_strict_mode_error_messages_are_strings(translator):
+    """Strict-mode ValueError messages must be plain strings, not tuples (trailing-comma bug)."""
+    translator.strict_mode = True
+
+    node_missing_prop = ("n1", "Test", {"source": "s", "licence": "l"})
+    with pytest.raises(ValueError, match="version.*missing|missing.*version"):
+        list(translator.translate_nodes([node_missing_prop]))
+
+    edge_missing_source = ("n1", "n2", "Test", {"licence": "l", "version": "v"})
+    with pytest.raises(ValueError, match="source"):
+        list(translator.translate_edges([edge_missing_source]))
+
+    edge_missing_licence = ("n1", "n2", "Test", {"source": "s", "version": "v"})
+    with pytest.raises(ValueError, match="licence"):
+        list(translator.translate_edges([edge_missing_licence]))
+
+    edge_missing_version = ("n1", "n2", "Test", {"source": "s", "licence": "l"})
+    with pytest.raises(ValueError, match="version"):
+        list(translator.translate_edges([edge_missing_version]))
+
+
 def test_translate_entities_empty_iterable(translator):
     """translate_entities with an empty iterable should warn and return an empty iterator (issue #493)."""
     result = list(translator.translate_entities([]))

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -1060,3 +1060,55 @@ class TestValidationModes:
         workflow.add_node("node1", "protein")
         with pytest.raises(ValueError):
             workflow.add_node("node1", "protein")  # Should fail due to deduplication
+
+
+class TestDeduplicationTrackingSync:
+    """Regression tests for _seen_nodes/_seen_edges staying in sync with the graph."""
+
+    def test_remove_node_allows_readd(self):
+        """After remove_node, the same ID must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("p1", "protein")
+        workflow.remove_node("p1")
+        result = workflow.add_node("p1", "protein")
+        assert result is True
+
+    def test_remove_edge_allows_readd(self):
+        """After remove_edge, the same ID must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+        workflow.remove_edge("e1")
+        result = workflow.add_edge("e1", "interaction", "n1", "n2")
+        assert result is True
+
+    def test_clear_allows_readd(self):
+        """After clear(), previously-seen IDs must be re-addable when deduplication=True."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+        workflow.clear()
+        result_node = workflow.add_node("n1", "protein")
+        assert result_node is True
+        workflow.add_node("n2", "protein")
+        result_edge = workflow.add_edge("e1", "interaction", "n1", "n2")
+        assert result_edge is True
+
+    def test_from_json_populates_seen_sets(self):
+        """from_json() must populate _seen_nodes/_seen_edges so loaded entities are tracked."""
+        workflow = create_workflow("test", deduplication=True)
+        workflow.add_node("n1", "protein")
+        workflow.add_node("n2", "protein")
+        workflow.add_edge("e1", "interaction", "n1", "n2")
+
+        json_str = workflow.to_json()
+
+        # Load into a fresh deduplication-enabled workflow
+        new_workflow = create_workflow("test2", deduplication=True)
+        new_workflow.from_json(json_str)
+
+        # Loaded entities should be tracked — re-adding must return False
+        assert new_workflow.add_node("n1", "protein") is False
+        assert new_workflow.add_edge("e1", "interaction", "n1", "n2") is False

--- a/tutorial/01_schema_config.yaml
+++ b/tutorial/01_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_protein

--- a/tutorial/02_schema_config.yaml
+++ b/tutorial/02_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: [uniprot_protein, entrez_protein]

--- a/tutorial/03_schema_config.yaml
+++ b/tutorial/03_schema_config.yaml
@@ -1,4 +1,4 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]

--- a/tutorial/04_schema_config.yaml
+++ b/tutorial/04_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str

--- a/tutorial/05_schema_config.yaml
+++ b/tutorial/05_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,5 +12,5 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform

--- a/tutorial/06_schema_config.yaml
+++ b/tutorial/06_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: node
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str

--- a/tutorial/06_schema_config_pandas.yaml
+++ b/tutorial/06_schema_config_pandas.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: edge
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str

--- a/tutorial/07_schema_config.yaml
+++ b/tutorial/07_schema_config.yaml
@@ -1,6 +1,6 @@
 protein:
     represented_as: node
-    preferred_id: [uniprot, entrez]
+    namespace: [uniprot, entrez]
     input_label: [uniprot_protein, entrez_protein]
     properties:
         sequence: str
@@ -12,13 +12,13 @@ protein isoform:
     is_a: protein
     inherit_properties: true
     represented_as: node
-    preferred_id: uniprot
+    namespace: uniprot
     input_label: uniprot_isoform
 
 protein protein interaction:
     is_a: pairwise molecular interaction
     represented_as: node
-    preferred_id: intact
+    namespace: intact
     input_label: interacts_with
     properties:
         method: str
@@ -27,5 +27,5 @@ protein protein interaction:
 complex:
     synonym_for: macromolecular complex
     represented_as: node
-    preferred_id: complexportal
+    namespace: complexportal
     input_label: complex

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -20,6 +20,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/d4/6585f3b6fdb75648bca294664af4becc8aa2fb3fb08f4e4e9fd27e10d773/adjusttext-1.3.0.tar.gz", hash = "sha256:4ab75cd4453af4828876ac3e964f2c49be642ea834f0c1f7449558d5f12cbca1", size = 15724, upload-time = "2024-10-31T16:45:36.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/1c/8feedd607cc14c5df9aef74fe3af9a99bf660743b842a9b5b1865326b4aa/adjustText-1.3.0-py3-none-any.whl", hash = "sha256:da23d7b24b6db5ffa039bb136bfa556207365e32f48ac74b07ad26dd485bc691", size = 13154, upload-time = "2024-10-31T16:45:35.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/80/7ad35ee5321a86b842f9e8516c8ae4c86f58db7b40e82ce9759f94517a50/adjusttext-1.3.0-py3-none-any.whl", hash = "sha256:bc6c118cd9d7caf6ae37f9355e51d840a2d7f64b4fb2956b8401de27c5af803b", size = 13264, upload-time = "2026-06-08T16:40:05.041Z" },
 ]
 
 [[package]]
@@ -277,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "biocypher"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Aggregated small-fix PRs

This batches **23 independently-reviewed PRs** (authored by the routine under @slobentanzer) onto a `staging` branch, each squash-merged as one conventional commit so `release-please` produces a clean changelog on merge to `main`. No releases were cut while batching (`release-please` only fires on push to `main`).

### Bug fixes (`fix:`)
- #544 get: `get_cached_version` returns file paths for extracted archives
- #545 config: replace deprecated `preferred_id` with `namespace` in test/tutorial schemas
- #546 translate: `_filter_props` must not mutate the shared schema dict in strict mode
- #547 core: replace non-existent `start_ontology()` calls with `_get_translator()`
- #548 neo4j: replace dots with underscores in label names
- #549 ontology: replace fragile `str(None)` sentinel with explicit `has_label` check
- #550 batch_writer: route scalar string quoting through `_quote_string()`
- #552 / #553 / #557 / #570: fix garbled / tuple-ified error messages (translate, core, misc, ontology, batch_writer)
- #554 core: `add_nodes`/`add_edges` crash on first call when `_nodes`/`_edges` is None
- #556 config: `config()` setter raised `KeyError` for keys absent from defaults
- #559 postgresql: missing f-string prefix in `_get_data_type` log
- #560 batch_writer: correct log message key in `edge_labels_order` fallback
- #563 biopathnet: use full Ontology graph so synonym types are found (#489)
- #567 postgresql: only inject `PGPASSWORD` when a password is set
- #569 get_writer: forward postgresql `host` config key as `db_host`
- #571 workflow: keep `_seen_nodes`/`_seen_edges` in sync with graph mutations
- #574 config: add missing `arangodb` section to default config
- #576 config: add missing `labels_order` keys to sqlite section (#575)

### Features (`feat:`, low-risk/additive)
- #565 neo4j: add `import_call_additional_options` config key
- #511 config: warn about unknown top-level keys in `biocypher_config.yaml` (also adds `airr` section)

### Conflict resolutions applied during aggregation
- Test files (`test_postgres.py`, `test_core.py`, `test_translate.py`, `test_config.py`, `test_neo4j.py`) — unioned the test functions added by overlapping PRs.
- `biocypher_config.yaml` — sqlite `labels_order` (#576) placed in the sqlite section; #511's duplicate `arangodb` block dropped in favour of #574's.
- `_config/__init__.py` test interaction — #556's "absent key" tests retargeted from `arangodb` (now a default, courtesy of #574) to a synthetic `custom_unknown_dbms` key.

### Verification
- Local `pytest` over all touched modules: **225 passed, 4 skipped** (Neo4j/Postgres container tests skip locally).
- Closed #562 (superseded by #571 — same four methods, with correct `deduplication` guards).

### Out of scope (left as standalone PRs to `main`)
- #516 (deprecate `label_as_edge`) — rebased + conflict resolved, needs review of the deprecation path.
- #555 (varying-property node header groups) — large refactor, awaiting FHIR-data validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
