### PR TITLE
fix(rdf,owl): write falsy property values instead of dropping them

### DIFF
--- a/biocypher/output/write/graph/_owl.py
+++ b/biocypher/output/write/graph/_owl.py
@@ -351,8 +351,9 @@ class _OWLWriter(_RDFWriter):
 
             # Add properties.
             for key, value in properties.items():
-                # only write value if it exists.
-                if value:
+                # only write value if it exists. `is not None` rather than a
+                # truthiness check: 0, 0.0, False and "" are values, not absence.
+                if value is not None:
                     self.add_property_to_graph(self.graph, rdf_subject, value, key)
 
         self._has_nodes = True
@@ -494,8 +495,9 @@ class _OWLWriter(_RDFWriter):
 
                 # Add properties to the edge modelled as an instance.
                 for key, value in rdf_properties.items():
-                    # only write value if it exists.
-                    if value:
+                    # only write value if it exists. `is not None` rather than a
+                    # truthiness check: 0, 0.0, False and "" are values, not absence.
+                    if value is not None:
                         self.add_property_to_graph(self.graph, rdf_id, value, key)
 
             else:

--- a/biocypher/output/write/graph/_rdf.py
+++ b/biocypher/output/write/graph/_rdf.py
@@ -253,8 +253,9 @@ class _RDFWriter(_BatchWriter):
 
             # add properties to the transformed edge --> node
             for key, value in rdf_properties.items():
-                # only write value if it exists.
-                if value:
+                # only write value if it exists. `is not None` rather than a
+                # truthiness check: 0, 0.0, False and "" are values, not absence.
+                if value is not None:
                     self.add_property_to_graph(graph, rdf_predicate, value, key)
 
         graph.serialize(destination=file_name, format=self.file_format)
@@ -404,8 +405,9 @@ class _RDFWriter(_BatchWriter):
                 ),
             )
             for key, value in properties.items():
-                # only write value if it exists.
-                if value:
+                # only write value if it exists. `is not None` rather than a
+                # truthiness check: 0, 0.0, False and "" are values, not absence.
+                if value is not None:
                     self.add_property_to_graph(graph, rdf_subject, value, key)
 
         graph.serialize(destination=file_name, format=self.file_format)

--- a/test/output/write/graph/test_rdf.py
+++ b/test/output/write/graph/test_rdf.py
@@ -5,6 +5,8 @@ import pytest
 
 from rdflib import CSVW, RDF, RDFS, Graph, Literal, Namespace
 
+from biocypher._create import BioCypherEdge, BioCypherNode
+
 
 @pytest.mark.parametrize("length", [4], scope="function")
 def test_rdf_write_data(bw_rdf, length, _get_nodes, _get_edges):
@@ -206,3 +208,68 @@ def test_rdf_ttl_format(bw_rdf, length, _get_nodes, _get_edges):
 
     # Basic verification that the graph contains expected data
     assert len(set(graph.subjects(RDF.type))) > 0
+
+
+# Property names deliberately chosen to stay in the biocypher namespace:
+# `property_to_uri` re-maps well-known names such as `name` and `count` onto
+# CSVW/ODRL, which would confuse what these tests are asserting.
+FALSY_PROPERTIES = {
+    "fraction_disordered": 0.0,
+    "taxon": 0,
+    "reviewed": False,
+    "free_text": "",
+    "score": 0.42,  # truthy control
+}
+
+
+def _load_written_graph(outdir: str) -> Graph:
+    graph = Graph()
+    for file in glob.glob(os.path.join(outdir, "*.ttl")):
+        graph += Graph().parse(file, format="ttl")
+    return graph
+
+
+def test_rdf_write_nodes_keeps_falsy_property_values(bw_rdf_ttl):
+    """0, 0.0, False and "" are values, not absence, and must reach the graph.
+
+    Guarding the property write with `if value:` drops them silently, which
+    biases every aggregate computed over the resulting graph.
+    """
+    node = BioCypherNode(
+        node_id="p1",
+        node_label="protein",
+        properties=dict(FALSY_PROPERTIES),
+    )
+
+    assert bw_rdf_ttl.write_nodes([node])
+
+    graph = _load_written_graph(bw_rdf_ttl.outdir)
+    biocypher_namespace = Namespace("https://biocypher.org/biocypher#")
+    for name, value in FALSY_PROPERTIES.items():
+        assert (
+            biocypher_namespace["p1"],
+            biocypher_namespace[name],
+            Literal(value),
+        ) in graph
+
+
+def test_rdf_write_edges_keeps_falsy_property_values(bw_rdf_ttl):
+    """Same guarantee on the edge path, which has its own copy of the guard."""
+    edge = BioCypherEdge(
+        relationship_id="prel1",
+        source_id="p1",
+        target_id="p2",
+        relationship_label="PERTURBED_IN_DISEASE",
+        properties=dict(FALSY_PROPERTIES),
+    )
+
+    assert bw_rdf_ttl.write_edges([edge])
+
+    graph = _load_written_graph(bw_rdf_ttl.outdir)
+    biocypher_namespace = Namespace("https://biocypher.org/biocypher#")
+    for name, value in FALSY_PROPERTIES.items():
+        assert (
+            biocypher_namespace["prel1"],
+            biocypher_namespace[name],
+            Literal(value),
+        ) in graph


### PR DESCRIPTION
## Summary

- `_rdf.py` and `_owl.py` guarded every property write with `if value:`, so `0`, `0.0`, `False` and `""` were silently discarded instead of written. The comment above each guard already says *"only write value if it exists"* — `is not None` is what that means. Four call sites: nodes and edges in each writer.
- The loss removes exactly the zeros, so it biases any mean, median or distribution computed over the graph, with no error and no warning. On a 10 000-protein graph of ours it dropped 8 411 literals and pushed the mean disorder of the low-pLDDT group from its true 0.2075 to 0.3140.
- Adds two regression tests covering the node and the edge path.

Fixes #587, which has the standalone reproduction and the full before/after numbers.

## Test plan

- [x] `test_rdf_write_nodes_keeps_falsy_property_values` and `test_rdf_write_edges_keeps_falsy_property_values` fail on `main` (both assert a dropped literal) and pass with this change.
- [x] Full suite green: `466 passed, 42 skipped` (464 before, +2 new).
- [x] `ruff check --select=E,F,I` (what `.pre-commit-config.yaml` gates) passes on all three files; `ruff format --check` clean on `_rdf.py` and the test file. `_owl.py` is reported unformatted both before and after this change, so I left the pre-existing formatting alone to keep the diff to the fix.

## Notes

- The test property names (`fraction_disordered`, `taxon`, `reviewed`, `free_text`) are deliberately chosen to stay in the biocypher namespace: `property_to_uri` re-maps well-known names such as `name`, `count` and `description` onto CSVW/ODRL/DC, which would obscure what the tests assert.
- `_biopathnet.py:92` has the same `if value:` pattern, but it writes a TSV field rather than an RDF literal, and an empty third column may mean something to that format. I left it out rather than guess — say the word and I will include it. (Noting #580 is in flight there.)
- Empty *lists* still produce no triples, which is unchanged and correct: a list with no members has nothing to write.
